### PR TITLE
Add descriptions to timezone functions

### DIFF
--- a/notifications_utils/timezones.py
+++ b/notifications_utils/timezones.py
@@ -8,7 +8,8 @@ local_timezone = pytz.timezone("Europe/London")
 
 def utc_string_to_aware_gmt_datetime(date):
     """
-    Date can either be a string or a naive datetime
+    Date can either be a string, naive UTC datetime or an aware UTC datetime
+    Returns an aware London datetime, essentially the time you'd see on your clock
     """
     if not isinstance(date, datetime):
         date = parser.parse(date)
@@ -18,8 +19,14 @@ def utc_string_to_aware_gmt_datetime(date):
 
 
 def convert_utc_to_bst(utc_dt):
+    """
+    Takes a naive UTC datetime and returns a naive London datetime
+    """
     return pytz.utc.localize(utc_dt).astimezone(local_timezone).replace(tzinfo=None)
 
 
 def convert_bst_to_utc(date):
+    """
+    Takes a naive London datetime and returns a naive UTC datetime
+    """
     return local_timezone.localize(date).astimezone(pytz.UTC).replace(tzinfo=None)


### PR DESCRIPTION
These are quite complex things and benefit from having better descriptions.

Note, we weren't quite happy with the names of the functions.

`aware_gmt_datetime` should really be `aware_london_datetime` and
the other two functions could have more verbose names (mentioning
that they convert from naive to naive) but we decided not to change
these as will involve lots of changes around the codebase.