### PR TITLE
REP-340: Use a different statsd client

### DIFF
--- a/notifications_utils/clients/statsd/statsd_client.py
+++ b/notifications_utils/clients/statsd/statsd_client.py
@@ -1,4 +1,4 @@
-from statsd import StatsClient
+from statsd import StatsdClient as StatsClient
 
 
 class StatsdClient():

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         'Flask>=0.12.2',
         'orderedset==2.0.1',
         'Jinja2==2.10.1',
-        'statsd==3.3.0',
+        'statsd-client==1.0.60',
         'Flask-Redis==0.4.0',
         'pyyaml==4.2b1',
         'phonenumbers==8.10.13',


### PR DESCRIPTION
- The statsd client uses UDP which means it doesn't know when the IP
address it is sending to has disappeared
- We would like to run the statsd exporter on the PaaS so that we can
co-locate it, scale it, monitor it easily etc. When the exporter gets
redeployed on PaaS or PaaS have to re-run it, its IP address changes and
the statsd clients in the apps sends the metrics into the void
- This ones uses socket.sendto(address) so should re-resolve DNS on each
  packet
- The DNS it is resolving is BOSH DNS which is very quick so this
  shouldn't affect the performance much