### PR TITLE
Rename `RecipientCSV.whitelist` to `RecipientCSV.guestlist`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 51.0.0
+
+* Initial argument to `RecipientCSV` renamed from `whitelist` to
+  `guestlist`, in other words consuming code should call
+  `RecipientCSV(guestlist=['test@example.com'])`
+* `RecipientCSV.whitelist` property renamed to `RecipientCSV.guestlist`
+
 ## 50.0.0
 
 * Make icon in `broadcast_preview_template.jinja2` an inline SVG

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -54,7 +54,7 @@ class RecipientCSV():
         template,
         max_errors_shown=20,
         max_initial_rows_shown=10,
-        whitelist=None,
+        guestlist=None,
         remaining_messages=sys.maxsize,
         allow_international_sms=False,
         allow_international_letters=False,
@@ -62,7 +62,7 @@ class RecipientCSV():
         self.file_data = strip_all_whitespace(file_data, extra_characters=',')
         self.max_errors_shown = max_errors_shown
         self.max_initial_rows_shown = max_initial_rows_shown
-        self.whitelist = whitelist
+        self.guestlist = guestlist
         self.template = template
         self.allow_international_sms = allow_international_sms
         self.allow_international_letters = allow_international_letters
@@ -78,15 +78,15 @@ class RecipientCSV():
         return self.rows[requested_index]
 
     @property
-    def whitelist(self):
-        return self._whitelist
+    def guestlist(self):
+        return self._guestlist
 
-    @whitelist.setter
-    def whitelist(self, value):
+    @guestlist.setter
+    def guestlist(self, value):
         try:
-            self._whitelist = list(value)
+            self._guestlist = list(value)
         except TypeError:
-            self._whitelist = []
+            self._guestlist = []
 
     @property
     def template(self):
@@ -138,10 +138,10 @@ class RecipientCSV():
     def allowed_to_send_to(self):
         if self.template_type == 'letter':
             return True
-        if not self.whitelist:
+        if not self.guestlist:
             return True
         return all(
-            allowed_to_send_to(row.recipient, self.whitelist)
+            allowed_to_send_to(row.recipient, self.guestlist)
             for row in self.rows
         )
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '50.0.0'  # 66e0f57bf1ac94cf290a875390691b18
+__version__ = '51.0.0'  # 9a99c58ba76c2d5f6440b54882099705

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -397,7 +397,7 @@ def test_big_list():
         template=_sample_template('email', 'hello ((name))'),
         max_errors_shown=100,
         max_initial_rows_shown=3,
-        whitelist=["a@b.com"]
+        guestlist=["a@b.com"]
     )
     assert len(list(big_csv.initial_rows)) == 3
     assert len(list(big_csv.initial_rows_with_errors)) == 100
@@ -778,7 +778,7 @@ def test_errors_when_too_many_rows():
 
 
 @pytest.mark.parametrize(
-    "file_contents,template_type,whitelist,count_of_rows_with_errors",
+    "file_contents,template_type,guestlist,count_of_rows_with_errors",
     [
         (
             """
@@ -806,21 +806,21 @@ def test_errors_when_too_many_rows():
         (
             """
                 email address
-                IN_WHITELIST@EXAMPLE.COM
-                not_in_whitelist@example.com
+                IN_GUESTLIST@EXAMPLE.COM
+                not_in_guestlist@example.com
             """,
             'email',
-            ['in_whitelist@example.com', '07700900460'],  # Email case differs to the one in the CSV
+            ['in_guestlist@example.com', '07700900460'],  # Email case differs to the one in the CSV
             1
         )
     ]
 )
-def test_recipient_whitelist(file_contents, template_type, whitelist, count_of_rows_with_errors):
+def test_recipient_guestlist(file_contents, template_type, guestlist, count_of_rows_with_errors):
 
     recipients = RecipientCSV(
         file_contents,
         template=_sample_template(template_type),
-        whitelist=whitelist
+        guestlist=guestlist
     )
 
     if count_of_rows_with_errors:
@@ -828,17 +828,17 @@ def test_recipient_whitelist(file_contents, template_type, whitelist, count_of_r
     else:
         assert recipients.allowed_to_send_to
 
-    # Make sure the whitelist isn’t emptied by reading it. If it’s an iterator then
+    # Make sure the guestlist isn’t emptied by reading it. If it’s an iterator then
     # there’s a risk that it gets emptied after being read once
-    recipients.whitelist = (str(fake_number) for fake_number in range(7700900888, 7700900898))
-    list(recipients.whitelist)
+    recipients.guestlist = (str(fake_number) for fake_number in range(7700900888, 7700900898))
+    list(recipients.guestlist)
     assert not recipients.allowed_to_send_to
     assert recipients.has_errors
 
-    # An empty whitelist is treated as no whitelist at all
-    recipients.whitelist = []
+    # An empty guestlist is treated as no guestlist at all
+    recipients.guestlist = []
     assert recipients.allowed_to_send_to
-    recipients.whitelist = itertools.chain()
+    recipients.guestlist = itertools.chain()
     assert recipients.allowed_to_send_to
 
 

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -346,7 +346,7 @@ def test_validate_email_address_raises_for_invalid(email_address):
 
 
 @pytest.mark.parametrize("phone_number", valid_uk_phone_numbers)
-def test_validates_against_whitelist_of_phone_numbers(phone_number):
+def test_validates_against_guestlist_of_phone_numbers(phone_number):
     assert allowed_to_send_to(phone_number, ['07123456789', '07700900460', 'test@example.com'])
     assert not allowed_to_send_to(phone_number, ['07700900460', '07700900461', 'test@example.com'])
 
@@ -355,12 +355,12 @@ def test_validates_against_whitelist_of_phone_numbers(phone_number):
     ['1-202-555-0104', '0012025550104'],
     ['0012025550104', '1-202-555-0104'],
 ])
-def test_validates_against_whitelist_of_international_phone_numbers(recipient_number, allowlist_number):
+def test_validates_against_guestlist_of_international_phone_numbers(recipient_number, allowlist_number):
     assert allowed_to_send_to(recipient_number, [allowlist_number])
 
 
 @pytest.mark.parametrize("email_address", valid_email_addresses)
-def test_validates_against_whitelist_of_email_addresses(email_address):
+def test_validates_against_guestlist_of_email_addresses(email_address):
     assert not allowed_to_send_to(email_address, ['very_special_and_unique@example.com'])
 
 


### PR DESCRIPTION
This matches what we call the feature in the UI and documentation, after we changed the name in https://github.com/alphagov/notifications-admin/pull/3479