### PR TITLE
Use isort to sort imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,7 @@ test: ## Run tests
 
 clean:
 	rm -rf cache venv
+
+.PHONY: fix-imports
+fix-imports:
+	isort -rc ./notifications_utils ./tests

--- a/notifications_utils/base64_uuid.py
+++ b/notifications_utils/base64_uuid.py
@@ -1,5 +1,5 @@
+from base64 import urlsafe_b64decode, urlsafe_b64encode
 from uuid import UUID
-from base64 import urlsafe_b64encode, urlsafe_b64decode
 
 
 def base64_to_bytes(key):

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -2,9 +2,8 @@ import numbers
 import uuid
 from time import time
 
-from flask_redis import FlaskRedis
 from flask import current_app
-
+from flask_redis import FlaskRedis
 # expose redis exceptions so that they can be caught
 from redis.exceptions import RedisError  # noqa
 

--- a/notifications_utils/clients/statsd/statsd_client.py
+++ b/notifications_utils/clients/statsd/statsd_client.py
@@ -1,11 +1,10 @@
 import random
 import time
+from socket import AF_INET, SOCK_DGRAM, gethostbyname, socket
 
 import cachetools.func
-
-from statsd.client.base import StatsClientBase
-from socket import socket, gethostbyname, AF_INET, SOCK_DGRAM
 from flask import current_app
+from statsd.client.base import StatsClientBase
 
 
 def time_monotonic_with_jitter():

--- a/notifications_utils/columns.py
+++ b/notifications_utils/columns.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 from functools import lru_cache
+
 from orderedset import OrderedSet
 
 

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -1,14 +1,14 @@
 import re
 
-from orderedset import OrderedSet
 from flask import Markup
+from orderedset import OrderedSet
 
 from notifications_utils.columns import Columns
 from notifications_utils.formatters import (
-    strip_and_remove_obscure_whitespace,
-    unescaped_formatted_list,
-    strip_html,
     escape_html,
+    strip_and_remove_obscure_whitespace,
+    strip_html,
+    unescaped_formatted_list,
 )
 
 

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -1,17 +1,18 @@
-import string
 import re
+import string
 import urllib
-
-import mistune
-import bleach
-from html import escape, _replace_charref
+from html import _replace_charref, escape
 from itertools import count
+
+import bleach
+import mistune
+import smartypants
 from flask import Markup
 from orderedset import OrderedSet
-from . import email_with_smart_quotes_regex
-from notifications_utils.sanitise_text import SanitiseSMS
-import smartypants
 
+from notifications_utils.sanitise_text import SanitiseSMS
+
+from . import email_with_smart_quotes_regex
 
 LINK_STYLE = 'word-wrap: break-word; color: #1D70B8;'
 

--- a/notifications_utils/international_billing_rates.py
+++ b/notifications_utils/international_billing_rates.py
@@ -18,8 +18,9 @@ Format of the yaml file looks like:
   - Dominican Republic
 """
 
-import yaml
 import os
+
+import yaml
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 

--- a/notifications_utils/letter_timings.py
+++ b/notifications_utils/letter_timings.py
@@ -1,12 +1,14 @@
-import pytz
-
-from datetime import datetime, time, timedelta
 from collections import namedtuple
+from datetime import datetime, time, timedelta
 
+import pytz
 from govuk_bank_holidays.bank_holidays import BankHolidays
-from notifications_utils.countries.data import Postage
-from notifications_utils.timezones import convert_utc_to_bst, utc_string_to_aware_gmt_datetime
 
+from notifications_utils.countries.data import Postage
+from notifications_utils.timezones import (
+    convert_utc_to_bst,
+    utc_string_to_aware_gmt_datetime,
+)
 
 LETTER_PROCESSING_DEADLINE = time(17, 30)
 CANCELLABLE_JOB_LETTER_STATUSES = [

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -1,14 +1,13 @@
-from itertools import product
-from pathlib import Path
-import re
-import sys
-
-from flask import request, g
-from flask.ctx import has_request_context, has_app_context
-from pythonjsonlogger.jsonlogger import JsonFormatter as BaseJSONFormatter
-
 import logging
 import logging.handlers
+import re
+import sys
+from itertools import product
+from pathlib import Path
+
+from flask import g, request
+from flask.ctx import has_app_context, has_request_context
+from pythonjsonlogger.jsonlogger import JsonFormatter as BaseJSONFormatter
 
 LOG_FORMAT = '%(asctime)s %(app_name)s %(name)s %(levelname)s ' \
              '%(request_id)s "%(message)s" [in %(pathname)s:%(lineno)d]'

--- a/notifications_utils/pdf.py
+++ b/notifications_utils/pdf.py
@@ -1,7 +1,9 @@
+import io
+
 import PyPDF2
 from PyPDF2 import PdfFileWriter
 from PyPDF2.utils import PdfReadError
-import io
+
 from notifications_utils import LETTER_MAX_PAGE_COUNT
 
 

--- a/notifications_utils/postal_address.py
+++ b/notifications_utils/postal_address.py
@@ -1,15 +1,13 @@
 import re
-
 from functools import lru_cache
 
 from notifications_utils.countries import UK, Country, CountryNotFoundError
 from notifications_utils.countries.data import Postage
 from notifications_utils.formatters import (
     normalise_lines,
-    remove_whitespace_before_punctuation,
     remove_whitespace,
+    remove_whitespace_before_punctuation,
 )
-
 
 address_lines_1_to_6_keys = [
     # The API only accepts snake_case placeholders

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -1,25 +1,23 @@
-import string
-import re
-import sys
 import csv
-import phonenumbers
-from io import StringIO
+import re
+import string
+import sys
+from collections import OrderedDict, namedtuple
 from contextlib import suppress
 from functools import lru_cache, partial
+from io import StringIO
 from itertools import islice
-from collections import OrderedDict, namedtuple
+
+import phonenumbers
+from flask import current_app
 from orderedset import OrderedSet
 
-from flask import current_app
-
-from . import EMAIL_REGEX_PATTERN, hostname_part, tld_part
+from notifications_utils.columns import Cell, Columns, Row
 from notifications_utils.formatters import (
+    OBSCURE_WHITESPACE,
     strip_and_remove_obscure_whitespace,
     strip_whitespace,
-    OBSCURE_WHITESPACE
 )
-from notifications_utils.template import Template
-from notifications_utils.columns import Columns, Row, Cell
 from notifications_utils.international_billing_rates import (
     COUNTRY_PREFIXES,
     INTERNATIONAL_BILLING_RATES,
@@ -29,7 +27,9 @@ from notifications_utils.postal_address import (
     address_lines_1_to_6_and_postcode_keys,
     address_lines_1_to_7_keys,
 )
+from notifications_utils.template import Template
 
+from . import EMAIL_REGEX_PATTERN, hostname_part, tld_part
 
 uk_prefix = '44'
 

--- a/notifications_utils/request_helper.py
+++ b/notifications_utils/request_helper.py
@@ -1,5 +1,5 @@
+from flask import abort, current_app, request
 from flask.wrappers import Request
-from flask import request, current_app, abort
 
 
 class NotifyRequest(Request):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -1,47 +1,49 @@
 import math
 from abc import ABC, abstractmethod
-from os import path
 from datetime import datetime
 from functools import lru_cache
-
-from jinja2 import Environment, FileSystemLoader
-from flask import Markup
 from html import unescape
+from os import path
+
+from flask import Markup
+from jinja2 import Environment, FileSystemLoader
 
 from notifications_utils import LETTER_MAX_PAGE_COUNT, SMS_CHAR_COUNT_LIMIT
 from notifications_utils.columns import Columns
+from notifications_utils.countries.data import Postage
 from notifications_utils.field import Field, PlainTextField
 from notifications_utils.formatters import (
     MAGIC_SEQUENCE,
-    unlink_govuk_escaped,
-    nl2br,
     add_prefix,
-    autolink_sms,
-    notify_email_markdown,
-    notify_email_preheader_markdown,
-    notify_plain_text_email_markdown,
-    notify_letter_preview_markdown,
-    sms_encode,
-    escape_html,
-    remove_whitespace_before_punctuation,
-    make_quotes_smart,
-    replace_hyphens_with_en_dashes,
-    replace_hyphens_with_non_breaking_hyphens,
-    strip_leading_whitespace,
     add_trailing_newline,
+    autolink_sms,
+    escape_html,
+    formatted_list,
+    make_quotes_smart,
+    nl2br,
+    normalise_multiple_newlines,
     normalise_whitespace,
     normalise_whitespace_and_newlines,
-    normalise_multiple_newlines,
+    notify_email_markdown,
+    notify_email_preheader_markdown,
+    notify_letter_preview_markdown,
+    notify_plain_text_email_markdown,
     remove_smart_quotes_from_email_addresses,
+    remove_whitespace_before_punctuation,
+    replace_hyphens_with_en_dashes,
+    replace_hyphens_with_non_breaking_hyphens,
+    sms_encode,
+    strip_leading_whitespace,
     strip_unsupported_characters,
-    formatted_list,
+    unlink_govuk_escaped,
 )
-from notifications_utils.countries.data import Postage
-from notifications_utils.postal_address import PostalAddress, address_lines_1_to_7_keys
+from notifications_utils.postal_address import (
+    PostalAddress,
+    address_lines_1_to_7_keys,
+)
+from notifications_utils.sanitise_text import SanitiseSMS
 from notifications_utils.take import Take
 from notifications_utils.template_change import TemplateChange
-from notifications_utils.sanitise_text import SanitiseSMS
-
 
 template_env = Environment(loader=FileSystemLoader(
     path.join(

--- a/notifications_utils/template_change.py
+++ b/notifications_utils/template_change.py
@@ -1,4 +1,5 @@
 from orderedset import OrderedSet
+
 from notifications_utils.columns import Columns
 
 

--- a/notifications_utils/timezones.py
+++ b/notifications_utils/timezones.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from dateutil import parser
-import pytz
 
+import pytz
+from dateutil import parser
 
 local_timezone = pytz.timezone("Europe/London")
 

--- a/notifications_utils/url_safe_token.py
+++ b/notifications_utils/url_safe_token.py
@@ -1,4 +1,5 @@
 from itsdangerous import URLSafeTimedSerializer
+
 from notifications_utils.formatters import url_encode_full_stops
 
 

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -11,3 +11,4 @@ flake8-bugbear==20.11.1
 flake8-print==4.0.0
 pytest-profiling==1.7.0
 snakeviz==2.1.0
+isort==5.7.0

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -29,6 +29,9 @@ fi
 flake8 .
 display_result $? 1 "Code style check"
 
+isort --check-only -rc ./notifications_utils ./tests
+display_result $? 2 "Import order"
+
 py.test -n4 tests/
 display_result $? 3 "Unit tests"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,10 @@ xfail_strict=true
 # W504 line break after binary operator
 extend_ignore=W504
 select=B901, B902
+
+[isort]
+line_length=80
+indent='    '
+multi_line_output=3
+known_first_party=notifications_utils,tests
+include_trailing_comma=True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import pytest
-from flask import Flask
-
 import requests_mock
+from flask import Flask
 
 
 class FakeService():

--- a/tests/test_antivirus_client.py
+++ b/tests/test_antivirus_client.py
@@ -1,8 +1,12 @@
 import io
-import requests
-import pytest
 
-from notifications_utils.clients.antivirus.antivirus_client import AntivirusClient, AntivirusError
+import pytest
+import requests
+
+from notifications_utils.clients.antivirus.antivirus_client import (
+    AntivirusClient,
+    AntivirusError,
+)
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_base64_uuid.py
+++ b/tests/test_base64_uuid.py
@@ -1,8 +1,14 @@
-from uuid import UUID
 import os
+from uuid import UUID
 
 import pytest
-from notifications_utils.base64_uuid import base64_to_uuid, uuid_to_base64, base64_to_bytes, bytes_to_base64
+
+from notifications_utils.base64_uuid import (
+    base64_to_bytes,
+    base64_to_uuid,
+    bytes_to_base64,
+    uuid_to_base64,
+)
 
 
 def test_bytes_to_base64_to_bytes():

--- a/tests/test_base_template.py
+++ b/tests/test_base_template.py
@@ -1,9 +1,8 @@
-import pytest
 from unittest.mock import patch
-from notifications_utils.template import (
-    Template,
-    SubjectMixin,
-)
+
+import pytest
+
+from notifications_utils.template import SubjectMixin, Template
 
 
 class ConcreteImplementation():

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -1,7 +1,8 @@
+from functools import partial
+
 import pytest
 
-from functools import partial
-from notifications_utils.columns import Columns, Row, Cell
+from notifications_utils.columns import Cell, Columns, Row
 
 
 def test_columns_as_dict_with_keys():

--- a/tests/test_countries.py
+++ b/tests/test_countries.py
@@ -3,7 +3,7 @@ import pytest
 from notifications_utils.countries import (
     Country,
     CountryMapping,
-    CountryNotFoundError
+    CountryNotFoundError,
 )
 from notifications_utils.countries.data import (
     _EUROPEAN_ISLANDS_LIST,
@@ -16,7 +16,9 @@ from notifications_utils.countries.data import (
     WELSH_NAMES,
     Postage,
 )
-from .country_synonyms import ALL as ALL_SYNONYMS, CROWDSOURCED_MISTAKES
+
+from .country_synonyms import ALL as ALL_SYNONYMS
+from .country_synonyms import CROWDSOURCED_MISTAKES
 
 
 def test_constants():

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -1,4 +1,5 @@
 import pytest
+
 from notifications_utils.field import Field, str2bool
 
 

--- a/tests/test_field_html_handling.py
+++ b/tests/test_field_html_handling.py
@@ -1,4 +1,5 @@
 import pytest
+
 from notifications_utils.field import Field
 
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -2,27 +2,27 @@ import pytest
 from flask import Markup
 
 from notifications_utils.formatters import (
-    unlink_govuk_escaped,
+    escape_html,
+    formatted_list,
+    make_quotes_smart,
+    normalise_whitespace,
     notify_email_markdown,
     notify_letter_preview_markdown,
     notify_plain_text_email_markdown,
-    sms_encode,
-    formatted_list,
-    escape_html,
-    remove_whitespace_before_punctuation,
-    make_quotes_smart,
-    replace_hyphens_with_en_dashes,
-    strip_whitespace,
-    strip_and_remove_obscure_whitespace,
     remove_smart_quotes_from_email_addresses,
+    remove_whitespace_before_punctuation,
+    replace_hyphens_with_en_dashes,
+    sms_encode,
+    strip_and_remove_obscure_whitespace,
     strip_unsupported_characters,
-    normalise_whitespace
+    strip_whitespace,
+    unlink_govuk_escaped,
 )
 from notifications_utils.template import (
     HTMLEmailTemplate,
     PlainTextEmailTemplate,
     SMSMessageTemplate,
-    SMSPreviewTemplate
+    SMSPreviewTemplate,
 )
 
 

--- a/tests/test_international_billing_rates.py
+++ b/tests/test_international_billing_rates.py
@@ -1,8 +1,8 @@
 import pytest
 
 from notifications_utils.international_billing_rates import (
-    INTERNATIONAL_BILLING_RATES,
     COUNTRY_PREFIXES,
+    INTERNATIONAL_BILLING_RATES,
 )
 
 

--- a/tests/test_letter_timings.py
+++ b/tests/test_letter_timings.py
@@ -1,10 +1,13 @@
-import pytest
-import pytz
-
 from datetime import datetime
 
+import pytest
+import pytz
 from freezegun import freeze_time
-from notifications_utils.letter_timings import get_letter_timings, letter_can_be_cancelled
+
+from notifications_utils.letter_timings import (
+    get_letter_timings,
+    letter_can_be_cancelled,
+)
 
 
 @freeze_time('2017-07-14 13:59:59')  # Friday, before print deadline (3PM BST)

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -5,8 +5,12 @@ import PyPDF2
 import pytest
 from PyPDF2.utils import PdfReadError
 
-from notifications_utils.pdf import extract_page_from_pdf, is_letter_too_long, pdf_page_count
-from tests.pdf_consts import one_page_pdf, multi_page_pdf, not_pdf
+from notifications_utils.pdf import (
+    extract_page_from_pdf,
+    is_letter_too_long,
+    pdf_page_count,
+)
+from tests.pdf_consts import multi_page_pdf, not_pdf, one_page_pdf
 
 
 def test_pdf_page_count_src_pdf_is_null():

--- a/tests/test_postal_address.py
+++ b/tests/test_postal_address.py
@@ -5,8 +5,8 @@ from notifications_utils.countries import Country
 from notifications_utils.countries.data import Postage
 from notifications_utils.postal_address import (
     PostalAddress,
-    is_a_real_uk_postcode,
     format_postcode_for_printing,
+    is_a_real_uk_postcode,
     normalise_postcode,
 )
 

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -1,19 +1,25 @@
-import pytest
 import itertools
 import string
 import unicodedata
 from functools import partial
-from orderedset import OrderedSet
 from random import choice, randrange
 from unittest.mock import Mock
 
+import pytest
+from orderedset import OrderedSet
+
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
 from notifications_utils.countries import Country
-from notifications_utils.recipients import Cell, RecipientCSV, Row, first_column_headings
+from notifications_utils.recipients import (
+    Cell,
+    RecipientCSV,
+    Row,
+    first_column_headings,
+)
 from notifications_utils.template import (
-    SMSMessageTemplate,
     EmailPreviewTemplate,
     LetterImageTemplate,
+    SMSMessageTemplate,
 )
 
 

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -1,15 +1,15 @@
-import pytest
-
 from functools import partial
 
+import pytest
+
 from notifications_utils.recipients import (
+    InvalidEmailError,
+    InvalidPhoneError,
     allowed_to_send_to,
     format_phone_number_human_readable,
     format_recipient,
     get_international_phone_info,
     international_phone_info,
-    InvalidEmailError,
-    InvalidPhoneError,
     is_uk_phone_number,
     normalise_phone_number,
     try_validate_and_format_phone_number,
@@ -18,7 +18,6 @@ from notifications_utils.recipients import (
     validate_phone_number,
     validate_recipient,
 )
-
 
 valid_uk_phone_numbers = [
     '7123456789',

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -1,14 +1,18 @@
 import uuid
-import pytest
 from datetime import datetime
 from unittest.mock import Mock, call
+
+import pytest
 from freezegun import freeze_time
 
 from notifications_utils.clients.redis import (
     daily_limit_cache_key,
     rate_limit_cache_key,
 )
-from notifications_utils.clients.redis.redis_client import RedisClient, prepare_value
+from notifications_utils.clients.redis.redis_client import (
+    RedisClient,
+    prepare_value,
+)
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_request_header_authentication.py
+++ b/tests/test_request_header_authentication.py
@@ -3,7 +3,10 @@ from unittest import mock  # noqa
 import pytest
 from werkzeug.test import EnvironBuilder
 
-from notifications_utils.request_helper import NotifyRequest, _check_proxy_header_secret
+from notifications_utils.request_helper import (
+    NotifyRequest,
+    _check_proxy_header_secret,
+)
 
 
 @pytest.mark.parametrize('header,secrets,expected', [

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -3,7 +3,7 @@ from urllib.parse import parse_qs
 import botocore
 import pytest
 
-from notifications_utils.s3 import s3download, s3upload, S3ObjectNotFound
+from notifications_utils.s3 import S3ObjectNotFound, s3download, s3upload
 
 contents = 'some file data'
 region = 'eu-west-1'

--- a/tests/test_sanitise_text.py
+++ b/tests/test_sanitise_text.py
@@ -1,7 +1,10 @@
 import pytest
 
-from notifications_utils.sanitise_text import SanitiseText, SanitiseSMS, SanitiseASCII
-
+from notifications_utils.sanitise_text import (
+    SanitiseASCII,
+    SanitiseSMS,
+    SanitiseText,
+)
 
 params, ids = zip(
     (('a', 'a'), 'ascii char (a)'),

--- a/tests/test_serialised_model.py
+++ b/tests/test_serialised_model.py
@@ -1,6 +1,9 @@
 import pytest
 
-from notifications_utils.serialised_model import SerialisedModel, SerialisedModelCollection
+from notifications_utils.serialised_model import (
+    SerialisedModel,
+    SerialisedModelCollection,
+)
 
 
 def test_cant_be_instatiated_with_abstract_properties():

--- a/tests/test_statsd_client.py
+++ b/tests/test_statsd_client.py
@@ -1,8 +1,12 @@
+from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 import pytest
-from datetime import datetime, timedelta
-from notifications_utils.clients.statsd.statsd_client import StatsdClient, NotifyStatsClient
+
+from notifications_utils.clients.statsd.statsd_client import (
+    NotifyStatsClient,
+    StatsdClient,
+)
 
 
 @pytest.fixture(scope='function')

--- a/tests/test_statsd_decorators.py
+++ b/tests/test_statsd_decorators.py
@@ -1,4 +1,5 @@
 from unittest.mock import ANY, Mock
+
 from notifications_utils.statsd_decorators import statsd
 
 

--- a/tests/test_template_change.py
+++ b/tests/test_template_change.py
@@ -1,4 +1,5 @@
 import pytest
+
 from notifications_utils.template_change import TemplateChange
 from tests.test_base_template import ConcreteTemplate
 

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1,33 +1,33 @@
 import datetime
-from time import process_time
 import os
-import pytest
-
-from bs4 import BeautifulSoup
 from functools import partial
+from time import process_time
 from unittest import mock
+
+import pytest
+from bs4 import BeautifulSoup
 from flask import Markup
 from freezegun import freeze_time
 from orderedset import OrderedSet
 
 from notifications_utils.formatters import unlink_govuk_escaped
 from notifications_utils.template import (
+    BaseBroadcastTemplate,
     BaseEmailTemplate,
     BaseLetterTemplate,
-    Template,
+    BroadcastMessageTemplate,
+    BroadcastPreviewTemplate,
+    EmailPreviewTemplate,
     HTMLEmailTemplate,
-    LetterPreviewTemplate,
     LetterImageTemplate,
+    LetterPreviewTemplate,
+    LetterPrintTemplate,
     PlainTextEmailTemplate,
     SMSBodyPreviewTemplate,
     SMSMessageTemplate,
     SMSPreviewTemplate,
-    EmailPreviewTemplate,
-    LetterPrintTemplate,
     SubjectMixin,
-    BaseBroadcastTemplate,
-    BroadcastMessageTemplate,
-    BroadcastPreviewTemplate,
+    Template,
 )
 
 

--- a/tests/test_timezones.py
+++ b/tests/test_timezones.py
@@ -2,7 +2,11 @@ from datetime import datetime
 
 import pytest
 
-from notifications_utils.timezones import convert_bst_to_utc, convert_utc_to_bst, utc_string_to_aware_gmt_datetime
+from notifications_utils.timezones import (
+    convert_bst_to_utc,
+    convert_utc_to_bst,
+    utc_string_to_aware_gmt_datetime,
+)
 
 
 @pytest.mark.parametrize('input_value', [

--- a/tests/test_url_safe_tokens.py
+++ b/tests/test_url_safe_tokens.py
@@ -3,7 +3,7 @@ import urllib
 from itsdangerous import BadSignature, SignatureExpired
 from pytest import fail
 
-from notifications_utils.url_safe_token import generate_token, check_token
+from notifications_utils.url_safe_token import check_token, generate_token
 
 
 def test_should_return_payload_from_signed_token():

--- a/tests/test_zendesk_client.py
+++ b/tests/test_zendesk_client.py
@@ -2,7 +2,10 @@ from base64 import b64decode
 
 import pytest
 
-from notifications_utils.clients.zendesk.zendesk_client import ZendeskClient, ZendeskError
+from notifications_utils.clients.zendesk.zendesk_client import (
+    ZendeskClient,
+    ZendeskError,
+)
 
 
 @pytest.fixture(scope='function')


### PR DESCRIPTION
Copies the [work done in the admin app](https://github.com/alphagov/notifications-admin/pull/1886) to install, configure and enforce sorting of imports using [isort](https://pypi.python.org/pypi/isort).
