### PR TITLE
Change DEFAULT_TTL to be `int` not `float`

### DIFF
--- a/notifications_utils/clients/redis/__init__.py
+++ b/notifications_utils/clients/redis/__init__.py
@@ -15,7 +15,7 @@ def rate_limit_cache_key(service_id, api_key_type):
 
 class RequestCache():
 
-    DEFAULT_TTL = timedelta(days=7).total_seconds()
+    DEFAULT_TTL = int(timedelta(days=7).total_seconds())
 
     def __init__(self, redis_client):
         self.redis_client = redis_client

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '51.1.0'  # 58d4938dfd637808987942cddf38e372
+__version__ = '51.1.1'  # 5fd0bbc81c3653cee9fa2ada1b78c8c5


### PR DESCRIPTION
See https://github.com/alphagov/notifications-admin/pull/4094
for reason for this change.

When this is merged to the admin app we can remove the forcing of
`int` on `DEFAULT_TTL` although there isn't much harm of running
it through `int` twice.