### PR TITLE
Speed up tests and code for RecipientCSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 51.2.0
+
+* Timeout processing CSVs to avoid timing out downstream requests
+
+This only affects the Admin app, which should ideally rescue the exception,
+but just letting it propagate is also acceptable as it's similar to the
+current behaviour where we timeout in CloudFront.
+
 ## 51.1.0
 
 * Make processing of spreadsheets with many empty columns more efficient

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '51.1.1'  # 5fd0bbc81c3653cee9fa2ada1b78c8c5
+__version__ = '51.2.0'  # 1e1f0a68e40b7c2b164567e4d7e1d373

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -808,15 +808,20 @@ def test_international_recipients(file_contents, rows_with_bad_recipients):
 
 def test_errors_when_too_many_rows():
     recipients = RecipientCSV(
-        "email address\n" + ("a@b.com\n" * (RecipientCSV.max_rows + 1)),
+        "email address\n" + ("a@b.com\n" * 101),
         template=_sample_template('email'),
     )
-    assert RecipientCSV.max_rows == 100_000
+
+    # Confirm the normal max_row limit
+    assert recipients.max_rows == 100_000
+    # Override to make this test faster
+    recipients.max_rows = 100
+
     assert recipients.too_many_rows is True
     assert recipients.has_errors is True
-    assert recipients.rows[99_000]['email_address'].data == 'a@b.com'
+    assert recipients.rows[99]['email_address'].data == 'a@b.com'
     # We stop processing subsequent rows
-    assert recipients.rows[100_000] is None
+    assert recipients.rows[100] is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -391,20 +391,6 @@ def test_check_if_message_too_long_for_sms_but_not_email_in_CSV(
         is_message_too_long.called
 
 
-def test_big_list():
-    big_csv = RecipientCSV(
-        "email address,name\n" + ("a@b.com\n" * RecipientCSV.max_rows),
-        template=_sample_template('email', 'hello ((name))'),
-        max_errors_shown=100,
-        max_initial_rows_shown=3,
-        guestlist=["a@b.com"]
-    )
-    assert len(list(big_csv.initial_rows)) == 3
-    assert len(list(big_csv.initial_rows_with_errors)) == 100
-    assert len(list(big_csv.rows)) == RecipientCSV.max_rows
-    assert big_csv.has_errors
-
-
 def test_overly_big_list_stops_processing_rows_beyond_max(mocker):
     mock_strip_and_remove_obscure_whitespace = mocker.patch(
         'notifications_utils.recipients.strip_and_remove_obscure_whitespace'

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -405,18 +405,6 @@ def test_big_list():
     assert big_csv.has_errors
 
 
-def test_processing_a_big_list():
-    process = Mock()
-
-    for _row in RecipientCSV(
-        "phone_number\n" + ("07900900900\n" * RecipientCSV.max_rows),
-        template=_sample_template('sms'),
-    ).get_rows():
-        process()
-
-    assert process.call_count == 100_000
-
-
 def test_overly_big_list_stops_processing_rows_beyond_max(mocker):
     mock_strip_and_remove_obscure_whitespace = mocker.patch(
         'notifications_utils.recipients.strip_and_remove_obscure_whitespace'

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -12,6 +12,7 @@ from notifications_utils import SMS_CHAR_COUNT_LIMIT
 from notifications_utils.countries import Country
 from notifications_utils.recipients import (
     Cell,
+    CSVTooBigError,
     RecipientCSV,
     Row,
     first_column_headings,
@@ -420,6 +421,21 @@ def test_overly_big_list_stops_processing_rows_beyond_max(mocker):
     assert len(
         mock_insert_or_append_to_dict.call_args_list
     ) == 10
+
+
+def test_rows_processing_timeout():
+    recipients = RecipientCSV(
+        # Keep the number of rows small to avoid DoSing other tests
+        'phone_number,07900900900\n' * 1000,
+        template=_sample_template('sms'),
+        # Use "0" to avoid flakey behaviour based on the no. of rows
+        processing_timeout=0,
+    )
+
+    with pytest.raises(CSVTooBigError) as excinfo:
+        recipients.rows
+
+    assert str(excinfo.value) == 'CSV is too big to process'
 
 
 def test_file_with_lots_of_empty_columns():


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177535141

This PR does two things:

- Introduces timeout functionality to avoid RecipientCSV
getting stuck processing massive CSVs.

- Rewrites / removes some the tests for this class, partly
to avoid the timeout but also just make it faster!

Please review commit by commit.

## Test timing stats

```
# before
time pytest
pytest  49.66s user 2.62s system 97% cpu 53.573 total

# after
time pytest
pytest  28.59s user 2.46s system 96% cpu 32.184 total
```

## Request timings

These are for [previewing an uploaded CSV in the Admin app](https://github.com/alphagov/notifications-admin/blob/925f86aa705583e920ea4f0300c3f85fd8546c90/app/main/views/send.py#L645).

Note: these might be a bit dodgy because there's no way to filter for the "/check/" URLs in Kibana: you can't search / filter for non-alphanumeric characters in strings. The query in the screenshot seems to filter out everything we don't care about. I might try and get the same data out of Athena, but I doubt it will change the default.

<img width="1117" alt="Screenshot 2021-12-07 at 16 41 36" src="https://user-images.githubusercontent.com/9029009/145070012-36f65b4a-9939-47e3-8067-8ff228930e4c.png">
