### PR TITLE
make xpass fail the test run

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [pycodestyle]
 max-line-length = 120
 exclude = ./migrations,./venv,./venv3
+
+[tool:pytest]
+xfail_strict=true


### PR DESCRIPTION
if a `pytest.mark.xfail` passes when you expect it to fail:

# BEFORE
```
=================== 571 passed, 16 xfailed, 3 xpassed in 6.48 seconds ===================
Unit tests passed
```

# AFTER
```======================================= FAILURES =======================================
_________________ test_phone_number_accepts_valid_values[07123456789] __________________
[XPASS(strict)]
__________ test_valid_phone_number_can_be_formatted_consistently[07123456789] __________
[XPASS(strict)]
____________ test_validates_against_whitelist_of_phone_numbers[07123456789] ____________
[XPASS(strict)]
=================== 3 failed, 571 passed, 16 xfailed in 6.39 seconds ===================
Unit tests failed
```