### PR TITLE
Don’t include URLs in the preheader

### DIFF
--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -533,6 +533,12 @@ class NotifyEmailPreheaderMarkdownRenderer(NotifyPlainTextEmailMarkdownRenderer)
     def hrule(self):
         return ''
 
+    def link(self, link, title, content):
+        return ''.join((
+            content,
+            ' ({})'.format(title) if title else '',
+        ))
+
 
 notify_email_markdown = mistune.Markdown(
     renderer=NotifyEmailMarkdownRenderer(),

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -210,6 +210,13 @@ def test_preheader_is_at_start_of_html_emails():
         'Hello Jo This – is a “heading” My favourite websites’ URLs are: • GOV.​UK • https://www.example.com',
     ),
     (
+        (
+            '[Markdown link](https://www.example.com)\n'
+        ),
+        {},
+        'Markdown link',
+    ),
+    (
         """
             Lorem Ipsum is simply dummy text of the printing and
             typesetting industry.


### PR DESCRIPTION
Currently our preheader renders links the same way as a plain text email does (i.e. by printing the URL after the link text).

This isn’t an accurate preview. The person opening the email won’t see the URL, they’ll only see the link text.

So this commit removes the URLs from the preheader, but keeps the text of the link.