### PR TITLE
Refactor placeholder code

### DIFF
--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -12,18 +12,51 @@ from notifications_utils.formatters import (
 )
 
 
-class Field():
+class Placeholder:
+    def __init__(self, body):
+        # body should not include the (( and )).
+        self.body = body.lstrip('((').rstrip('))')
 
+    @classmethod
+    def from_match(cls, match):
+        return cls(match.group(0))
+
+    def is_conditional(self):
+        return '??' in self.body
+
+    @property
+    def name(self):
+        # for non conditionals, name equals body
+        return self.body.split('??')[0]
+
+    @property
+    def conditional_text(self):
+        if self.is_conditional():
+            # ((a?? b??c)) returns " b??c"
+            return '??'.join(self.body.split('??')[1:])
+        else:
+            raise ValueError('{} not conditional'.format(self))
+
+    def get_conditional_body(self, show_conditional):
+        # note: unsanitised/converted
+        if self.is_conditional():
+            return self.conditional_text if str2bool(show_conditional) else ''
+        else:
+            raise ValueError('{} not conditional'.format(self))
+
+    def __repr__(self):
+        return 'Placeholder({})'.format(self.body)
+
+
+class Field:
     placeholder_pattern = re.compile(
-        '\(\('            # opening ((
-        '([^\(\)\?]+)'    # 1. name of placeholder, eg ‘registration number’
-        '(\?\?)?'         # 2. optional ??
-        '([^\)\(]*)'      # 3. conditional text to display if the placeholder’s value is True
-        '\)\)'            # closing ))
+        r'\({2}'        # opening ((
+        r'([^()]+)'     # body of placeholder - potentially standard or conditional.
+        r'\){2}'        # closing ))
     )
-    placeholder_tag = "<span class='placeholder'>(({}{}))</span>"
+    placeholder_tag = "<span class='placeholder'>(({}))</span>"
     conditional_placeholder_tag = "<span class='placeholder-conditional'>(({}??</span>{}))"
-    placeholder_tag_no_brackets = "<span class='placeholder-no-brackets'>{}{}</span>"
+    placeholder_tag_no_brackets = "<span class='placeholder-no-brackets'>{}</span>"
     placeholder_tag_redacted = "<span class='placeholder-redacted'>hidden</span>"
 
     def __init__(
@@ -64,60 +97,54 @@ class Field():
     def values(self, value):
         self._values = Columns(value) if value else {}
 
-    def get_match(self, match):
-        if match[1] and match[2]:
-            return match[0]
-        return match[0] + match[2]
-
     def format_match(self, match):
+        placeholder = Placeholder.from_match(match)
+
         if self.redact_missing_personalisation:
-            return self.placeholder_tag_redacted.format(
-                self.sanitizer(match.group(1)),
-                self.sanitizer(match.group(3)) or ''
-            )
-        if match.group(2) and match.group(3):
+            return self.placeholder_tag_redacted
+
+        if placeholder.is_conditional():
             return self.conditional_placeholder_tag.format(
-                self.sanitizer(match.group(1)),
-                self.sanitizer(match.group(3))
+                self.sanitizer(placeholder.name),
+                self.sanitizer(placeholder.conditional_text)
             )
+
         return self.placeholder_tag.format(
-            self.sanitizer(match.group(1)), self.sanitizer(match.group(3))
+            self.sanitizer(placeholder.name)
         )
 
     def replace_match(self, match):
-        if match.group(2) and match.group(3) and self.values.get(match.group(1)) is not None:
-            return match.group(3) if str2bool(self.values.get(match.group(1))) else ''
-        if self.get_replacement(match) is not None:
-            return self.get_replacement(match)
+        placeholder = Placeholder.from_match(match)
+        replacement = self.values.get(placeholder.name)
+
+        if placeholder.is_conditional() and replacement is not None:
+            return placeholder.get_conditional_body(replacement)
+
+        replaced_value = self.get_replacement(placeholder)
+        if replaced_value is not None:
+            return self.get_replacement(placeholder)
+
         return self.format_match(match)
 
-    def get_replacement(self, match):
-
-        replacement = self.values.get(match.group(1) + match.group(3))
+    def get_replacement(self, placeholder):
+        replacement = self.values.get(placeholder.name)
+        if replacement is None:
+            return None
 
         if isinstance(replacement, list):
-            return self.get_replacement_as_list(list(filter(None, replacement)))
+            vals = list(filter(None, replacement))
+            if not vals:
+                return None
+            return self.sanitizer(self.get_replacement_as_list(vals))
 
-        if (
-            isinstance(replacement, bool) or
-            replacement == 0 or
-            replacement == ''
-        ):
-            return str(replacement)
-
-        if replacement:
-            return self.sanitizer(str(replacement)) or ''
-
-        return None
+        return self.sanitizer(str(replacement))
 
     def get_replacement_as_list(self, replacement):
-        if not replacement:
-            return None
         if self.markdown_lists:
-            return self.sanitizer('\n\n' + '\n'.join(
+            return '\n\n' + '\n'.join(
                 '* {}'.format(item) for item in replacement
-            ))
-        return self.sanitizer(unescaped_formatted_list(replacement, before_each='', after_each=''))
+            )
+        return unescaped_formatted_list(replacement, before_each='', after_each='')
 
     @property
     def _raw_formatted(self):
@@ -132,7 +159,7 @@ class Field():
     @property
     def placeholders(self):
         return OrderedSet(
-            self.get_match(match) for match in re.findall(
+            Placeholder(body).name for body in re.findall(
                 self.placeholder_pattern, self.content
             )
         )

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -18,11 +18,11 @@ class Field():
         '\(\('            # opening ((
         '([^\(\)\?]+)'    # 1. name of placeholder, eg ‘registration number’
         '(\?\?)?'         # 2. optional ??
-        '([^\)\(]*)'      # 3. optional text to display if the placeholder’s value is True
+        '([^\)\(]*)'      # 3. conditional text to display if the placeholder’s value is True
         '\)\)'            # closing ))
     )
     placeholder_tag = "<span class='placeholder'>(({}{}))</span>"
-    optional_placeholder_tag = "<span class='placeholder-conditional'>(({}??</span>{}))"
+    conditional_placeholder_tag = "<span class='placeholder-conditional'>(({}??</span>{}))"
     placeholder_tag_no_brackets = "<span class='placeholder-no-brackets'>{}{}</span>"
     placeholder_tag_redacted = "<span class='placeholder-redacted'>hidden</span>"
 
@@ -76,7 +76,7 @@ class Field():
                 self.sanitizer(match.group(3)) or ''
             )
         if match.group(2) and match.group(3):
-            return self.optional_placeholder_tag.format(
+            return self.conditional_placeholder_tag.format(
                 self.sanitizer(match.group(1)),
                 self.sanitizer(match.group(3))
             )

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -3,5 +3,6 @@ pycodestyle==2.3.1
 pytest==3.2.3
 pytest-mock==1.6.3
 pytest-cov==2.5.1
+pytest-xdist==1.20.1
 requests-mock==1.3.0
 freezegun==0.3.9

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -33,7 +33,7 @@ display_result $? 1 "Code style check"
 #py.test --cov=client tests/
 #display_result $? 2 "Code coverage"
 
-py.test -v tests/
+py.test -n4 tests/
 display_result $? 3 "Unit tests"
 
 python setup.py sdist

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -218,7 +218,7 @@ def test_handling_of_missing_values(content, values, expected):
         ['true'], {'True': True}, (True, 'true', 1)
     ]
 )
-def test_what_will_not_trigger_optional_placeholder(value):
+def test_what_will_not_trigger_conditional_placeholder(value):
     assert str2bool(value) is False
 
 
@@ -235,7 +235,7 @@ def test_what_will_not_trigger_optional_placeholder(value):
         'show'
     ]
 )
-def test_what_will_trigger_optional_placeholder(value):
+def test_what_will_trigger_conditional_placeholder(value):
     assert str2bool(value) is True
 
 

--- a/tests/test_field_html_handling.py
+++ b/tests/test_field_html_handling.py
@@ -25,27 +25,27 @@ from notifications_utils.field import Field
         'string <em>without</em> html',
     ),
     (
-        'string ((<em>optional</em>??<em>placeholder</em>)) html',
+        'string ((<em>conditional</em>??<em>placeholder</em>)) html',
         {},
-        'string <span class=\'placeholder-conditional\'>((optional??</span>placeholder)) html',
+        'string <span class=\'placeholder-conditional\'>((conditional??</span>placeholder)) html',
         (
             'string '
             '<span class=\'placeholder-conditional\'>'
-            '((&lt;em&gt;optional&lt;/em&gt;??</span>'
+            '((&lt;em&gt;conditional&lt;/em&gt;??</span>'
             '&lt;em&gt;placeholder&lt;/em&gt;)) '
             'html'
         ),
         (
             'string '
             '<span class=\'placeholder-conditional\'>'
-            '((<em>optional</em>??</span>'
+            '((<em>conditional</em>??</span>'
             '<em>placeholder</em>)) '
             'html'
         ),
     ),
     (
-        'string ((optional??<em>placeholder</em>)) html',
-        {'optional': True},
+        'string ((conditional??<em>placeholder</em>)) html',
+        {'conditional': True},
         'string placeholder html',
         'string &lt;em&gt;placeholder&lt;/em&gt; html',
         'string <em>placeholder</em> html',

--- a/tests/test_international_billing_rates.py
+++ b/tests/test_international_billing_rates.py
@@ -10,7 +10,7 @@ def test_international_billing_rates_exists():
     assert INTERNATIONAL_BILLING_RATES['1']['names'][0] == 'Canada'
 
 
-@pytest.mark.parametrize('country_prefix, values', INTERNATIONAL_BILLING_RATES.items())
+@pytest.mark.parametrize('country_prefix, values', sorted(INTERNATIONAL_BILLING_RATES.items()))
 def test_international_billing_rates_are_in_correct_format(country_prefix, values):
     assert isinstance(country_prefix, str)
     # we don't want the prefixes to have + at the beginning for instance

--- a/tests/test_placeholders.py
+++ b/tests/test_placeholders.py
@@ -1,0 +1,54 @@
+import re
+
+import pytest
+
+from notifications_utils.field import Placeholder
+
+
+@pytest.mark.parametrize('body, expected', [
+    ('((with-brackets))', 'with-brackets'),
+    ('without-brackets', 'without-brackets'),
+])
+def test_placeholder_returns_name(body, expected):
+    assert Placeholder(body).name == expected
+
+
+@pytest.mark.parametrize('body, is_conditional', [
+    ('not a conditional', False),
+    ('not? a conditional', False),
+    ('a?? conditional', True),
+])
+def test_placeholder_identifies_conditional(body, is_conditional):
+    assert Placeholder(body).is_conditional() == is_conditional
+
+
+@pytest.mark.parametrize('body, conditional_text', [
+    ('a??b', 'b'),
+    ('a?? b ', ' b '),
+    ('a??b??c', 'b??c'),
+])
+def test_placeholder_gets_conditional_text(body, conditional_text):
+    assert Placeholder(body).conditional_text == conditional_text
+
+
+def test_placeholder_raises_if_accessing_conditional_text_on_non_conditional():
+    with pytest.raises(ValueError):
+        Placeholder('hello').conditional_text
+
+
+@pytest.mark.parametrize('body, value, result', [
+    ('a??b', 'Yes', 'b'),
+    ('a??b', 'No', ''),
+])
+def test_placeholder_gets_conditional_body(body, value, result):
+    assert Placeholder(body).get_conditional_body(value) == result
+
+
+def test_placeholder_raises_if_getting_conditional_body_on_non_conditional():
+    with pytest.raises(ValueError):
+        Placeholder('hello').get_conditional_body('Yes')
+
+
+def test_placeholder_can_be_constructed_from_regex_match():
+    match = re.search(r'\(\(.*\)\)', 'foo ((bar)) baz')
+    assert Placeholder.from_match(match).name == 'bar'


### PR DESCRIPTION
No actual logic change here, but lots of refactoring.

#### The Past

* Tests run sequentially.
* Placeholders with `??` in the middle are known as optional placeholders in code
* In the `Field` class, a regex matched placeholders by `((.*))`, but also at the same time identified whether it was a conditional 

#### The Future

* Tests run in parallel
* Placeholders with `??` in the middle are known as _conditional_ placeholders.
* In the `Field` class, a regex matches anything with `((.*))` as some sort of placeholder
* A new `Placeholder` class handles extracting the name, and working out if it's conditional
  - in the future, this class will also handle if placeholders are optional too