### PR TITLE
Remove more markdown formatting rules to prevent characters disappearing 

### DIFF
--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -54,12 +54,14 @@ mistune.InlineLexer.default_rules = list(
     OrderedSet(mistune.InlineLexer.default_rules) - set((
         'emphasis',
         'double_emphasis',
+        'strikethrough',
     ))
 )
 mistune.InlineLexer.inline_html_rules = list(
     set(mistune.InlineLexer.inline_html_rules) - set((
         'emphasis',
         'double_emphasis',
+        'strikethrough',
     ))
 )
 
@@ -355,9 +357,6 @@ class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
 
     def link(self, link, title, content):
         return '{}: {}'.format(content, self.autolink(link))
-
-    def strikethrough(self, text):
-        return text
 
     def footnote_ref(self, key, index):
         return ""

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -55,6 +55,7 @@ mistune.InlineLexer.default_rules = list(
         'emphasis',
         'double_emphasis',
         'strikethrough',
+        'code',
     ))
 )
 mistune.InlineLexer.inline_html_rules = list(
@@ -62,6 +63,7 @@ mistune.InlineLexer.inline_html_rules = list(
         'emphasis',
         'double_emphasis',
         'strikethrough',
+        'code',
     ))
 )
 
@@ -339,9 +341,6 @@ class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
         return '<strong>{}</strong>'.format(
             link.replace('http://', '').replace('https://', '')
         )
-
-    def codespan(self, text):
-        return text
 
     def image(self, src, title, alt_text):
         return ""

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -865,15 +865,15 @@ def test_link_with_title(markdown_function, expected):
 @pytest.mark.parametrize('markdown_function, expected', (
     [
         notify_letter_preview_markdown,
-        '<p>Strike</p>'
+        '<p>~~Strike~~</p>'
     ],
     [
         notify_email_markdown,
-        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">Strike</p>'
+        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">~~Strike~~</p>'
     ],
     [
         notify_plain_text_email_markdown,
-        '\n\nStrike'
+        '\n\n~~Strike~~'
     ],
 ))
 def test_strikethrough(markdown_function, expected):

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -700,15 +700,15 @@ def test_autolink(markdown_function, link, expected):
 @pytest.mark.parametrize('markdown_function, expected', (
     [
         notify_letter_preview_markdown,
-        '<p>variable called thing</p>'
+        '<p>variable called `thing`</p>'
     ],
     [
         notify_email_markdown,
-        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">variable called thing</p>'
+        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">variable called `thing`</p>'
     ],
     [
         notify_plain_text_email_markdown,
-        '\n\nvariable called thing',
+        '\n\nvariable called `thing`',
     ],
 ))
 def test_codespan(markdown_function, expected):


### PR DESCRIPTION
This pull request allows users to include tilde and backtick characters in their emails without them sometimes disappearing. 

Tilde and backticks are used to define strikethrough and code snippets respectively.

Strikethrough in Markdown is specified using double tildes, for example:
```
This is ~~not~~ some `code`
```
Becomes
> This is ~~not~~ some `code`

We don’t support either of these formatting options and we remove them by just outputting the text, for example:
> This is not some code

This is bad if you’re using tildes or backticks for other purposes, for example as ‘special’ characters in a password.

This commit fixes the problem by removing strikethrough and code snippets from the Markdown rules that get applied. This is better than our previous approach of overriding the rules we didn’t want, because it preserves the text the user has given us, with no overhead.