### PR TITLE
Fix calculation of minor and patch version numbers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,13 @@ reset-version:
 	git checkout origin/master -- notifications_utils/version.py
 
 .PHONY: version-major
-version-major: reset-version
+version-major: reset-version ## Update the major version number
 	./scripts/bump_version.py major
 
 .PHONY: version-minor
-version-minor: reset-version
+version-minor: reset-version ## Update the minor version number
 	./scripts/bump_version.py minor
 
 .PHONY: version-patch
-version-patch: reset-version
+version-patch: reset-version ## Update the patch version number
 	./scripts/bump_version.py patch

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '51.0.1'  # 6c75568e88c5e5f046b1d88569772291
+__version__ = '51.1.0'  # 58d4938dfd637808987942cddf38e372

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -12,12 +12,13 @@ parser = argparse.ArgumentParser()
 parser.add_argument('version_part', choices=version_parts)
 version_part = parser.parse_args().version_part
 
-new_major, new_minor, new_patch = (
-    int(current) + (part == version_part)
-    for part, current in zip(
-        version_parts, __version__.split('.')
-    )
-)
+current_major, current_minor, current_patch = map(int, __version__.split('.'))
+
+new_major, new_minor, new_patch = {
+    'major': (current_major + 1, 0, 0),
+    'minor': (current_major, current_minor + 1, 0),
+    'patch': (current_major, current_minor, current_patch + 1),
+}[version_part]
 
 package_contents = subprocess.run(
     ('tar', 'cf', '-', 'notifications_utils'),


### PR DESCRIPTION
# Before

Previous version | Command | New version | Correct
---|---|---|---
50.0.1 | `make version-patch` | 50.0.2 | ✅
50.0.1 | `make version-minor` | 50.1.1 | ❌
50.1.1 | `make version-major` | 51.1.1 | ❌

# After

Previous version | Command | New version | Correct
---|---|---|---
50.0.1 | `make version-patch` | 50.0.2 | ✅
50.0.1 | `make version-minor` | 50.1.0 | ✅
50.1.1 | `make version-major` | 51.0.0 | ✅