### PR TITLE
Set links to use govuk-blue

### DIFF
--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -436,7 +436,7 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
     def autolink(self, link, is_email=False):
         if is_email:
             return link
-        return '<a style="word-wrap: break-word;" href="{}">{}</a>'.format(
+        return '<a style="word-wrap: break-word; color: #005ea5;" href="{}">{}</a>'.format(
             urllib.parse.quote(
                 urllib.parse.unquote(link),
                 safe=':/?#=&;'


### PR DESCRIPTION
Links are currently not given an explicit colour, whilst text is.

This explicitly sets them to use `$govuk-blue`. 

NB this doesn't set `active` or `visited` states. These would be trickier to support, and appear to not have great support anyway:
https://www.campaignmonitor.com/css/selectors/active/
https://www.campaignmonitor.com/css/selectors/visited/