### PR TITLE
Make looking up individual CSV rows faster

### DIFF
--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -76,6 +76,7 @@ class RecipientCSV():
         self.whitelist = whitelist
         self.template = template if isinstance(template, Template) else None
         self.international_sms = international_sms
+        self.rows = list(self.get_rows())
         self.annotated_rows = list(self.get_annotated_rows())
         self.remaining_messages = remaining_messages
 
@@ -160,8 +161,7 @@ class RecipientCSV():
             skipinitialspace=True,
         )
 
-    @property
-    def rows(self):
+    def get_rows(self):
 
         column_headers = self._raw_column_headers  # this is for caching
         length_of_column_headers = len(column_headers)

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -86,10 +86,7 @@ class RecipientCSV():
         return self._len
 
     def __getitem__(self, requested_index):
-        for row_index, row in enumerate(self.rows):
-            if row_index == requested_index:
-                return row
-        raise IndexError
+        return self.rows[requested_index]
 
     @property
     def whitelist(self):

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -759,10 +759,13 @@ def test_dont_error_if_too_many_recipients_not_specified():
         3,
         {'phone number': 'foo'},
     ), raises=IndexError),
-    pytest.mark.xfail((
+    (
         -1,
-        {'phone number': 'foo'},
-    ), raises=IndexError),
+        {
+            'p h o n e  n u m b e r': '07700 90000 3',
+            '   colour   ': 'blue'
+        },
+    ),
 ])
 def test_recipients_can_be_accessed_by_index(index, expected_row):
     recipients = RecipientCSV(


### PR DESCRIPTION
# Cache initial row generation

The underlying CSV file never changes once the class has been instantiated – i.e. we never reuse an instance of the `RecipientCSV` class with a different file.

Therefore we should never read from the file more than once.

This will allow us to do some things which previously would have been very inefficient, for example:

# Index directly into the cached row 

Looping through all preceding rows every time you want one row is very inefficient – basically an example of [Shlemiel the painter’s algorithm](https://www.joelonsoftware.com/2001/12/11/back-to-basics/).

Since the rows are now a list, not a generator, we can index directly into them.
