### PR TITLE
Make processing empty cells faster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 51.1.0
+
+* Make processing of spreadsheets with many empty columns more efficient
+
 ## 51.0.0
 
 * Initial argument to `RecipientCSV` renamed from `whitelist` to

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -338,6 +338,11 @@ def strip_all_whitespace(value, extra_characters=''):
 
 
 def strip_and_remove_obscure_whitespace(value):
+    if value == '':
+        # Return early to avoid making multiple, slow calls to
+        # str.replace on an empty string
+        return ''
+
     for character in OBSCURE_ZERO_WIDTH_WHITESPACE + OBSCURE_FULL_WIDTH_WHITESPACE:
         value = value.replace(character, '')
 

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -583,6 +583,11 @@ def allowed_to_send_to(recipient, allowlist):
 
 
 def insert_or_append_to_dict(dict_, key, value):
+    if not (key or value):
+        # We don’t care about completely empty values so it’s faster to
+        # ignore them rather than working out how to store them
+        return
+
     if dict_.get(key):
         if isinstance(dict_[key], list):
             dict_[key].append(value)

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '51.0.1'  # 6c75568e88c5e5f046b1d88569772291
+__version__ = '51.1.0'  # 58d4938dfd637808987942cddf38e372

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -448,6 +448,20 @@ def test_overly_big_list_stops_processing_rows_beyond_max(mocker):
     ) == 10
 
 
+def test_empty_column_names():
+    recipient_csv = RecipientCSV(
+        """
+            phone_number,,,name
+            07900900123,foo,bar,baz
+        """,
+        template=_sample_template('sms'),
+    )
+
+    assert recipient_csv[0]['phone_number'].data == '07900900123'
+    assert recipient_csv[0][''].data == ['foo', 'bar']
+    assert recipient_csv[0]['name'].data == 'baz'
+
+
 @pytest.mark.parametrize(
     "file_contents,template,expected_recipients,expected_personalisation",
     [

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -448,17 +448,23 @@ def test_overly_big_list_stops_processing_rows_beyond_max(mocker):
     ) == 10
 
 
-def test_big_empty_list():
+def test_file_with_lots_of_empty_columns():
     process = Mock()
 
-    lots_of_commas = ',' * 100_000
+    lots_of_commas = ',' * 10_000
 
-    for _row in RecipientCSV(
+    for row in RecipientCSV(
         f'phone_number{lots_of_commas}\n' + (
             f'07900900900{lots_of_commas}\n' * 100
         ),
         template=_sample_template('sms'),
-    ).get_rows():
+    ):
+        assert [
+            (key, cell.data) for key, cell in row.items()
+        ] == [
+            # Note that we haven’t stored any of the empty cells
+            ('phonenumber', '07900900900')
+        ]
         process()
 
     assert process.call_count == 100

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -448,6 +448,22 @@ def test_overly_big_list_stops_processing_rows_beyond_max(mocker):
     ) == 10
 
 
+def test_big_empty_list():
+    process = Mock()
+
+    lots_of_commas = ',' * 100_000
+
+    for _row in RecipientCSV(
+        f'phone_number{lots_of_commas}\n' + (
+            f'07900900900{lots_of_commas}\n' * 100
+        ),
+        template=_sample_template('sms'),
+    ).get_rows():
+        process()
+
+    assert process.call_count == 100
+
+
 def test_empty_column_names():
     recipient_csv = RecipientCSV(
         """


### PR DESCRIPTION
# Make strip_and_remove_obscure_whitespace more efficient 

Doing `str.replace` is relatively expensive, and it has no effect when performed on an empty string. So we can make this function a bit more efficient by short circuiting when given an empty input.

## Performance on `test_big_empty_list`

### Before

`37.0s`

### After

`15.8s`

# Don’t repeatedly store values against unnamed columns from spreadsheets

If a spreadsheet has many empty columns we dutifully store those empty values against an empty column header, only to never look at them again. This takes extra time because the process of storing them is a bit more involved that just a `dict.update`.

By skipping storing these values we can make processing a spreadsheet a bit more efficient.

## Performance on `test_big_empty_list`

### Before

`15.8s`

### After

`5.3s`

# Overall performance improvement

7&times; faster