### PR TITLE
Make sure we reject email addresses with pipes

### DIFF
--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -134,6 +134,7 @@ invalid_email_addresses = (
     'spaces in local@domain.com',
     'spaces-in-domain@dom ain.com',
     'underscores-in-domain@dom_ain.com',
+    'pipe-in-domain@example.com|gov.uk',
 )
 
 


### PR DESCRIPTION
Makes sure we don’t enable the behaviour described in this issue: https://github.com/alphagov/notifications-admin/issues/1369