### PR TITLE
Skip rows past 100,000 sooner

### DIFF
--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -170,6 +170,10 @@ class RecipientCSV():
 
         for index, row in enumerate(rows_as_lists_of_columns):
 
+            if index >= self.max_rows:
+                yield None
+                continue
+
             output_dict = OrderedDict()
 
             for column_name, column_value in zip(column_headers, row):
@@ -189,18 +193,15 @@ class RecipientCSV():
                 for key in column_headers[length_of_row:]:
                     insert_or_append_to_dict(output_dict, key, None)
 
-            if index < self.max_rows:
-                yield Row(
-                    output_dict,
-                    index=index,
-                    error_fn=self._get_error_for_field,
-                    recipient_column_headers=self.recipient_column_headers,
-                    placeholders=self.placeholders_as_column_keys,
-                    template=self.template,
-                    allow_international_letters=self.allow_international_letters,
-                )
-            else:
-                yield None
+            yield Row(
+                output_dict,
+                index=index,
+                error_fn=self._get_error_for_field,
+                recipient_column_headers=self.recipient_column_headers,
+                placeholders=self.placeholders_as_column_keys,
+                template=self.template,
+                allow_international_letters=self.allow_international_letters,
+            )
 
     @property
     def more_rows_than_can_send(self):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '51.0.0'  # 9a99c58ba76c2d5f6440b54882099705
+__version__ = '51.0.1'  # 6c75568e88c5e5f046b1d88569772291

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -417,21 +417,35 @@ def test_processing_a_big_list():
     assert process.call_count == 100_000
 
 
-@pytest.mark.parametrize('number_of_rows', (
-    (RecipientCSV.max_rows + 1),
-    (RecipientCSV.max_rows * 10),
-))
-def test_overly_big_list(number_of_rows):
+def test_overly_big_list_stops_processing_rows_beyond_max(mocker):
+    mock_strip_and_remove_obscure_whitespace = mocker.patch(
+        'notifications_utils.recipients.strip_and_remove_obscure_whitespace'
+    )
+    mock_insert_or_append_to_dict = mocker.patch(
+        'notifications_utils.recipients.insert_or_append_to_dict'
+    )
+
     big_csv = RecipientCSV(
-        "phonenumber,name\n" + ("07700900123,example\n" * number_of_rows),
+        "phonenumber,name\n" + ("07700900123,example\n" * 123),
         template=_sample_template('sms', content='hello ((name))'),
     )
-    assert len(big_csv) == number_of_rows
-    assert big_csv.too_many_rows is True
-    assert big_csv.has_errors is True
-    assert list(big_csv.rows_with_missing_data) == []
-    assert list(big_csv.rows_with_bad_recipients) == []
-    assert list(big_csv.rows_with_message_too_long) == []
+    big_csv.max_rows = 10
+
+    # Our CSV has lots of rows…
+    assert big_csv.too_many_rows
+    assert len(big_csv) == 123
+
+    # …but we’ve only called the expensive whitespace function on each
+    # of the 2 cells in the first 10 rows
+    assert len(
+        mock_strip_and_remove_obscure_whitespace.call_args_list
+    ) == 20
+
+    # …and we’ve only called the function which builds the internal data
+    # structure once for each of the first 10 rows
+    assert len(
+        mock_insert_or_append_to_dict.call_args_list
+    ) == 10
 
 
 @pytest.mark.parametrize(

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -417,12 +417,16 @@ def test_processing_a_big_list():
     assert process.call_count == 100_000
 
 
-def test_overly_big_list():
+@pytest.mark.parametrize('number_of_rows', (
+    (RecipientCSV.max_rows + 1),
+    (RecipientCSV.max_rows * 10),
+))
+def test_overly_big_list(number_of_rows):
     big_csv = RecipientCSV(
-        "phonenumber,name\n" + ("07700900123,example\n" * (RecipientCSV.max_rows + 1)),
+        "phonenumber,name\n" + ("07700900123,example\n" * number_of_rows),
         template=_sample_template('sms', content='hello ((name))'),
     )
-    assert len(big_csv) == 100_001
+    assert len(big_csv) == number_of_rows
     assert big_csv.too_many_rows is True
     assert big_csv.has_errors is True
     assert list(big_csv.rows_with_missing_data) == []


### PR DESCRIPTION
Skip processing rows past 100,000 sooner 

In 26443fa I added an efficiency improvement which avoids trying to process the contents of spreadsheet rows once we’ve iterated past the maximum number of rows we allow.

This is good, because it means we don’t waste time trying to validate a million phone numbers, for example.

However it could be even better because we’re still doing some processing of these rows to put them into a data structure, which we then throw away.

So this commit adds the row count check earlier, which means it’s as fast to process a million rows as it is to process 100,000 rows.

***

## Time to run `tests/test_recipient_csv.py::test_overly_big_list`

Row count | Before | After
---|---|---
100,001 | 8.37s | 8.34s
1,000,000 | 12.14s | 8.96s

