### PR TITLE
Remove whitespace before commas in things we send

### DIFF
--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -21,6 +21,8 @@ dvla_markup_tags = re.compile(
     re.IGNORECASE
 )
 
+whitespace_before_commas = re.compile(r'\s+,')
+
 
 def unlink_govuk_escaped(message):
     return re.sub(
@@ -124,6 +126,10 @@ def fix_extra_newlines_in_dvla_lists(dvla_markup):
 
 def strip_pipes(value):
     return value.replace('|', '')
+
+
+def remove_whitespace_before_commas(value):
+    return re.sub(whitespace_before_commas, ',', value)
 
 
 class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -11,6 +11,7 @@ from notifications_utils.formatters import (
     strip_dvla_markup,
     strip_pipes,
     escape_html,
+    remove_whitespace_before_commas,
 )
 from notifications_utils.template import (
     HTMLEmailTemplate,
@@ -676,3 +677,21 @@ def test_bleach_doesnt_try_to_make_valid_html_before_cleaning():
     ) == (
         "&lt;to cancel daily cat facts reply 'cancel'&gt;"
     )
+
+
+@pytest.mark.parametrize('dirty, clean', [
+    (
+        'Hello ((name)) ,\n\nThis is a message',
+        'Hello ((name)),\n\nThis is a message'
+    ),
+    (
+        'Hello Jo ,\n\nThis is a message',
+        'Hello Jo,\n\nThis is a message'
+    ),
+    (
+        '\n   \t    , word',
+        ', word',
+    ),
+])
+def test_removing_whitespace_before_commas(dirty, clean):
+    assert remove_whitespace_before_commas(dirty) == clean


### PR DESCRIPTION
I’ve seen a couple of times (and we’ve done it in emails our service has sent) where a space sneaks in before a comma. This tends to happen with placeholders, eg:

> Hi ((name)) ,

…which results in:

![image](https://user-images.githubusercontent.com/355079/28219954-b734fc6a-68b5-11e7-82f1-8dc420e5fb03.png)

…which doesn’t look great.

Now we could do some postprocessing of the template content to remove whitespace between closing placeholder tags and commas, ie look for anything like `)) ,` and strip it before saving the template.

I think it’s better to do it at the time of rendering because:

- this covers templates already in the system
- I can’t think of a single case where we’d _ever_ want a space before a comma (butt in here if you can)

So this commit does the replacement in all the places where it might be useful, for all types of messages.

The tests are fairly verbose here, but this stuff is quite complex now, so more tests can’t hurt I don’t think.