### PR TITLE
Add Microsort-specific spacing styles

### DIFF
--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -142,7 +142,7 @@
                   <img
                     src="{{ brand_logo }}"
                     border="0"
-                    style="display: block; border: 0; margin-top: 10px; margin-bottom: 12px;"
+                    style="display: block; border: 0; Margin-top: 10px; Margin-bottom: 12px;"
                     height="{% if brand_name -%} 27 {%- else -%} 54 {%- endif %}"
                     alt=""
                   />

--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -27,6 +27,10 @@
       li {
         margin-left: 4px !important;
       }
+      table {
+        mso-table-lspace: 0pt;
+        mso-table-rspace: 0pt;
+      }
     </style>
   <![endif]-->
 

--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -35,19 +35,19 @@
 <body style="font-family: Helvetica, Arial, sans-serif;font-size: 16px;margin: 0;color:#0b0c0c;">
 {% endif %}
 {% if govuk_banner %}
-  <table role="presentation" width="100%" style="min-width: 100%;width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
+  <table role="presentation" width="100%" style="border-collapse: collapse;min-width: 100%;width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
     <tr>
       <td width="100%" height="53" bgcolor="#0b0c0c">
         <!--[if (gte mso 9)|(IE)]>
-          <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0">
+          <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
             <tr>
               <td>
         <![endif]-->
-        <table role="presentation" width="100%" style="max-width: 580px;" cellpadding="0" cellspacing="0" border="0" align="center">
+        <table role="presentation" width="100%" style="border-collapse: collapse;max-width: 580px;" cellpadding="0" cellspacing="0" border="0" align="center">
           <tr>
             <td width="70" bgcolor="#0b0c0c" valign="middle">
               <a href="https://www.gov.uk" title="Go to the GOV.UK homepage" style="text-decoration: none;">
-                <table role="presentation" cellpadding="0" cellspacing="0" border="0">
+                <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
                   <tr>
                     <td style="padding-left: 10px">
                       <img
@@ -89,18 +89,18 @@
       cellpadding="0"
       cellspacing="0"
       border="0"
-      style="max-width: 580px; width: 100% !important;"
+      style="border-collapse: collapse;max-width: 580px; width: 100% !important;"
       width="100%"
   >
     <tr>
       <td width="10" height="10" valign="middle"></td>
       <td>
         <!--[if (gte mso 9)|(IE)]>
-          <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0">
+          <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
             <tr>
               <td height="10">
         <![endif]-->
-                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
                   <tr>
                     <td bgcolor="#005EA5" width="100%" height="10"></td>
                   </tr>
@@ -117,15 +117,15 @@
 {% endif %}
 {% if brand_banner %}
   {% set brand_colour = brand_colour if brand_colour else '#0b0c0c' %}
-  <table role="presentation" width="100%" style="min-width: 100%;width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
+  <table role="presentation" width="100%" style="border-collapse: collapse;min-width: 100%;width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
       <tr>
         <td width="100%" height="53" bgcolor="{{brand_colour}}">
           <!--[if (gte mso 9)|(IE)]>
-            <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0">
+            <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
               <tr>
                 <td>
           <![endif]-->
-          <table role="presentation" width="100%" style="max-width: 580px;" cellpadding="0" cellspacing="0" border="0" align="center">
+          <table role="presentation" width="100%" style="border-collapse: collapse;max-width: 580px;" cellpadding="0" cellspacing="0" border="0" align="center">
             <tr>
               {% if brand_logo %}
                 <td
@@ -181,18 +181,18 @@
       cellpadding="0"
       cellspacing="0"
       border="0"
-      style="max-width: 580px; width: 100% !important;"
+      style="border-collapse: collapse;max-width: 580px; width: 100% !important;"
       width="100%"
   >
     <tr>
       <td width="10" height="10" valign="middle"></td>
       <td>
         <!--[if (gte mso 9)|(IE)]>
-          <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0">
+          <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
             <tr>
               <td height="10">
         <![endif]-->
-                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse">
                   <tr>
                     {% if brand_colour %}
                     <td height="10" width="1">{{ spacer(1, 10) }}</td>
@@ -233,7 +233,7 @@
       cellpadding="0"
       cellspacing="0"
       border="0"
-      style="max-width: 580px; width: 100% !important;"
+      style="border-collapse: collapse;max-width: 580px; width: 100% !important;"
       width="100%"
   >
     <tr>
@@ -243,7 +243,7 @@
       <td width="10" valign="middle">&nbsp;</td>
       <td style="font-family: Helvetica, Arial, sans-serif; font-size: 19px; line-height: 1.315789474; max-width: 560px;">
         <!--[if (gte mso 9)|(IE)]>
-          <table role="presentation" width="560" align="center" cellpadding="0" cellspacing="0" border="0">
+          <table role="presentation" width="560" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
             <tr>
               <td style="font-family: Helvetica, Arial, sans-serif; font-size: 19px; line-height: 1.315789474;">
         <![endif]-->

--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -100,7 +100,7 @@
       <td width="10" height="10" valign="middle"></td>
       <td>
         <!--[if (gte mso 9)|(IE)]>
-          <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 580px;">
+          <table role="presentation" width="560" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 560px;">
             <tr>
               <td height="10">
         <![endif]-->
@@ -193,7 +193,7 @@
       <td width="10" height="10" valign="middle"></td>
       <td>
         <!--[if (gte mso 9)|(IE)]>
-          <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 580px;">
+          <table role="presentation" width="560" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 560px;">
             <tr>
               <td height="10">
         <![endif]-->

--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -43,7 +43,7 @@
     <tr>
       <td width="100%" height="53" bgcolor="#0b0c0c">
         <!--[if (gte mso 9)|(IE)]>
-          <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
+          <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 580px;">
             <tr>
               <td>
         <![endif]-->
@@ -100,7 +100,7 @@
       <td width="10" height="10" valign="middle"></td>
       <td>
         <!--[if (gte mso 9)|(IE)]>
-          <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
+          <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 580px;">
             <tr>
               <td height="10">
         <![endif]-->
@@ -125,7 +125,7 @@
       <tr>
         <td width="100%" height="53" bgcolor="{{brand_colour}}">
           <!--[if (gte mso 9)|(IE)]>
-            <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
+            <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 580px;">
               <tr>
                 <td>
           <![endif]-->
@@ -193,7 +193,7 @@
       <td width="10" height="10" valign="middle"></td>
       <td>
         <!--[if (gte mso 9)|(IE)]>
-          <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
+          <table role="presentation" width="580" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 580px;">
             <tr>
               <td height="10">
         <![endif]-->
@@ -248,7 +248,7 @@
       <td width="10" valign="middle">&nbsp;</td>
       <td style="font-family: Helvetica, Arial, sans-serif; font-size: 19px; line-height: 1.315789474; max-width: 560px;">
         <!--[if (gte mso 9)|(IE)]>
-          <table role="presentation" width="560" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;">
+          <table role="presentation" width="560" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 560px;">
             <tr>
               <td style="font-family: Helvetica, Arial, sans-serif; font-size: 19px; line-height: 1.315789474;">
         <![endif]-->

--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -132,6 +132,7 @@
           <table role="presentation" width="100%" style="border-collapse: collapse;max-width: 580px;" cellpadding="0" cellspacing="0" border="0" align="center">
             <tr>
               {% if brand_logo %}
+                <td width="10">{{ spacer(10) }}</td>
                 <td
                   width="70"
                   height="{% if brand_name -%} 49 {%- else -%} 76 {%- endif %}"
@@ -141,26 +142,26 @@
                   <img
                     src="{{ brand_logo }}"
                     border="0"
-                    style="display: block; border: 0; Margin-top: 10px; Margin-bottom: 12px; Margin-left: 10px;"
+                    style="display: block; border: 0; margin-top: 10px; margin-bottom: 12px;"
                     height="{% if brand_name -%} 27 {%- else -%} 54 {%- endif %}"
                     alt=""
                   />
                 </td>
               {% endif %}
               {% if brand_name %}
+                {% if brand_logo %}
+                <td width="5">{{ spacer(5) }}</td>
+                {% endif %}
+                <td width="5">{{ spacer(5) }}</td>
                 <td width="100%" bgcolor="{{brand_colour}}" valign="middle" align="left">
                   <span style="
                     display: block;
-                    padding-left: 5px;
                     font-family: Helvetica, Arial, sans-serif;
                     font-weight: 700;
                     font-size: 19px;
                     color: #ffffff;
                     line-height: 25px;
                     margin: 14px 0;
-                    {% if brand_logo %}
-                      margin-left: 5px;
-                    {% endif %}
                     ">
                       {{ brand_name }}
                   </span>

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -66,7 +66,7 @@ def test_brand_banner_shows():
         '<td width="10" height="10" valign="middle"></td>'
     ) not in email
     assert (
-        'role="presentation" width="100%" style="min-width: 100%;width: 100% !important;"'
+        'role="presentation" width="100%" style="border-collapse: collapse;min-width: 100%;width: 100% !important;"'
     ) in email
 
 


### PR DESCRIPTION
One of our users (using Outlook 2016 on Windows 10) reported issues with the top banner of our email template when set up with their branding:
- the spacing between the brand image and text was missing
- the column of the main content area was a lot larger than that for the banner

We have been unable to replicate this when testing with Email on Acid. The problems described can be seen with other combinations of email client and OS though. These fixes work on those versions (and don't break any existing code) so it's worth deploying them to see if they have an effect for this user.

The fixes are:
- replacing the padding and margin between the brand image and text with a spacer cell/image combo
- making higher DPI systems pick up our width styles by duplicating those set in HTML attributes to inline CSS
- adding some Microsoft Office-specific CSS which can remove spacing Outlook sets sometimes

I also noticed the blue bar below the GOV.UK banner was too big in Outlook due to the wrong width being set in HTML wrapped in Outlook-specific conditional comments. A fix for this is also included.