### PR TITLE
Fix empty address placeholders becoming HTML

### DIFF
--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -357,7 +357,7 @@ class LetterPreviewTemplate(WithSubjectTemplate):
         ).keys()
 
         return {
-            key: Columns(self.values).get(key, '')
+            key: Columns(self.values).get(key) or ''
             for key in keys
         }
 

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1028,6 +1028,24 @@ def test_letter_output_numeric_id(extra_args, expected_field):
             "postcode": "N1 4W2",
         },
     ),
+    (
+        {
+            "addressline1": "line 1",
+            "addressline2": "line 2",
+            "addressline3": None,
+            "addressline6": None,
+            "postcode": "N1 4W2",
+        },
+        {
+            "addressline1": "line 1",
+            "addressline2": "line 2",
+            "addressline3": "",
+            "addressline4": "",
+            "addressline5": "",
+            "addressline6": "",
+            "postcode": "N1 4W2",
+        },
+    ),
 ])
 def test_letter_address_format(address, expected):
     assert LetterDVLATemplate(

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -970,49 +970,65 @@ def test_letter_output_numeric_id(extra_args, expected_field):
     assert str(template).split('|')[1] == expected_field
 
 
-@pytest.mark.parametrize("address, expected",
-                         (
-                                 [{"address line 1": "line 1",
-                                   "address line 2": "line 2",
-                                   "address line 3": "line 3",
-                                   "address line 4": "line 4",
-                                   "address line 5": "line 5",
-                                   "address line 6": "line 6",
-                                   "postcode": "N1 4W2"},
-                                  {"addressline1": "line 1",
-                                   "addressline2": "line 2",
-                                   "addressline3": "line 3",
-                                   "addressline4": "line 4",
-                                   "addressline5": "line 5",
-                                   "addressline6": "line 6",
-                                   "postcode": "N1 4W2"}],
-
-                                 [{"addressline1": "line 1",
-                                   "addressline2": "line 2",
-                                   "addressline3": "line 3",
-                                   "addressline4": "line 4",
-                                   "addressline5": "line 5",
-                                   "addressLine6": "line 6",
-                                   "postcode": "N1 4W2"},
-                                  {"addressline1": "line 1", "addressline2": "line 2", "addressline3": "line 3",
-                                   "addressline4": "line 4", "addressline5": "line 5", "addressline6": "line 6",
-                                   "postcode": "N1 4W2"}
-                                  ],
-
-                                 [{"addressline1": "line 1",
-                                   "addressline3": "line 3",
-                                   "addressline5": "line 5",
-                                   "addressline6": "line 6",
-                                   "postcode": "N1 4W2"},
-                                  {"addressline1": "line 1",
-                                   # addressline2 is required, but not given
-                                   "addressline3": "line 3",
-                                   "addressline4": "",
-                                   "addressline5": "line 5",
-                                   "addressline6": "line 6",
-                                   "postcode": "N1 4W2"}
-                                  ]
-                         ))
+@pytest.mark.parametrize("address, expected", [
+    (
+        {
+            "address line 1": "line 1",
+            "address line 2": "line 2",
+            "address line 3": "line 3",
+            "address line 4": "line 4",
+            "address line 5": "line 5",
+            "address line 6": "line 6",
+            "postcode": "N1 4W2",
+        },
+        {
+            "addressline1": "line 1",
+            "addressline2": "line 2",
+            "addressline3": "line 3",
+            "addressline4": "line 4",
+            "addressline5": "line 5",
+            "addressline6": "line 6",
+            "postcode": "N1 4W2",
+        },
+    ), (
+        {
+            "addressline1": "line 1",
+            "addressline2": "line 2",
+            "addressline3": "line 3",
+            "addressline4": "line 4",
+            "addressline5": "line 5",
+            "addressLine6": "line 6",
+            "postcode": "N1 4W2",
+        },
+        {
+            "addressline1": "line 1",
+            "addressline2": "line 2",
+            "addressline3": "line 3",
+            "addressline4": "line 4",
+            "addressline5": "line 5",
+            "addressline6": "line 6",
+            "postcode": "N1 4W2",
+        },
+    ),
+    (
+        {
+            "addressline1": "line 1",
+            "addressline3": "line 3",
+            "addressline5": "line 5",
+            "addressline6": "line 6",
+            "postcode": "N1 4W2",
+        },
+        {
+            "addressline1": "line 1",
+            # addressline2 is required, but not given
+            "addressline3": "line 3",
+            "addressline4": "",
+            "addressline5": "line 5",
+            "addressline6": "line 6",
+            "postcode": "N1 4W2",
+        },
+    ),
+])
 def test_letter_address_format(address, expected):
     assert LetterDVLATemplate(
         {'content': '', 'subject': ''},


### PR DESCRIPTION
Situation
---
A CSV file has an optional address column (eg `address line 3`) but no values for this column in (some of) the rows.

Problem
---
The outputted data for those rows will have `<span class='placeholder'>…` in the address block, instead of empty strings.

Why it’s happening
---

`{'x': None}.get('x', '')` returns `None`, _not_ `''`.

`Field`s treat `None` as missing personalisation, and `''` as a valid replacement. So they were seeing missing personalisation when the intent of the code was to say _replace this bit of the address with an empty string because it’s optional_.

The fix
---
Converting `None` to `''` for all optional address lines (fix is in 01bd264, other commit is just whitespace changes).