### PR TITLE
Fix bug with double semicolons appearing in sequences of special characters 

### DIFF
--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -148,7 +148,7 @@ def strip_html(value):
 def escape_html(value):
     if not value:
         return value
-    value = str(value).replace('<', '&lt;')
+    value = str(value)
     # If the content contains a HTML encoded non-breaking space then we
     # need to protect it from the escape/unescape process by temporarily
     # turning it into something else

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -4,6 +4,7 @@ import urllib
 
 import mistune
 import bleach
+from html import escape, unescape
 from itertools import count
 from flask import Markup
 from orderedset import OrderedSet
@@ -148,6 +149,12 @@ def escape_html(value):
     if not value:
         return value
     value = str(value).replace('<', '&lt;')
+    # If the content contains a HTML encoded non-breaking space then we
+    # need to protect it from the escape/unescape process by temporarily
+    # turning it into something else
+    value = value.replace('&nbsp;', MAGIC_SEQUENCE)
+    value = escape(unescape(value), quote=False)
+    value = value.replace(MAGIC_SEQUENCE, '&nbsp;')
     return bleach.clean(value, tags=[], strip=False)
 
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,3 +1,4 @@
+import bleach
 import pytest
 from flask import Markup
 
@@ -916,6 +917,18 @@ def test_bleach_doesnt_try_to_make_valid_html_before_cleaning():
     ) == (
         "&lt;to cancel daily cat facts reply 'cancel'&gt;"
     )
+
+
+def test_work_around_bleach_entity_bug():
+    # This content looks a bit like a HTML escape sequence (for example
+    # &copy; or &gt;) but it has a naughty question mark in it:
+    content = '&?a;'
+    # Bleach (the underlying library we use) handles it incorrectly,
+    # replacing the `a` with a second semicolon:
+    assert bleach.clean(content) == '&?;;'
+    # But we work around Bleach and handle it correctly, encoding the
+    # ampersand and preserving the `a`:
+    assert escape_html(content) == '&amp;?a;'
 
 
 @pytest.mark.parametrize('dirty, clean', [


### PR DESCRIPTION
We use a library called Bleach for escaping dangerous HTML in our template content. It doesn’t seem to handle things which look like HTML entities (for example `&copy;` or `&gt;`) but contain unexpected characters (the only one I’ve found so far is a question mark, for example `&?a;`).

This results in the last character of an escape sequence being replaced with a semicolon. I haven’t dug into the Bleach source deeply enough to identify where the problem is, and which other characters might affect it.

But a fix is to use Python’s builtins to convert any escape sequences to their unicode equivalent, and then escape them again. This seems to not get confused the way Bleach does.

We can then pass the output of this to Bleach, which passes through stuff that’s already properly encoded.

This fix is described in https://github.com/mozilla/bleach/issues/453#issuecomment-499182492:

> A quick solution that can be implemented by developers is to just escape(unescape()) the input before sending it to bleach.
>
> …
>
> This solution does not utilize a HTML parser, it's all regex under the hood, so there may be some edge cases. This has passed all our use cases though.
>
> While I personally think bleach should handle stuff like this, I don't think it is necessary when invoking bleach is only a component of your user input sanitization routine.

There’s one more gotcha, which is that, for historic reasons, we allow users ([specifically GOV.UK Email](https://github.com/alphagov/notifications-utils/pull/427)) to include the non-breaking space character (encoded as `&nbsp;`) in order to create empty paragraphs. This character is ignored by the Markdown parser unless it’s encoded – just including the unicode character won’t force an extra paragraph. Python’s `html.escape` doesn’t encodes things like quotes:
```python
html.escape('"')
'&quot;'
```
But it doesn’t see a need to encoded non-breaking spaces:
```python
html.escape('\xa0')
'\xa0'
```

So to preserve the encoded non-breaking space we also have to temporarily convert it to something else, do the `unescape`/`escape` dance, and then convert it back.