### PR TITLE
Test detection and formatting of conditional placeholder with line-break in it

### DIFF
--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -107,6 +107,11 @@ def test_returns_a_string_without_placeholders(content):
             "This is a conditional warning"
         ),
         (
+            "((warning??This is a conditional warning\nwith line break))",
+            {"warning": True},
+            "This is a conditional warning\nwith line break"
+        ),
+        (
             "((warning??This is a conditional warning))",
             {"warning": False},
             ""
@@ -185,6 +190,10 @@ def test_optional_redacting_of_missing_values(template_content, data, expected):
         (
             "((warning?? This is a warning))",
             "<span class='placeholder-conditional'>((warning??</span> This is a warning))"
+        ),
+        (
+            "((warning?? This is a warning\n text after linebreak))",
+            "<span class='placeholder-conditional'>((warning??</span> This is a warning\n text after linebreak))"
         ),
     ]
 )


### PR DESCRIPTION
We recently had an incident where changes in the code broke optional placeholders with linebreaks in them.

We should protect against that in the future by having unit tests checking for those cases.