### PR TITLE
statsd error cleanup - reduce logging and cache dns failures

### DIFF
--- a/notifications_utils/clients/statsd/statsd_client.py
+++ b/notifications_utils/clients/statsd/statsd_client.py
@@ -31,7 +31,7 @@ class NotifyStatsClient(StatsClientBase):
         try:
             self._sock.sendto(data.encode('ascii'), (self._cached_host(), self._port))
         except Exception as e:
-            current_app.logger.exception('Error sending statsd metric: {}'.format(str(e)))
+            current_app.logger.warning('Error sending statsd metric: {}'.format(str(e)))
             pass
 
 

--- a/notifications_utils/clients/statsd/statsd_client.py
+++ b/notifications_utils/clients/statsd/statsd_client.py
@@ -25,11 +25,21 @@ class NotifyStatsClient(StatsClientBase):
 
     @cachetools.func.ttl_cache(maxsize=2, ttl=15, timer=time_monotonic_with_jitter)
     def _cached_host(self):
-        return self._resolve(self._host)
+        try:
+            return self._resolve(self._host)
+        except Exception as e:
+            # if we get an error store None in the cache so that we don't keep trying to retrieve the DNS
+            # if paas's dns server is having issues
+            current_app.logger.warning('Error resolving statsd dns: {}'.format(str(e)))
+            return None
 
     def _send(self, data):
         try:
-            self._sock.sendto(data.encode('ascii'), (self._cached_host(), self._port))
+            host = self._cached_host()
+
+            # if we can't resolve DNS then host is none - just skip sending stats for next 15 secs
+            if host:
+                self._sock.sendto(data.encode('ascii'), (host, self._port))
         except Exception as e:
             current_app.logger.warning('Error sending statsd metric: {}'.format(str(e)))
             pass

--- a/tests/test_statsd_client.py
+++ b/tests/test_statsd_client.py
@@ -105,6 +105,17 @@ def test_should_log_but_not_throw_if_socket_errors(app, mocker):
     mock_logger.warning.assert_called_with('Error sending statsd metric: Mock Exception')
 
 
+def test_should_not_attempt_to_send_if_cache_contains_none(app, mocker):
+    stats_client = NotifyStatsClient('localhost', 8125, '')
+    mock_sock = mocker.patch.object(stats_client, "_sock")
+    mock_cached_host = mocker.patch.object(stats_client, '_cached_host', return_value=None)
+
+    stats_client._send('data')
+
+    mock_cached_host.assert_called_once_with()
+    assert mock_sock.called is False
+
+
 def test_should_manage_dns(app, mocker):
     stats_client = NotifyStatsClient('exporter.apps.internal', 8125, '')
 
@@ -115,11 +126,22 @@ def test_should_manage_dns(app, mocker):
 def test_should_cache_dns(app, mocker):
     stats_client = NotifyStatsClient('exporter.apps.internal', 8125, '')
 
-    with patch.object(stats_client, '_resolve', return_value='1.2.3.4'):
+    with patch.object(stats_client, '_resolve', return_value='1.2.3.4') as mock_dns_lookup:
         assert stats_client._cached_host() == '1.2.3.4'
+        mock_dns_lookup.assert_called_once_with('exporter.apps.internal')
 
-    assert stats_client._cached_host() == '1.2.3.4'
+    with patch.object(stats_client, '_resolve') as mock_dns_lookup:
+        assert stats_client._cached_host() == '1.2.3.4'
+        assert mock_dns_lookup.called is False
 
-    stats_client._cached_host.cache_clear()
-    with patch.object(stats_client, '_resolve', return_value='4.3.2.1'):
-        assert stats_client._cached_host() == '4.3.2.1'
+
+def test_should_cache_none_if_dns_fails(app, mocker):
+    stats_client = NotifyStatsClient('exporter.apps.internal', 8125, '')
+
+    with patch.object(stats_client, '_resolve', side_effect=Exception('DNS No Worky')) as mock_dns_lookup:
+        assert stats_client._cached_host() is None
+        mock_dns_lookup.assert_called_once_with('exporter.apps.internal')
+
+    with patch.object(stats_client, '_resolve') as mock_dns_lookup:
+        assert stats_client._cached_host() is None
+        assert mock_dns_lookup.called is False

--- a/tests/test_statsd_client.py
+++ b/tests/test_statsd_client.py
@@ -102,7 +102,7 @@ def test_should_log_but_not_throw_if_socket_errors(app, mocker):
     mock_logger = mocker.patch('flask.Flask.logger')
 
     stats_client._send('data')
-    mock_logger.exception.assert_called_with('Error sending statsd metric: Mock Exception')
+    mock_logger.warning.assert_called_with('Error sending statsd metric: Mock Exception')
 
 
 def test_should_manage_dns(app, mocker):


### PR DESCRIPTION
### reduce error log to warning log for statsd errors

we send lots of statsd messages. If there's a problem with statsd, it's likely to be a high volume at once, which means we're likely to trip the pagerduty P1 error threshold

we see lots of statsd errors when cells roll. This is probably because there's just another moving cog - the internal DNS server, hosted on each cell. cells roll often and without our knowledge

there's nothing we can do about these errors, and they resolve themselves within seconds

there's a risk we may not see these messages at all if they're reduced to warning level, however, we can look at a tool like sentry if this is something we're concerned about


### dont send statsd data for 15 secs if DNS fails

If the DNS lookup fails (and it's not cached) we'll raise an exception, skip sending the statsd data, and then carry on with regular program flow - which may well try another statsd call almost immediately. Interestingly, if these DNS calls slow down, as we run in eventlets, we may end up with many concurrent DNS requests, compounding any problems the DNS server is experiencing.

To solve this, if the DNS lookup fails, cache that failed value for ~15 seconds. Then, if we encounter that failed value (None) when trying to send, we can just quietly and quickly skip sending statsd. After ~15 seconds the cache will expire and we'll try hitting DNS again.