### PR TITLE
Check for invalid characters in entire address

### DIFF
--- a/notifications_utils/postal_address.py
+++ b/notifications_utils/postal_address.py
@@ -104,7 +104,7 @@ class PostalAddress():
     @property
     def has_invalid_characters(self):
         return any(
-            line.startswith(tuple(self.INVALID_CHARACTERS))
+            any([c in line for c in set(self.INVALID_CHARACTERS)])
             for line in self.normalised_lines
         )
 

--- a/tests/test_postal_address.py
+++ b/tests/test_postal_address.py
@@ -221,7 +221,7 @@ def test_postcode(address, expected_postcode):
         C@ity of Town
         SW1A 1AA
         ''',
-        False,
+        True,
     ),
     (
         '''


### PR DESCRIPTION
As it turns out, invalid characters in any part of the address is not suitable for the software at the postal providers. This will check the
entire postal address for these characters.