### PR TITLE
Don’t require space between asterisk and list item

### DIFF
--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -357,6 +357,11 @@ def test_ordered_list(markdown_function, expected):
         '2. two\n'
         '3. three\n'
     ) == expected
+    assert markdown_function(
+        '1.one\n'
+        '2.two\n'
+        '3.three\n'
+    ) == expected
 
 
 @pytest.mark.parametrize('markdown_function, expected', (
@@ -399,6 +404,11 @@ def test_unordered_list(markdown_function, expected):
         '* one\n'
         '* two\n'
         '* three\n'
+    ) == expected
+    assert markdown_function(
+        '*one\n'
+        '*two\n'
+        '*three\n'
     ) == expected
 
 


### PR DESCRIPTION
Markdown requires you to do lists like this:

> * apple
> * orange
>
> 1. Banana
> 2. Paw-paw

Users that aren’t familiar with Markdown often don’t realise that the space between the bullet or number and the text of their list item is significant – and why should they? Let’s allow them to also do:

> *apple
> *orange
>
> 1.banana
> 2.paw-paw

This commit:

1. copies the regexes used by our Markdown parser
2. modifies them to not require the space
3. overrides the parser’s regexes with the modified ones

The original regexes can be found here – only difference is removing the (literal) space character from them:
https://github.com/lepture/mistune/blob/5b8c3f7db4321bada0b955a9fb833a3faba4a67f/mistune.py#L118-L138