### PR TITLE
Use Mistune’s built in newline handling

### DIFF
--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -326,6 +326,18 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
         )
 
 
-notify_email_markdown = mistune.Markdown(renderer=NotifyEmailMarkdownRenderer())
-notify_letter_preview_markdown = mistune.Markdown(renderer=NotifyLetterMarkdownPreviewRenderer())
-notify_letter_dvla_markdown = mistune.Markdown(renderer=NotifyLetterMarkdownDVLARenderer())
+notify_email_markdown = mistune.Markdown(
+    renderer=NotifyEmailMarkdownRenderer(),
+    hard_wrap=True,
+    use_xhtml=False,
+)
+notify_letter_preview_markdown = mistune.Markdown(
+    renderer=NotifyLetterMarkdownPreviewRenderer(),
+    hard_wrap=True,
+    use_xhtml=False,
+)
+notify_letter_dvla_markdown = mistune.Markdown(
+    renderer=NotifyLetterMarkdownDVLARenderer(),
+    hard_wrap=True,
+    use_xhtml=False,
+)

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -14,11 +14,6 @@ govuk_not_a_link = re.compile(
     re.IGNORECASE
 )
 
-single_newlines = re.compile(
-    r'^(.+)\n(?=[^\n])',
-    re.MULTILINE
-)
-
 dvla_markup_tags = re.compile(
     str('|'.join('\<{}\>'.format(tag) for tag in {
         'cr', 'h1', 'h2', 'p', 'normal', 'op', 'np', 'bul', 'tab'
@@ -32,16 +27,6 @@ def unlink_govuk_escaped(message):
         govuk_not_a_link,
         r'\1' + '.\u200B' + r'\2',  # Unicode zero-width space
         message
-    )
-
-
-def prepare_newlines_for_markdown(text):
-    return re.sub(
-        single_newlines,
-        lambda match: '{}  \n'.format(
-            match.group(1).strip()
-        ),
-        text
     )
 
 

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -619,7 +619,5 @@ def get_html_email_body(template_content, template_values, redact_missing_person
     ).then(
         unlink_govuk_escaped
     ).then(
-        prepare_newlines_for_markdown
-    ).then(
         notify_email_markdown
     ).as_string

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -550,8 +550,6 @@ class LetterDVLATemplate(LetterPreviewTemplate):
             Take.as_field(
                 self.content, self.values, markdown_lists=True, html='strip_dvla_markup'
             ).then(
-                prepare_newlines_for_markdown
-            ).then(
                 notify_letter_dvla_markdown
             ).then(
                 fix_extra_newlines_in_dvla_lists

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -356,8 +356,6 @@ class LetterPreviewTemplate(WithSubjectTemplate):
             ).then(
                 strip_pipes
             ).then(
-                prepare_newlines_for_markdown
-            ).then(
                 notify_letter_preview_markdown
             ).as_string,
             'address': Take.as_field(

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -14,7 +14,6 @@ from notifications_utils.formatters import (
     notify_email_markdown,
     notify_letter_preview_markdown,
     notify_letter_dvla_markdown,
-    prepare_newlines_for_markdown,
     remove_empty_lines,
     gsm_encode,
     escape_html,

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -444,7 +444,7 @@ def test_unordered_list(markdown_function, expected):
     [
         notify_letter_preview_markdown,
         (
-            '<p>line one\n'
+            '<p>line one<br/>'
             'line two</p>'
             '<p>new paragraph</p>'
         )
@@ -452,7 +452,7 @@ def test_unordered_list(markdown_function, expected):
     [
         notify_letter_dvla_markdown,
         (
-            'line one\n'
+            'line one<cr>'
             'line two<cr><cr>'
             'new paragraph<cr><cr>'
         )
@@ -460,7 +460,7 @@ def test_unordered_list(markdown_function, expected):
     [
         notify_email_markdown,
         (
-            '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">line one\n'
+            '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">line one<br/>'
             'line two</p>'
             '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">new paragraph</p>'
         )

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -6,7 +6,6 @@ from notifications_utils.formatters import (
     notify_email_markdown,
     notify_letter_preview_markdown,
     notify_letter_dvla_markdown,
-    prepare_newlines_for_markdown,
     gsm_encode,
     formatted_list,
     strip_dvla_markup,
@@ -148,43 +147,6 @@ def test_preserves_whitespace_when_making_links():
         'https://example.com\n'
         '\n'
         'Next paragraph'
-    )
-
-
-def test_add_spaces_after_single_newlines_so_markdown_converts_them():
-    converted = prepare_newlines_for_markdown(
-        'Paragraph one\n'
-        '\n'
-        'Paragraph two has linebreaks\n'
-        'This is the second line\n'
-        'The third has 2 spaces after it  \n'
-        'And this is the fourth\n'
-        '\n'
-        'Next paragraph'
-    )
-    assert converted == (
-        'Paragraph one\n'
-        '\n'
-        'Paragraph two has linebreaks  \n'
-        'This is the second line  \n'
-        'The third has 2 spaces after it  \n'
-        'And this is the fourth\n'
-        '\n'
-        'Next paragraph'
-    )
-    assert notify_email_markdown(converted) == (
-        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
-        'Paragraph one'
-        '</p>'
-        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
-        'Paragraph two has linebreaks<br/>'
-        'This is the second line<br/>'
-        'The third has 2 spaces after it<br/>'
-        'And this is the fourth'
-        '</p>'
-        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
-        'Next paragraph'
-        '</p>'
     )
 
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -126,12 +126,12 @@ def test_HTML_template_has_URLs_replaced_with_links():
         '<a style="word-wrap: break-word;" href="https://service.example.com/accept_invite/a1b2c3d4">'
         'https://service.example.com/accept_invite/a1b2c3d4'
         '</a>'
-    ) in str(HTMLEmailTemplate({'content': '''
-        You’ve been invited to a service. Click this link:
-        https://service.example.com/accept_invite/a1b2c3d4
-
-        Thanks
-    ''', 'subject': ''}))
+    ) in str(HTMLEmailTemplate({'content': (
+        'You’ve been invited to a service. Click this link:\n'
+        'https://service.example.com/accept_invite/a1b2c3d4\n'
+        '\n'
+        'Thanks\n'
+    ), 'subject': ''}))
 
 
 def test_preserves_whitespace_when_making_links():

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -437,6 +437,29 @@ def test_paragraphs(markdown_function, expected):
     ) == expected
 
 
+@pytest.mark.parametrize('markdown_function, expected', (
+    [
+        notify_letter_preview_markdown,
+        '<p>before</p><p>after</p>'
+    ],
+    [
+        notify_letter_dvla_markdown,
+        'before<cr><cr>after<cr><cr>'
+    ],
+    [
+        notify_email_markdown,
+        (
+            '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">before</p>'
+            '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">after</p>'
+        )
+    ]
+))
+def test_multiple_newlines_get_truncated(markdown_function, expected):
+    assert markdown_function(
+        'before\n\n\n\n\n\nafter'
+    ) == expected
+
+
 @pytest.mark.parametrize('markdown_function', (
     notify_letter_preview_markdown, notify_letter_dvla_markdown, notify_email_markdown
 ))

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -276,7 +276,6 @@ def test_sms_preview_adds_newlines(nl2br):
 @mock.patch('notifications_utils.template.remove_empty_lines', return_value='123 Street')
 @mock.patch('notifications_utils.template.unlink_govuk_escaped')
 @mock.patch('notifications_utils.template.notify_letter_preview_markdown', return_value='Bar')
-@mock.patch('notifications_utils.template.prepare_newlines_for_markdown', return_value='Baz')
 @mock.patch('notifications_utils.template.strip_pipes', side_effect=lambda x: x)
 @pytest.mark.parametrize('values, expected_address', [
     ({}, Markup(
@@ -352,7 +351,6 @@ def test_sms_preview_adds_newlines(nl2br):
 ])
 def test_letter_preview_renderer(
     strip_pipes,
-    prepare_newlines,
     letter_markdown,
     unlink_govuk,
     remove_empty_lines,
@@ -380,8 +378,7 @@ def test_letter_preview_renderer(
         'admin_base_url': 'http://localhost:6012',
         'logo_file_name': expected_logo_file_name,
     })
-    prepare_newlines.assert_called_once_with('Foo')
-    letter_markdown.assert_called_once_with('Baz')
+    letter_markdown.assert_called_once_with(Markup('Foo'))
     unlink_govuk.assert_not_called()
     assert strip_pipes.call_args_list == [
         mock.call('Subject'),

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1245,8 +1245,8 @@ def test_letter_address_format(address, expected):
         (
             'Here is a list of bullets:'
             '<cr>'
-            '<op><bul><tab>one  '
-            '<op><bul><tab>two  '
+            '<op><bul><tab>one'
+            '<op><bul><tab>two'
             '<op><bul><tab>three'
             '<p><cr>'
             'New paragraph<cr><cr>'
@@ -1263,8 +1263,8 @@ def test_letter_address_format(address, expected):
         (
             '<h2>List title:<normal>'
             '<cr>'
-            '<op><bul><tab>one  '
-            '<op><bul><tab>two  '
+            '<op><bul><tab>one'
+            '<op><bul><tab>two'
             '<op><bul><tab>three'
             '<p><cr>'
         )
@@ -1280,8 +1280,8 @@ def test_letter_address_format(address, expected):
         (
             'Here’s an ordered list:'
             '<cr><cr>'
-            '<np>one  '
-            '<np>two  '
+            '<np>one'
+            '<np>two'
             '<np>three'
             '<p><cr>'
         )

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -181,12 +181,12 @@ def test_HTML_template_has_URLs_replaced_with_links():
         '<a style="word-wrap: break-word;" href="https://service.example.com/accept_invite/a1b2c3d4">'
         'https://service.example.com/accept_invite/a1b2c3d4'
         '</a>'
-    ) in str(HTMLEmailTemplate({'content': '''
-        You’ve been invited to a service. Click this link:
-        https://service.example.com/accept_invite/a1b2c3d4
-
-        Thanks
-    ''', 'subject': ''}))
+    ) in str(HTMLEmailTemplate({'content': (
+        'You’ve been invited to a service. Click this link:\n'
+        'https://service.example.com/accept_invite/a1b2c3d4\n'
+        '\n'
+        'Thanks\n'
+    ), 'subject': ''}))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Turns out that Mistune has an option to respect single newlines like Github-flavored markdown does. This is much cleaner than our hacky thing of adding two spaces before a single newline to force the Markdown parser to see it.