### PR TITLE
Don’t check for values before counting characters in text messages

### DIFF
--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -142,8 +142,6 @@ class SMSMessageTemplate(Template):
         return len((
             # we always want to call SMSMessageTemplate.__str__ regardless of subclass, to avoid any html formatting
             SMSMessageTemplate.__str__(self)
-            if self._values
-            else gsm_encode(add_prefix(self.content.strip(), self.prefix))
         ).encode(self.encoding))
 
     @property

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -139,10 +139,10 @@ class SMSMessageTemplate(Template):
 
     @property
     def content_count(self):
-        return len((
+        return len(
             # we always want to call SMSMessageTemplate.__str__ regardless of subclass, to avoid any html formatting
-            SMSMessageTemplate.__str__(self)
-        ).encode(self.encoding))
+            SMSMessageTemplate.__str__(self).encode(self.encoding)
+        )
 
     @property
     def fragment_count(self):

--- a/tests/test_base_template.py
+++ b/tests/test_base_template.py
@@ -121,7 +121,7 @@ def test_extracting_placeholders(template_content, template_subject, expected):
 
 @pytest.mark.parametrize('template_cls', [SMSMessageTemplate, SMSPreviewTemplate])
 @pytest.mark.parametrize(
-    "content,prefix, expected_length, expected_replaced_length",
+    "content, prefix, expected_length, expected_replaced_length",
     [
         ("The quick brown fox jumped over the lazy dog", None, 44, 44),
         # should be replaced with a ?


### PR DESCRIPTION
This conditional stuff about what to do when placeholders are/aren’t filled is handled by the `Field` instance now. Can remove it here to make the code cleaner. Tests for this are pretty robust:
https://github.com/alphagov/notifications-utils/blob/f90242731c54827b161efd334aad41129cecb000/tests/test_base_template.py#L122-L143