### PR TITLE
Don’t try to upgrade Celery to a newer version

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-celery==4.4.0
+celery==4.4.0 # pyup: ignore
 beautifulsoup4==4.10.0
 pytest==6.2.5
 pytest-mock==3.6.1


### PR DESCRIPTION
We need to keep the Celery version at the lowest version of used among any of our apps. Antivirus is on v4.4. We need to upgrade the apps before we can upgrade the common version in this repo, and we shouldn’t block other PRs to this repo in the meantime.