### PR TITLE
Remove Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-[![Build Status](https://api.travis-ci.org/alphagov/notifications-utils.svg?branch=master)](https://api.travis-ci.org/alphagov/notifications-utils.svg?branch=master)
-
-
 # GOV.UK Notify - notifications-utils [BETA]
 Shared python code for GOV.UK Notify
 


### PR DESCRIPTION
We don’t use Travis any more