### PR TITLE
Do extra code style checks with flake8-bugbear

### DIFF
--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -14,8 +14,8 @@ from notifications_utils.formatters import (
 
 class Placeholder:
     def __init__(self, body):
-        # body should not include the (( and )).
-        self.body = body.lstrip('((').rstrip('))')
+        # body shouldn’t include leading/trailing brackets, like (( and ))
+        self.body = body.lstrip('(').rstrip(')')
 
     @classmethod
     def from_match(cls, match):

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -7,6 +7,7 @@ pytest-xdist==2.2.0
 requests-mock==1.8.0
 freezegun==1.0.0
 flake8==3.8.4
+flake8-bugbear==19.8.0
 flake8-print==4.0.0
 pytest-profiling==1.7.0
 snakeviz==2.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,4 @@ xfail_strict=true
 [flake8]
 # W504 line break after binary operator
 extend_ignore=W504
+select=B901, B902

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -233,7 +233,7 @@ def test_get_rows_does_no_error_checking_of_rows_or_cells(mocker):
     )
 
     rows = recipients.get_rows()
-    for i in range(3):
+    for _ in range(3):
         assert next(rows).recipient == 'a@b.com'
 
     assert has_error_mock.called is False
@@ -258,7 +258,7 @@ def test_get_rows_only_iterates_over_file_once(mocker):
     )
 
     rows = recipients.get_rows()
-    for i in range(3):
+    for _ in range(3):
         next(rows)
 
     assert row_mock.call_count == 3
@@ -402,7 +402,7 @@ def test_big_list():
 def test_processing_a_big_list():
     process = Mock()
 
-    for row in RecipientCSV(
+    for _row in RecipientCSV(
         "phone_number\n" + ("07900900900\n" * RecipientCSV.max_rows),
         template=_sample_template('sms'),
     ).get_rows():


### PR DESCRIPTION
Flake8 Bugbear checks for some extra things that aren’t code style errors, but are likely to introduce bugs or unexpected behaviour. A good example is having mutable default function arguments, which get shared between every call to the function and therefore mutating a value in one place can unexpectedly cause it to change in another.

This commit enables all the extra warnings provided by Flake8 Bugbear.

Matches the work done in other repos:
- https://github.com/alphagov/notifications-admin/pull/3172
- https://github.com/alphagov/notifications-api/pull/3071