### PR TITLE
Clean up some deprecated things

### DIFF
--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -1,6 +1,6 @@
 import re
 
-from flask import Markup
+from markupsafe import Markup
 from orderedset import OrderedSet
 
 from notifications_utils.columns import Columns

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -7,7 +7,7 @@ from itertools import count
 import bleach
 import mistune
 import smartypants
-from flask import Markup
+from markupsafe import Markup
 from orderedset import OrderedSet
 
 from notifications_utils.sanitise_text import SanitiseSMS

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -5,8 +5,8 @@ from functools import lru_cache
 from html import unescape
 from os import path
 
-from flask import Markup
 from jinja2 import Environment, FileSystemLoader
+from markupsafe import Markup
 
 from notifications_utils import LETTER_MAX_PAGE_COUNT, SMS_CHAR_COUNT_LIMIT
 from notifications_utils.columns import Columns

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def sample_service():
     return FakeService()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def rmock():
     with requests_mock.mock() as rmock:
         yield rmock

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,5 +1,5 @@
 import pytest
-from flask import Markup
+from markupsafe import Markup
 
 from notifications_utils.formatters import (
     escape_html,

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -6,8 +6,8 @@ from unittest import mock
 
 import pytest
 from bs4 import BeautifulSoup
-from flask import Markup
 from freezegun import freeze_time
+from markupsafe import Markup
 from orderedset import OrderedSet
 
 from notifications_utils.formatters import unlink_govuk_escaped


### PR DESCRIPTION
 'jinja2.Markup' is deprecated and will be removed in Jinja 3.1. Import 'markupsafe.Markup' instead.

PytestDeprecationWarning: @pytest.yield_fixture is deprecated. Use @pytest.fixture instead; they are the same.