### PR TITLE
Validate international phone numbers

### DIFF
--- a/notifications_utils/international_billing_rates.py
+++ b/notifications_utils/international_billing_rates.py
@@ -23,3 +23,4 @@ import yaml
 
 with open('./notifications_utils/international_billing_rates.yml') as f:
     INTERNATIONAL_BILLING_RATES = yaml.safe_load(f)
+    COUNTRY_PREFIXES = frozenset(INTERNATIONAL_BILLING_RATES.keys())

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -406,6 +406,9 @@ def validate_phone_number(number, column=None, international=False):
     ):
         return validate_uk_phone_number(number)
 
+    if (number.startswith('0') and not number.startswith('00')):
+        return validate_phone_number(number)
+
     number = normalise_phone_number(number)
 
     if (

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -380,7 +380,7 @@ def validate_phone_number(number, column=None):
 
     if not any(
         number.startswith(prefix)
-        for prefix in ['7', '07', '447', '4407', '00447']
+        for prefix in ['7', '447', '4407', '00447']
     ):
         raise InvalidPhoneError('Not a UK mobile number')
 

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -425,15 +425,7 @@ def validate_phone_number(number, column=None, international=False):
     return number
 
 
-def format_phone_number(number, international=False):
-    return validate_phone_number(number, international=international)
-
-
-def validate_and_format_phone_number(number, international=False):
-    return format_phone_number(
-        validate_phone_number(number, international=international),
-        international=international
-    )
+validate_and_format_phone_number = validate_phone_number
 
 
 def validate_email_address(email_address, column=None):

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -366,41 +366,41 @@ class InvalidAddressError(InvalidEmailError):
     pass
 
 
-def validate_phone_number(number, column=None):
+def normalise_phone_number(number):
 
-    for character in ['(', ')', ' ', '-']:
+    for character in ['(', ')', ' ', '-', '+']:
         number = number.replace(character, '')
 
-    number = number.lstrip('+').lstrip('0')
+    return number.lstrip('0').lstrip('44').lstrip('0')
+
+
+def validate_phone_number(number, column=None):
+
+    number = normalise_phone_number(number)
 
     try:
         list(map(int, number))
     except ValueError:
         raise InvalidPhoneError('Must not contain letters or symbols')
 
-    if not any(
-        number.startswith(prefix)
-        for prefix in ['7', '447', '4407', '00447']
-    ):
+    if not number.startswith('7'):
         raise InvalidPhoneError('Not a UK mobile number')
 
-    # Split number on first 7
-    number = number.split('7', 1)[1]
-    if len(number) > 9:
+    if len(number) > 10:
         raise InvalidPhoneError('Too many digits')
 
-    if len(number) < 9:
+    if len(number) < 10:
         raise InvalidPhoneError('Not enough digits')
 
     return number
 
 
 def format_phone_number(number):
-    return '+447{}'.format(number)
+    return '+44{}'.format(number)
 
 
 def format_phone_number_human_readable(number):
-    return '07{} {} {}'.format(*re.findall('...', number))
+    return '0{} {} {}'.format(number[:4], number[4:7], number[7:10])
 
 
 def validate_and_format_phone_number(number, human_readable=False):

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -384,7 +384,7 @@ def normalise_phone_number(number):
 
 def validate_uk_phone_number(number, column=None):
 
-    number = normalise_phone_number(number).lstrip('44').lstrip('0')
+    number = normalise_phone_number(number).lstrip(uk_prefix).lstrip('0')
 
     if not number.startswith('7'):
         raise InvalidPhoneError('Not a UK mobile number')
@@ -395,7 +395,7 @@ def validate_uk_phone_number(number, column=None):
     if len(number) < 10:
         raise InvalidPhoneError('Not enough digits')
 
-    return number
+    return '{}{}'.format(uk_prefix, number)
 
 
 def validate_phone_number(number, column=None, international=False):
@@ -409,7 +409,7 @@ def validate_phone_number(number, column=None, international=False):
     number = normalise_phone_number(number)
 
     if (
-        number.startswith('44') or
+        number.startswith(uk_prefix) or
         (number.startswith('7') and len(number) < 11)
     ):
         return validate_uk_phone_number(number)
@@ -425,18 +425,25 @@ def validate_phone_number(number, column=None, international=False):
     return number
 
 
-def format_phone_number(number):
-    return '+44{}'.format(number)
+def format_phone_number(number, international=False):
+    return validate_phone_number(number, international=international)
 
 
 def format_phone_number_human_readable(number):
-    return '0{} {} {}'.format(number[:4], number[4:7], number[7:10])
+    if number.startswith(uk_prefix):
+        return '0{} {} {}'.format(number[2:6], number[6:9], number[9:12])
+    return '+{}'.format(number)
 
 
-def validate_and_format_phone_number(number, human_readable=False):
+def validate_and_format_phone_number(number, human_readable=False, international=False):
     if human_readable:
-        return format_phone_number_human_readable(validate_phone_number(number))
-    return format_phone_number(validate_phone_number(number))
+        return format_phone_number_human_readable(
+            validate_phone_number(number, international=international)
+        )
+    return format_phone_number(
+        validate_phone_number(number, international=international),
+        international=international
+    )
 
 
 def validate_email_address(email_address, column=None):

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -429,17 +429,7 @@ def format_phone_number(number, international=False):
     return validate_phone_number(number, international=international)
 
 
-def format_phone_number_human_readable(number):
-    if number.startswith(uk_prefix):
-        return '0{} {} {}'.format(number[2:6], number[6:9], number[9:12])
-    return '+{}'.format(number)
-
-
-def validate_and_format_phone_number(number, human_readable=False, international=False):
-    if human_readable:
-        return format_phone_number_human_readable(
-            validate_phone_number(number, international=international)
-        )
+def validate_and_format_phone_number(number, international=False):
     return format_phone_number(
         validate_phone_number(number, international=international),
         international=international

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -2,7 +2,7 @@ import re
 import sys
 import csv
 from contextlib import suppress
-from functools import lru_cache
+from functools import lru_cache, partial
 from collections import OrderedDict
 from orderedset import OrderedSet
 
@@ -406,16 +406,13 @@ def validate_phone_number(number, column=None, international=False):
     ):
         return validate_uk_phone_number(number)
 
-    if (number.startswith('0') and not number.startswith('00')):
-        return validate_phone_number(number)
-
     number = normalise_phone_number(number)
 
     if (
         number.startswith('44') or
         (number.startswith('7') and len(number) < 11)
     ):
-        return validate_phone_number(number)
+        return validate_uk_phone_number(number)
 
     if len(number) < 5:
         raise InvalidPhoneError('Not enough digits')
@@ -495,11 +492,11 @@ def validate_address(address_line, column):
     return address_line
 
 
-def validate_recipient(recipient, template_type, column=None):
+def validate_recipient(recipient, template_type, column=None, international_sms=False):
     return {
         'email': validate_email_address,
-        'sms': validate_phone_number,
-        'letter': validate_address
+        'sms': partial(validate_phone_number, international=international_sms),
+        'letter': validate_address,
     }[template_type](recipient, column)
 
 

--- a/tests/test_international_billing_rates.py
+++ b/tests/test_international_billing_rates.py
@@ -1,6 +1,9 @@
 import pytest
 
-from notifications_utils.international_billing_rates import INTERNATIONAL_BILLING_RATES
+from notifications_utils.international_billing_rates import (
+    INTERNATIONAL_BILLING_RATES,
+    COUNTRY_PREFIXES,
+)
 
 
 def test_international_billing_rates_exists():
@@ -22,3 +25,7 @@ def test_international_billing_rates_are_in_correct_format(country_prefix, value
     assert all(isinstance(country, str) for country in values['names'])
 
     assert isinstance(values['attributes'], dict)
+
+
+def test_country_codes():
+    assert len(COUNTRY_PREFIXES) == 214

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -13,6 +13,7 @@ from notifications_utils.recipients import (
     InvalidAddressError,
     validate_recipient,
     validate_phone_number,
+    normalise_phone_number,
 )
 
 
@@ -127,6 +128,21 @@ invalid_email_addresses = (
     'spaces-in-domain@dom ain.com',
     'underscores-in-domain@dom_ain.com',
 )
+
+
+@pytest.mark.parametrize('phone_number', [
+    'abcd',
+    '079OO900123',
+    pytest.mark.xfail(''),
+    pytest.mark.xfail('12345'),
+    pytest.mark.xfail('+12345'),
+    pytest.mark.xfail('1-2-3-4-5'),
+    pytest.mark.xfail('1 2 3 4 5'),
+    pytest.mark.xfail('(1)2345'),
+])
+def test_normalise_phone_number_raises_if_unparseable_characters(phone_number):
+    with pytest.raises(InvalidPhoneError) as e:
+        normalise_phone_number(phone_number)
 
 
 @pytest.mark.parametrize("phone_number", valid_phone_numbers)

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -5,7 +5,6 @@ from functools import partial
 
 from notifications_utils.recipients import (
     validate_phone_number,
-    format_phone_number,
     validate_and_format_phone_number,
     InvalidPhoneError,
     validate_email_address,
@@ -166,7 +165,6 @@ def test_phone_number_accepts_valid_international_values(validator, phone_number
 
 @pytest.mark.parametrize("phone_number", valid_phone_numbers)
 def test_valid_uk_phone_number_can_be_formatted_consistently(phone_number):
-    assert format_phone_number(validate_phone_number(phone_number)) == '447123456789'
     assert validate_and_format_phone_number(phone_number) == '447123456789'
 
 
@@ -179,10 +177,6 @@ def test_valid_uk_phone_number_can_be_formatted_consistently(phone_number):
     ('23051234567', '23051234567'),
 ])
 def test_valid_international_phone_number_can_be_formatted_consistently(phone_number, expected_formatted):
-    assert format_phone_number(
-        validate_phone_number(phone_number, international=True),
-        international=True,
-    ) == expected_formatted
     assert validate_and_format_phone_number(
         phone_number, international=True
     ) == expected_formatted

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -30,6 +30,7 @@ invalid_phone_numbers = sum([
         (phone_number, error) for phone_number in group
     ] for error, group in [
         ('Too many digits', (
+            '712345678910',
             '0712345678910',
             '0044712345678910',
             '0044712345678910',

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -76,11 +76,7 @@ invalid_phone_numbers = sum([
 
 invalid_international_phone_numbers = list(filter(
     lambda number: number[0] not in {
-        '08081 570364',   # Could be international (but isn’t)
-        '0117 496 0860',  # Could be USA
-        '020 7946 0991',  # Could be Egypt
         '712345678910',   # Could be Russia
-        '0712345678910',  # Could be Russia
     },
     invalid_phone_numbers
 )) + list(sum([

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -165,10 +165,33 @@ def test_phone_number_accepts_valid_international_values(validator, phone_number
 
 
 @pytest.mark.parametrize("phone_number", valid_phone_numbers)
-def test_valid_phone_number_can_be_formatted_consistently(phone_number):
-    assert format_phone_number(validate_phone_number(phone_number)) == '+447123456789'
-    assert validate_and_format_phone_number(phone_number) == '+447123456789'
+def test_valid_uk_phone_number_can_be_formatted_consistently(phone_number):
+    assert format_phone_number(validate_phone_number(phone_number)) == '447123456789'
+    assert validate_and_format_phone_number(phone_number) == '447123456789'
     assert validate_and_format_phone_number(phone_number, human_readable=True) == '07123 456 789'
+
+
+@pytest.mark.parametrize("phone_number, expected_formatted, expected_human_readable", [
+    ('71234567890', '71234567890', '+71234567890'),
+    ('1-202-555-0104', '12025550104', '+12025550104'),
+    ('+12025550104', '12025550104', '+12025550104'),
+    ('0012025550104', '12025550104', '+12025550104'),
+    ('+0012025550104', '12025550104', '+12025550104'),
+    ('23051234567', '23051234567', '+23051234567'),
+])
+def test_valid_international_phone_number_can_be_formatted_consistently(
+    phone_number, expected_formatted, expected_human_readable
+):
+    assert format_phone_number(
+        validate_phone_number(phone_number, international=True),
+        international=True,
+    ) == expected_formatted
+    assert validate_and_format_phone_number(
+        phone_number, international=True
+    ) == expected_formatted
+    assert validate_and_format_phone_number(
+        phone_number, human_readable=True, international=True
+    ) == expected_human_readable
 
 
 @pytest.mark.parametrize("phone_number, error_message", invalid_phone_numbers)

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -81,18 +81,10 @@ invalid_international_phone_numbers = list(filter(
         '712345678910',   # Could be Russia
     },
     invalid_phone_numbers
-)) + list(sum([
-    [
-        (phone_number, error) for phone_number in group
-    ] for error, group in [
-        ('Not a valid country prefix', (
-            '800000000000',
-        )),
-        ('Not enough digits', (
-            '1234',
-        )),
-    ]
-], []))
+)) + [
+    ('800000000000', 'Not a valid country prefix'),
+    ('1234', 'Not enough digits'),
+]
 
 
 valid_email_addresses = (

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -168,20 +168,17 @@ def test_phone_number_accepts_valid_international_values(validator, phone_number
 def test_valid_uk_phone_number_can_be_formatted_consistently(phone_number):
     assert format_phone_number(validate_phone_number(phone_number)) == '447123456789'
     assert validate_and_format_phone_number(phone_number) == '447123456789'
-    assert validate_and_format_phone_number(phone_number, human_readable=True) == '07123 456 789'
 
 
-@pytest.mark.parametrize("phone_number, expected_formatted, expected_human_readable", [
-    ('71234567890', '71234567890', '+71234567890'),
-    ('1-202-555-0104', '12025550104', '+12025550104'),
-    ('+12025550104', '12025550104', '+12025550104'),
-    ('0012025550104', '12025550104', '+12025550104'),
-    ('+0012025550104', '12025550104', '+12025550104'),
-    ('23051234567', '23051234567', '+23051234567'),
+@pytest.mark.parametrize("phone_number, expected_formatted", [
+    ('71234567890', '71234567890'),
+    ('1-202-555-0104', '12025550104'),
+    ('+12025550104', '12025550104'),
+    ('0012025550104', '12025550104'),
+    ('+0012025550104', '12025550104'),
+    ('23051234567', '23051234567'),
 ])
-def test_valid_international_phone_number_can_be_formatted_consistently(
-    phone_number, expected_formatted, expected_human_readable
-):
+def test_valid_international_phone_number_can_be_formatted_consistently(phone_number, expected_formatted):
     assert format_phone_number(
         validate_phone_number(phone_number, international=True),
         international=True,
@@ -189,9 +186,6 @@ def test_valid_international_phone_number_can_be_formatted_consistently(
     assert validate_and_format_phone_number(
         phone_number, international=True
     ) == expected_formatted
-    assert validate_and_format_phone_number(
-        phone_number, human_readable=True, international=True
-    ) == expected_human_readable
 
 
 @pytest.mark.parametrize("phone_number, error_message", invalid_phone_numbers)


### PR DESCRIPTION
This pull request adds validation that can be optionally enabled to allow international phone numbers. We consider an international phone number to be anything that starts with:

- `00` (but not `0`), and then a valid country prefix
- `+` and then a valid country prefix
- just a valid country prefix

As with UK numbers we ignore any brackets, dashes, spaces before validating.

There is one exception, Russia, whose country prefix is `7`. A number starting with `7` could be either a UK mobile number or a Russian phone number. So we only consider a phone number to be Russian if the part after the `7` is at least 10 digits.

Any number that starts with `7` and has fewer than 10 digits we treat as a UK mobile number. UK mobile numbers have 9 digits after the first `7`.

This pull request also does a bunch of other tidying up, but that’s the meat of it.
