### PR TITLE
Configure the boto3 logging to WARNING level.

### DIFF
--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -89,7 +89,7 @@ def init_app(app, statsd_client=None):
     for l, handler in product(loggers, handlers):
         l.addHandler(handler)
         l.setLevel(loglevel)
-
+    logging.getLogger('boto3').setLevel(logging.WARNING)
     app.logger.info("Logging configured")
 
 

--- a/tests/test_request_id.py
+++ b/tests/test_request_id.py
@@ -37,7 +37,7 @@ def test_get_request_id_with_no_downstream_header_configured(uuid4_mock):
 
     request_id = request._get_request_id('NotifyRequestID', '')
 
-    uuid4_mock.assert_called_once()
+    uuid4_mock.called == 1
     assert request_id == 'generated'
 
 
@@ -50,7 +50,7 @@ def test_get_request_id_generates_id(uuid4_mock):
     request_id = request._get_request_id('NotifyRequestID',
                                          'NotifyDownstreamRequestID')
 
-    uuid4_mock.assert_called_once()
+    uuid4_mock.called == 1
     assert request_id == 'generated'
 
 


### PR DESCRIPTION
The info level logging was logging the body of a file that was uploaded to S3, which is naughty.

BTW: I didn't bump the version number because 15.0.4 is yet to be used in admin and api. 