### PR TITLE
Add alt tag for GOV UK Crown

### DIFF
--- a/notifications_utils/email_template.jinja2
+++ b/notifications_utils/email_template.jinja2
@@ -48,7 +48,7 @@
             <td width="70" bgcolor="#0b0c0c" valign="middle">
               <a href="https://www.gov.uk" style="text-decoration: none;"><img
                       src="https://static.notifications.service.gov.uk/images/gov.uk_logotype_crown.png"
-                      alt="" height="32" border="0" style="margin-top: 4px; margin-left: 10px;"></a>
+                      alt="GOV UK Crown" height="32" border="0" style="margin-top: 4px; margin-left: 10px;"></a>
             </td>
             <td width="100%" bgcolor="#0b0c0c" valign="middle" align="left">
               <span style="padding-left: 5px;"><a href="https://www.gov.uk" style="


### PR DESCRIPTION
While submitting the MOT Reminders service for an accessibility audit,
we found that the GOV UK Crown in the email notifications  was missing
an alt tag. This was flagged up during the audit, and it was recommended
that we add the alt tag to reduce confusion for users using screen
readers.