### PR TITLE
Update isort config to match that in API

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,3 +12,4 @@ indent='    '
 multi_line_output=3
 known_first_party=notifications_utils,tests
 include_trailing_comma=True
+use_parentheses=True


### PR DESCRIPTION
As discussed in [1]. This has no effect on the existing imports.

[1]: https://github.com/alphagov/notifications-api/pull/3175#issuecomment-795530323