### PR TITLE
Reflect correctly pluralised exception message

### DIFF
--- a/tests/test_serialised_model.py
+++ b/tests/test_serialised_model.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 
 from notifications_utils.serialised_model import (
@@ -17,30 +19,50 @@ def test_cant_be_instatiated_with_abstract_properties():
     with pytest.raises(TypeError) as e:
         SerialisedModel()
 
-    assert str(e.value) == (
-        "Can't instantiate abstract class SerialisedModel with abstract methods ALLOWED_PROPERTIES"
-    )
+    if sys.version_info < (3, 9):
+        assert str(e.value) == (
+            "Can't instantiate abstract class SerialisedModel with abstract methods ALLOWED_PROPERTIES"
+        )
+    else:
+        assert (
+            "Can't instantiate abstract class SerialisedModel with abstract method ALLOWED_PROPERTIES"
+        )
 
     with pytest.raises(TypeError) as e:
         Custom()
 
-    assert str(e.value) == (
-        "Can't instantiate abstract class Custom with abstract methods ALLOWED_PROPERTIES"
-    )
+    if sys.version_info < (3, 9):
+        assert str(e.value) == (
+            "Can't instantiate abstract class Custom with abstract methods ALLOWED_PROPERTIES"
+        )
+    else:
+        assert str(e.value) == (
+            "Can't instantiate abstract class Custom with abstract method ALLOWED_PROPERTIES"
+        )
 
     with pytest.raises(TypeError) as e:
         SerialisedModelCollection()
 
-    assert str(e.value) == (
-        "Can't instantiate abstract class SerialisedModelCollection with abstract methods model"
-    )
+    if sys.version_info < (3, 9):
+        assert str(e.value) == (
+            "Can't instantiate abstract class SerialisedModelCollection with abstract methods model"
+        )
+    else:
+        assert str(e.value) == (
+            "Can't instantiate abstract class SerialisedModelCollection with abstract method model"
+        )
 
     with pytest.raises(TypeError) as e:
         CustomCollection()
 
-    assert str(e.value) == (
-        "Can't instantiate abstract class CustomCollection with abstract methods model"
-    )
+    if sys.version_info < (3, 9):
+        assert str(e.value) == (
+            "Can't instantiate abstract class CustomCollection with abstract methods model"
+        )
+    else:
+        assert str(e.value) == (
+            "Can't instantiate abstract class CustomCollection with abstract method model"
+        )
 
 
 def test_looks_up_from_dict():

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import sys
 from functools import partial
 from time import process_time
 from unittest import mock
@@ -32,18 +33,54 @@ from notifications_utils.template import (
 
 
 @pytest.mark.parametrize('template_class, expected_error', (
-    (Template, (
-        "Can't instantiate abstract class Template with abstract methods __str__"
-    )),
-    (BaseEmailTemplate, (
-        "Can't instantiate abstract class BaseEmailTemplate with abstract methods __str__"
-    )),
-    (BaseLetterTemplate, (
-        "Can't instantiate abstract class BaseLetterTemplate with abstract methods __str__"
-    )),
-    (BaseBroadcastTemplate, (
-        "Can't instantiate abstract class BaseBroadcastTemplate with abstract methods __str__"
-    )),
+    pytest.param(
+        Template, (
+            "Can't instantiate abstract class Template with abstract methods __str__"
+        ),
+        marks=pytest.mark.skipif(sys.version_info >= (3, 9), reason='‘methods’ will be singular')
+    ),
+    pytest.param(
+        Template, (
+            "Can't instantiate abstract class Template with abstract method __str__"
+        ),
+        marks=pytest.mark.skipif(sys.version_info < (3, 9), reason='‘method’ will be pluralised')
+    ),
+    pytest.param(
+        BaseEmailTemplate, (
+            "Can't instantiate abstract class BaseEmailTemplate with abstract methods __str__"
+        ),
+        marks=pytest.mark.skipif(sys.version_info >= (3, 9), reason='‘methods’ will be singular')
+    ),
+    pytest.param(
+        BaseEmailTemplate, (
+            "Can't instantiate abstract class BaseEmailTemplate with abstract method __str__"
+        ),
+        marks=pytest.mark.skipif(sys.version_info < (3, 9), reason='‘method’ will be pluralised')
+    ),
+    pytest.param(
+        BaseLetterTemplate, (
+            "Can't instantiate abstract class BaseLetterTemplate with abstract methods __str__"
+        ),
+        marks=pytest.mark.skipif(sys.version_info >= (3, 9), reason='‘methods’ will be singular')
+    ),
+    pytest.param(
+        BaseLetterTemplate, (
+            "Can't instantiate abstract class BaseLetterTemplate with abstract method __str__"
+        ),
+        marks=pytest.mark.skipif(sys.version_info < (3, 9), reason='‘method’ will be pluralised')
+    ),
+    pytest.param(
+        BaseBroadcastTemplate, (
+            "Can't instantiate abstract class BaseBroadcastTemplate with abstract methods __str__"
+        ),
+        marks=pytest.mark.skipif(sys.version_info >= (3, 9), reason='‘methods’ will be singular')
+    ),
+    pytest.param(
+        BaseBroadcastTemplate, (
+            "Can't instantiate abstract class BaseBroadcastTemplate with abstract method __str__"
+        ),
+        marks=pytest.mark.skipif(sys.version_info < (3, 9), reason='‘method’ will be pluralised')
+    ),
 ))
 def test_abstract_classes_cant_be_instantiated(template_class, expected_error):
     with pytest.raises(TypeError) as error:


### PR DESCRIPTION
As of https://github.com/python/cpython/commit/4a12a178f4a6b9a59d97fecc727f2b6b28dfc85f the exception message for instantiating a class with abstract methods is only pluralised if there is more than one abstract method.

Our tests were expecting the exception message to always be pluralised.

This means the tests fail on Python versions greater than 3.9.0. This commit makes the tests pass with both (incorrectly) pluralised and non-pluralised versions of the message.