### PR TITLE
Use pycodestyle instead of PEP8

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ This is done through [pip](pip.readthedocs.org/) and [virtualenv](https://virtua
 [VirtualEnvWrapper](http://virtualenvwrapper.readthedocs.org/en/latest/command_ref.html) for our virtual environemnts.
 
 Setting up a virtualenvwrapper for python3
-    
+
     mkvirtualenv -p /usr/local/bin/python3 notifications-python-client
 
 
 The boostrap script will set the application up. *Ensure you have activated the virtual environment first.*
 
     ./scripts/bootstrap.sh
-    
+
 This will
 
 * Use pip to install dependencies.
@@ -37,7 +37,6 @@ This will
 
 The `./scripts/run_tests.py` script will run all the tests. [py.test](http://pytest.org/latest/) is used for testing.
 
-Running tests will also apply syntax checking, using [pep8](https://www.python.org/dev/peps/pep-0008/).
+Running tests will also apply syntax checking, using [pycodestyle](https://pypi.python.org/pypi/pycodestyle).
 
 Additionally code coverage is checked via pytest-cov:
-

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pep8==1.7.0
+pycodestyle==2.3.1
 pytest==3.0.5
 pytest-mock==1.5.0
 pytest-cov==2.4.0

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -26,7 +26,7 @@ if [ -d venv ]; then
   source ./venv/bin/activate
 fi
 
-pep8 .
+pycodestyle .
 display_result $? 1 "Code style check"
 
 ## Code coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,3 @@
-[pep8]
+[pycodestyle]
 max-line-length = 120
 exclude = ./migrations,./venv,./venv3
-


### PR DESCRIPTION
PEP8 was renamed to pycodestyle; this issue explains why: PyCQA/pycodestyle#466

This commit changes our tests to use pycodestyle instead of pep8.

No changes to our code were required as a result.