### PR TITLE
AUTO: Refresh the statsd client every second

### DIFF
--- a/notifications_utils/clients/statsd/statsd_client.py
+++ b/notifications_utils/clients/statsd/statsd_client.py
@@ -1,4 +1,5 @@
 from statsd import StatsClient
+from threading import Timer
 
 
 class StatsdClient():
@@ -12,13 +13,16 @@ class StatsdClient():
             app.config.get('NOTIFY_ENVIRONMENT'),
             app.config.get('NOTIFY_APP_NAME')
         )
+        self.host = app.config.get('STATSD_HOST')
+        self.port = app.config.get('STATSD_PORT')
+        self.prefix = app.config.get('STATSD_PREFIX')
 
         if self.active:
-            self.statsd_client = StatsClient(
-                app.config.get('STATSD_HOST'),
-                app.config.get('STATSD_PORT'),
-                prefix=app.config.get('STATSD_PREFIX')
-            )
+            self._refresh_client()
+
+    def _refresh_client(self):
+        self.statsd_client = StatsClient(self.host, self.port, self.prefix)
+        Timer(1, self._refresh_client).start()
 
     def format_stat_name(self, stat):
         return self.namespace + stat


### PR DESCRIPTION
- The statsd client uses UDP which means it doesn't know when the IP
  address it is sending to has disappeared
- We would like to run the statsd exporter on the PaaS so that we can
  co-locate it, scale it, monitor it easily etc. When the exporter gets redeployed on PaaS or PaaS have to re-run it, its IP address changes and the statsd clients in the apps sends the metrics into the void
- To make sure we pick up the new IP address when the exporter is redeployed, recreate the statsd client every 1 second which will refresh DNS
- I did a very basic test sending 500k stats with this client and a raw
  StatsClient and the performance was almost identical
- We are running this on the PaaS which means DNS is actually BOSH DNS
  which is much faster than normal DNS