### PR TITLE
Don’t escape HTML in the data we output to DVLA

### DIFF
--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -4,7 +4,12 @@ from orderedset import OrderedSet
 from flask import Markup
 
 from notifications_utils.columns import Columns
-from notifications_utils.formatters import unescaped_formatted_list, strip_html, escape_html
+from notifications_utils.formatters import (
+    unescaped_formatted_list,
+    strip_html,
+    escape_html,
+    strip_dvla_markup,
+)
 
 
 class Field():
@@ -29,7 +34,8 @@ class Field():
         self.sanitizer = {
             'strip': strip_html,
             'escape': escape_html,
-            'passthrough': str
+            'passthrough': str,
+            'strip_dvla_markup': strip_dvla_markup,
         }[html]
 
     def __str__(self):

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -134,6 +134,10 @@ def fix_extra_newlines_in_dvla_lists(dvla_markup):
     )
 
 
+def strip_pipes(value):
+    return value.replace('|', '')
+
+
 class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
 
     def block_code(self, code, language=None):

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -19,6 +19,13 @@ single_newlines = re.compile(
     re.MULTILINE
 )
 
+dvla_markup_tags = re.compile(
+    str('|'.join('\<{}\>'.format(tag) for tag in {
+        'cr', 'h1', 'h2', 'p', 'normal', 'op', 'np', 'bul', 'tab'
+    })),
+    re.IGNORECASE
+)
+
 
 def unlink_govuk_escaped(message):
     return re.sub(
@@ -66,6 +73,10 @@ def strip_html(value):
 
 def escape_html(value):
     return bleach.clean(value, tags=[], strip=False)
+
+
+def strip_dvla_markup(value):
+    return re.sub(dvla_markup_tags, '', value)
 
 
 def unescaped_formatted_list(

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -19,6 +19,7 @@ from notifications_utils.formatters import (
     gsm_encode,
     escape_html,
     fix_extra_newlines_in_dvla_lists,
+    strip_dvla_markup,
 )
 from notifications_utils.take import Take
 from notifications_utils.template_change import TemplateChange
@@ -307,9 +308,9 @@ class LetterPreviewTemplate(WithSubjectTemplate):
         return Markup(self.jinja_template.render({
             'admin_base_url': self.admin_base_url,
             'logo_file_name': self.logo_file_name,
-            'subject': self.subject,
+            'subject': strip_dvla_markup(self.subject),
             'message': Take.as_field(
-                self.content, self.values, html='escape', markdown_lists=True
+                strip_dvla_markup(self.content), self.values, html='escape', markdown_lists=True
             ).then(
                 prepare_newlines_for_markdown
             ).then(
@@ -427,7 +428,7 @@ class LetterDVLATemplate(LetterPreviewTemplate):
 
     @property
     def subject(self):
-        return str(Field(self._subject, self.values, html='passthrough'))
+        return str(Field(self._subject, self.values, html='strip_dvla_markup'))
 
     def __str__(self):
 
@@ -480,7 +481,7 @@ class LetterDVLATemplate(LetterPreviewTemplate):
             datetime.utcnow().strftime('%-d %B %Y'),
             self.subject,
             Take.as_field(
-                self.content, self.values, markdown_lists=True
+                self.content, self.values, markdown_lists=True, html='strip_dvla_markup'
             ).then(
                 prepare_newlines_for_markdown
             ).then(

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -425,6 +425,10 @@ class LetterDVLATemplate(LetterPreviewTemplate):
             raise TypeError('numeric_id must be an integer')
         self._numeric_id = int(value)
 
+    @property
+    def subject(self):
+        return str(Field(self._subject, self.values, html='passthrough'))
+
     def __str__(self):
 
         OTT = '140'
@@ -474,7 +478,7 @@ class LetterDVLATemplate(LetterPreviewTemplate):
             '{}'
         ).format(
             datetime.utcnow().strftime('%-d %B %Y'),
-            str(Field(self.subject, self.values)),
+            self.subject,
             Take.as_field(
                 self.content, self.values, markdown_lists=True
             ).then(

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -10,6 +10,7 @@ from notifications_utils.formatters import (
     gsm_encode,
     formatted_list,
     strip_dvla_markup,
+    strip_pipes,
 )
 from notifications_utils.template import (
     HTMLEmailTemplate,
@@ -677,3 +678,7 @@ def test_removing_dvla_markup():
             '<tAb>'
         )
     ) == 'some words & some more <words>'
+
+
+def test_removing_pipes():
+    assert strip_pipes('|a|b|c') == 'abc'

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -8,7 +8,8 @@ from notifications_utils.formatters import (
     notify_letter_dvla_markdown,
     prepare_newlines_for_markdown,
     gsm_encode,
-    formatted_list
+    formatted_list,
+    strip_dvla_markup,
 )
 from notifications_utils.template import (
     HTMLEmailTemplate,
@@ -665,3 +666,14 @@ def test_formatted_list(items, kwargs, expected_output):
 
 def test_formatted_list_returns_markup():
     assert isinstance(formatted_list([0]), Markup)
+
+
+def test_removing_dvla_markup():
+    assert strip_dvla_markup(
+        (
+            'some words & some more <words>'
+            '<cr><h1><h2><p><normal><op><np><bul><tab>'
+            '<CR><H1><H2><P><NORMAL><OP><NP><BUL><TAB>'
+            '<tAb>'
+        )
+    ) == 'some words & some more <words>'

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -264,6 +264,7 @@ def test_sms_preview_adds_newlines(nl2br):
 @mock.patch('notifications_utils.template.unlink_govuk_escaped')
 @mock.patch('notifications_utils.template.notify_letter_preview_markdown', return_value='Bar')
 @mock.patch('notifications_utils.template.prepare_newlines_for_markdown', return_value='Baz')
+@mock.patch('notifications_utils.template.strip_pipes', side_effect=lambda x: x)
 @pytest.mark.parametrize('values, expected_address', [
     ({}, Markup(
         "<span class='placeholder-no-brackets'>address line 1</span>\n"
@@ -337,6 +338,7 @@ def test_sms_preview_adds_newlines(nl2br):
     ({'logo_file_name': 'example.jpg'}, 'example.jpg'),
 ])
 def test_letter_preview_renderer(
+    strip_pipes,
     prepare_newlines,
     letter_markdown,
     unlink_govuk,
@@ -368,6 +370,12 @@ def test_letter_preview_renderer(
     prepare_newlines.assert_called_once_with('Foo')
     letter_markdown.assert_called_once_with('Baz')
     unlink_govuk.assert_not_called()
+    assert strip_pipes.call_args_list == [
+        mock.call('Subject'),
+        mock.call('Foo'),
+        mock.call(expected_address),
+        mock.call(expected_rendered_contact_block),
+    ]
 
 
 @mock.patch('notifications_utils.template.LetterPDFLinkTemplate.jinja_template.render')

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -465,8 +465,8 @@ def test_subject_line_gets_replaced():
             'addressline5': '',
             'addressline6': '',
         }),
-        mock.call('subject', {}, html='passthrough'),
-        mock.call('content', {}, markdown_lists=True),
+        mock.call('subject', {}, html='strip_dvla_markup'),
+        mock.call('content', {}, markdown_lists=True, html='strip_dvla_markup'),
     ]),
 ])
 @mock.patch('notifications_utils.template.Field.__init__', return_value=None)
@@ -490,6 +490,20 @@ def test_email_preview_escapes_html_in_from_name():
     )
     assert '<script>' not in str(template)
     assert '&lt;script&gt;alert("")&lt;/script&gt;' in str(template)
+
+
+@mock.patch('notifications_utils.template.strip_dvla_markup', return_value='FOOBARBAZ')
+def test_letter_preview_strips_dvla_markup(mock_strip_dvla_markup):
+    assert 'FOOBARBAZ' in str(LetterPreviewTemplate(
+        {
+            "content": 'content',
+            'subject': 'subject',
+        },
+    ))
+    assert mock_strip_dvla_markup.call_args_list == [
+        mock.call(Markup('subject')),
+        mock.call('content'),
+    ]
 
 
 dvla_file_spec = [

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -465,8 +465,7 @@ def test_subject_line_gets_replaced():
             'addressline5': '',
             'addressline6': '',
         }),
-        mock.call('subject', {}, html='escape'),
-        mock.call('1\n2\n3\n4\n5\n6\n7\n8', {}),
+        mock.call('subject', {}, html='passthrough'),
         mock.call('content', {}, markdown_lists=True),
     ]),
 ])
@@ -860,7 +859,7 @@ dvla_file_spec = [
         """,
         'Example': (
             '29 April 2016<cr><cr>'
-            '<h1>Your application is due soon<normal><cr><cr>'
+            '<h1>Your application is something & something<normal><cr><cr>'
             'Dear Henry Hadlow,<cr><cr>'
             'Thank you for applying to register a lasting power of '
             'attorney (LPA) for property and financial affairs. We '
@@ -883,7 +882,7 @@ def test_letter_output_template(field):
                 'attorney (LPA) for property and financial affairs. We '
                 'have checked your application and...'
             ),
-            'subject': 'Your ((thing)) is due soon',
+            'subject': 'Your ((thing)) is something & something',
         },
         {
             'thing': 'application',


### PR DESCRIPTION
We have a problem where stuff like `&amp;` was showing up in our letters. We shouldn’t be doing this sanitising in the data we send to DVLA, but we also shouldn’t be letting users pass DVLA-markup like `<cr>` through us.