### PR TITLE
Add Flake8 linting to project

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+# Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
+# W503: line break before binary operator
+exclude = venv*,__pycache__
+ignore = W503
+max-complexity = 8
+max-line-length = 120

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -1,9 +1,8 @@
 from itertools import product
 import re
-import os
 import sys
 
-from flask import request, current_app, g
+from flask import request, g
 from flask.ctx import has_request_context
 from pythonjsonlogger.jsonlogger import JsonFormatter as BaseJSONFormatter
 from time import monotonic

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -7,8 +7,6 @@ from functools import lru_cache, partial
 from collections import OrderedDict, namedtuple
 from orderedset import OrderedSet
 
-from flask import Markup
-
 from notifications_utils.formatters import formatted_list
 from notifications_utils.template import Template
 from notifications_utils.columns import Columns

--- a/notifications_utils/s3.py
+++ b/notifications_utils/s3.py
@@ -1,5 +1,3 @@
-import uuid
-
 import botocore
 from boto3 import resource
 from flask import current_app

--- a/notifications_utils/timezones.py
+++ b/notifications_utils/timezones.py
@@ -1,6 +1,5 @@
 import dateutil
 import pytz
-from dateutil import parser
 
 
 def utc_string_to_aware_gmt_datetime(date):

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
-pycodestyle==2.3.1
 pytest==3.2.3
 pytest-mock==1.6.3
 pytest-cov==2.5.1
 requests-mock==1.3.0
 freezegun==0.3.9
+flake8==3.4.1

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -26,7 +26,7 @@ if [ -d venv ]; then
   source ./venv/bin/activate
 fi
 
-pycodestyle .
+flake8 .
 display_result $? 1 "Code style check"
 
 ## Code coverage

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,2 @@
-[pycodestyle]
-max-line-length = 120
-exclude = ./migrations,./venv,./venv3
-
 [tool:pytest]
 xfail_strict=true

--- a/tests/test_base_template.py
+++ b/tests/test_base_template.py
@@ -1,15 +1,10 @@
 import pytest
 from unittest.mock import PropertyMock
 from unittest.mock import patch
-from flask import Markup
 from notifications_utils.template import (
     Template,
-    HTMLEmailTemplate,
     SMSMessageTemplate,
     SMSPreviewTemplate,
-    LetterPreviewTemplate,
-    NeededByTemplateError,
-    NoPlaceholderForDataError,
     WithSubjectTemplate
 )
 
@@ -179,5 +174,5 @@ def test_compare_template():
     ) as mocked:
         old_template = Template({'content': 'faked', 'template_type': 'sms'})
         new_template = Template({'content': 'faked', 'template_type': 'sms'})
-        template_changes = old_template.compare_to(new_template)
+        old_template.compare_to(new_template)
         mocked.assert_called_once_with(old_template, new_template)

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,4 +1,3 @@
-import os
 import logging as builtin_logging
 import logging.handlers as builtin_logging_handlers
 import uuid

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -1,11 +1,10 @@
 import pytest
 from unittest import mock
 import itertools
-from flask import Markup
 from functools import partial
 
-from notifications_utils.recipients import RecipientCSV, Columns
-from notifications_utils.template import Template, SMSMessageTemplate
+from notifications_utils.recipients import RecipientCSV
+from notifications_utils.template import SMSMessageTemplate
 
 
 @pytest.mark.parametrize(
@@ -249,7 +248,6 @@ def test_big_list_validates_right_through(template_type, row_count, header, fill
         max_errors_shown=100,
         max_initial_rows_shown=3
     )
-    auto_generated_row_count = RecipientCSV.max_rows / 10
     assert len(list(big_csv.annotated_rows)) == row_count
     assert big_csv.rows_with_bad_recipients == {row_count - 1}  # 0 indexed
     assert big_csv.rows_with_errors == {row_count - 1}

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -1,4 +1,3 @@
-import re
 import pytest
 
 from functools import partial
@@ -12,7 +11,6 @@ from notifications_utils.recipients import (
     allowed_to_send_to,
     InvalidAddressError,
     validate_recipient,
-    validate_phone_number,
     is_uk_phone_number,
     normalise_phone_number,
     international_phone_info,
@@ -149,7 +147,7 @@ def test_detect_international_phone_numbers(phone_number):
 
 
 @pytest.mark.parametrize("phone_number", valid_uk_phone_numbers)
-def test_detect_international_phone_numbers(phone_number):
+def test_detect_uk_phone_numbers(phone_number):
     assert is_uk_phone_number(phone_number) is True
 
 
@@ -205,7 +203,7 @@ def test_get_international_info(phone_number, expected_info):
     pytest.mark.xfail('(1)2345'),
 ])
 def test_normalise_phone_number_raises_if_unparseable_characters(phone_number):
-    with pytest.raises(InvalidPhoneError) as e:
+    with pytest.raises(InvalidPhoneError):
         normalise_phone_number(phone_number)
 
 
@@ -395,7 +393,7 @@ def test_validates_against_whitelist_of_email_addresses(email_address):
     ('33(0)1 12345678', '+33 1 12 34 56 78'),  # Paris (France)
     ('33(0)1 12 34 56 78 90 12 34', '+33 112345678901234'),  # Long, not real, number
 ])
-def test_get_international_info(phone_number, expected_formatted):
+def test_format_uk_and_international_phone_numbers(phone_number, expected_formatted):
     assert format_phone_number_human_readable(phone_number) == expected_formatted
 
 

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -167,12 +167,12 @@ def test_should_allow_request_if_not_over_limit(mocked_redis_client, mocked_redi
 
 
 @freeze_time("2001-01-01 12:00:00.000000")
-def test_should_allow_request_if_not_over_limit(mocked_redis_client, mocked_redis_pipeline):
+def test_rate_limit_not_exceeded(mocked_redis_client, mocked_redis_pipeline):
     mocked_redis_pipeline.execute.return_value = [True, True, 80, True]
     assert not mocked_redis_client.exceeded_rate_limit("key", 90, 100)
 
 
-def test_should_not_call_set_if_not_enabled(mocked_redis_client, mocked_redis_pipeline):
+def test_should_not_call_rate_limit_if_not_enabled(mocked_redis_client, mocked_redis_pipeline):
     mocked_redis_client.active = False
 
     assert not mocked_redis_client.exceeded_rate_limit('key', 100, 100)

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -59,13 +59,13 @@ def test_brand_banner_shows():
         {'content': 'hello world', 'subject': ''},
         brand_banner=True,
         govuk_banner=False
-        ))
+    ))
     assert (
         '<td width="10" height="10" valign="middle"></td>'
-        ) not in email
+    ) not in email
     assert (
         'role="presentation" width="100%" style="min-width: 100%;width: 100% !important;"'
-        ) in email
+    ) in email
 
 
 @pytest.mark.parametrize(
@@ -86,7 +86,7 @@ def test_brand_data_shows(brand_logo, brand_name, brand_colour):
         brand_logo=brand_logo,
         brand_name=brand_name,
         brand_colour=brand_colour
-        ))
+    ))
 
     assert 'GOV.UK' not in email
     if brand_logo:
@@ -319,7 +319,7 @@ def test_sms_messages_downgrade_non_gsm(mock_gsm_encode, template_class):
 
 
 @mock.patch('notifications_utils.template.gsm_encode', return_value='downgraded')
-def test_sms_messages_downgrade_non_gsm(mock_gsm_encode):
+def test_sms_messages_dont_downgrade_non_gsm_if_setting_is_false(mock_gsm_encode):
     template = str(SMSPreviewTemplate(
         {'content': '😎'},
         prefix='👉',
@@ -500,7 +500,7 @@ def test_letter_image_renderer_pagination(page_image_url):
     ),
 ])
 def test_letter_image_renderer_requires_arguments(partial_call, expected_exception):
-    with pytest.raises(expected_exception) as error:
+    with pytest.raises(expected_exception):
         partial_call({'content': '', 'subject': ''})
 
 
@@ -1549,12 +1549,12 @@ def test_lists_in_combination_with_other_elements_in_letters(markdown, expected)
 
 
 @pytest.mark.parametrize('template_class', [
-        SMSMessageTemplate,
-        SMSPreviewTemplate,
+    SMSMessageTemplate,
+    SMSPreviewTemplate,
 ])
 def test_message_too_long(template_class):
     body = ('b' * 200) + '((foo))'
-    template = template_class({'content': body}, prefix='a' * 100, values={'foo': 'c'*200})
+    template = template_class({'content': body}, prefix='a' * 100, values={'foo': 'c' * 200})
     assert template.is_message_too_long() is True
 
 


### PR DESCRIPTION
[The GDS Way™](https://gds-way.cloudapps.digital/manuals/programming-languages/python/linting.html#how-to-use-flake8) recommends using [Flake8](http://flake8.pycqa.org/en/latest/) to lint Python projects.

This commit takes the Flake8 config [from Digital Marketplace API](https://github.com/alphagov/digitalmarketplace-api/blob/d5ab8afef4a0472f9d266d94ab4ffe1333a9aaad/.flake8) and removes the bits we don’t need.

It changes the `max_complexity` setting to 8, which is the most complex code we have in this repo currently (we shouldn’t be writing code _more_ complex than what we already have).

This commit also fixes the errors found by Flake8, which includes 6(!) tests which were never getting run because they had the same names as existing tests.

Here is a full list of the errors that were found and fixed:
```
./notifications_utils/logging.py:3:1: F401 'os' imported but unused
./notifications_utils/logging.py:6:1: F401 'flask.current_app' imported but unused
./notifications_utils/recipients.py:10:1: F401 'flask.Markup' imported but unused
./notifications_utils/s3.py:1:1: F401 'uuid' imported but unused
./notifications_utils/timezones.py:3:1: F401 'dateutil.parser' imported but unused
./tests/test_base_template.py:4:1: F401 'flask.Markup' imported but unused
./tests/test_base_template.py:5:1: F401 'notifications_utils.template.NeededByTemplateError' imported but unused
./tests/test_base_template.py:5:1: F401 'notifications_utils.template.NoPlaceholderForDataError' imported but unused
./tests/test_base_template.py:5:1: F401 'notifications_utils.template.HTMLEmailTemplate' imported but unused
./tests/test_base_template.py:5:1: F401 'notifications_utils.template.LetterPreviewTemplate' imported but unused
./tests/test_base_template.py:182:9: F841 local variable 'template_changes' is assigned to but never used
./tests/test_logging.py:1:1: F401 'os' imported but unused
./tests/test_recipient_csv.py:4:1: F401 'flask.Markup' imported but unused
./tests/test_recipient_csv.py:7:1: F401 'notifications_utils.recipients.Columns' imported but unused
./tests/test_recipient_csv.py:8:1: F401 'notifications_utils.template.Template' imported but unused
./tests/test_recipient_csv.py:252:5: F841 local variable 'auto_generated_row_count' is assigned to but never used
./tests/test_recipient_validation.py:1:1: F401 're' imported but unused
./tests/test_recipient_validation.py:6:1: F811 redefinition of unused 'validate_phone_number' from line 6
./tests/test_recipient_validation.py:151:1: F811 redefinition of unused 'test_detect_international_phone_numbers' from line 146
./tests/test_recipient_validation.py:208:46: F841 local variable 'e' is assigned to but never used
./tests/test_recipient_validation.py:384:1: F811 redefinition of unused 'test_get_international_info' from line 156
./tests/test_redis_client.py:169:1: F811 redefinition of unused 'test_should_allow_request_if_not_over_limit' from line 163
./tests/test_redis_client.py:175:1: F811 redefinition of unused 'test_should_not_call_set_if_not_enabled' from line 75
./tests/test_template_types.py:62:9: E123 closing bracket does not match indentation of opening bracket's line
./tests/test_template_types.py:65:9: E123 closing bracket does not match indentation of opening bracket's line
./tests/test_template_types.py:68:9: E123 closing bracket does not match indentation of opening bracket's line
./tests/test_template_types.py:89:9: E123 closing bracket does not match indentation of opening bracket's line
./tests/test_template_types.py:321:1: F811 redefinition of unused 'test_sms_messages_downgrade_non_gsm' from line 311
./tests/test_template_types.py:503:47: F841 local variable 'error' is assigned to but never used
./tests/test_template_types.py:1552:9: E126 continuation line over-indented for hanging indent
./tests/test_template_types.py:1557:86: E226 missing whitespace around arithmetic operator
```

We should set this up for our other repos.