### PR TITLE
Revert "Timeout processing RecipientCSV rows"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 51.2.1
+
+* Revert 51.2.0.
+
 ## 51.2.0
 
 * Timeout processing CSVs to avoid timing out downstream requests

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -6,7 +6,6 @@ from contextlib import suppress
 from functools import lru_cache, partial
 from io import StringIO
 from itertools import islice
-from threading import Thread
 
 import phonenumbers
 from flask import current_app
@@ -59,7 +58,6 @@ class RecipientCSV():
         remaining_messages=sys.maxsize,
         allow_international_sms=False,
         allow_international_letters=False,
-        processing_timeout=20,
     ):
         self.file_data = strip_all_whitespace(file_data, extra_characters=',')
         self.max_errors_shown = max_errors_shown
@@ -70,7 +68,6 @@ class RecipientCSV():
         self.allow_international_letters = allow_international_letters
         self.remaining_messages = remaining_messages
         self.rows_as_list = None
-        self.processing_timeout = processing_timeout
 
     def __len__(self):
         if not hasattr(self, '_len'):
@@ -150,22 +147,8 @@ class RecipientCSV():
 
     @property
     def rows(self):
-        return self.try_get_rows()
-
-    def try_get_rows(self):
-        if self.rows_as_list is not None:
-            return self.rows_as_list
-
-        def cache_rows():
+        if self.rows_as_list is None:
             self.rows_as_list = list(self.get_rows())
-
-        thread = Thread(target=cache_rows, daemon=True)
-        thread.start()
-        thread.join(timeout=self.processing_timeout)
-
-        if thread.is_alive():
-            raise CSVTooBigError()
-
         return self.rows_as_list
 
     @property
@@ -186,6 +169,7 @@ class RecipientCSV():
         next(rows_as_lists_of_columns, None)  # skip the header row
 
         for index, row in enumerate(rows_as_lists_of_columns):
+
             if index >= self.max_rows:
                 yield None
                 continue
@@ -375,11 +359,6 @@ class InvalidPhoneError(InvalidEmailError):
 
 class InvalidAddressError(InvalidEmailError):
     pass
-
-
-class CSVTooBigError(Exception):
-    def __init__(self, message=None):
-        super().__init__(message or 'CSV is too big to process')
 
 
 def normalise_phone_number(number):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '51.2.0'  # 1e1f0a68e40b7c2b164567e4d7e1d373
+__version__ = '51.2.1'  # 15d2163e4f04672521d384b17b1fecb2

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -12,7 +12,6 @@ from notifications_utils import SMS_CHAR_COUNT_LIMIT
 from notifications_utils.countries import Country
 from notifications_utils.recipients import (
     Cell,
-    CSVTooBigError,
     RecipientCSV,
     Row,
     first_column_headings,
@@ -421,21 +420,6 @@ def test_overly_big_list_stops_processing_rows_beyond_max(mocker):
     assert len(
         mock_insert_or_append_to_dict.call_args_list
     ) == 10
-
-
-def test_rows_processing_timeout():
-    recipients = RecipientCSV(
-        # Keep the number of rows small to avoid DoSing other tests
-        'phone_number,07900900900\n' * 1000,
-        template=_sample_template('sms'),
-        # Use "0" to avoid flakey behaviour based on the no. of rows
-        processing_timeout=0,
-    )
-
-    with pytest.raises(CSVTooBigError) as excinfo:
-        recipients.rows
-
-    assert str(excinfo.value) == 'CSV is too big to process'
 
 
 def test_file_with_lots_of_empty_columns():


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177535141

This reverts commit 4fdf28412c4a74824f06607a19e9893b9e730326.

It turns out showing a contextual message for this error is hard,
as we would need to either:

- Show the error on an existing preview page, but be very careful
to structure the code so that none of the other checks run, since
these would trigger more timeout errors.

- Introduce a new error page. This is unprecedented for previewing
a CSV, where we always try to show a preview - this isn't possible
if the CSV is taking too long to process.

Taking a step back, we shouldn't really be adding timeout wrappers
around our code. A more future-proof approach would be:

- To monitor timings for all requests to our apps.
- Take action to improve performance where necessary.

While it's still possible to get this code to run for a long time,
the improvements we've already made should reduce the likelihood
of this being an issue in practice.