### PR TITLE
Purge unused redis functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 52.0.0
+
+* Deprecate the following unused `redis_client` functions:
+  - `redis_client.increment_hash_value`
+  - `redis_client.decrement_hash_value`
+  - `redis_client.get_all_from_hash`
+  - `redis_client.set_hash_and_expire`
+  - `redis_client.expire`
+
 ## 51.3.1
 
 * Bump govuk-bank-holidays to cache holidays for next year.

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -154,44 +154,6 @@ class RedisClient:
 
         return None
 
-    def decrement_hash_value(self, key, value, raise_exception=False):
-        return self.increment_hash_value(key, value, raise_exception, incr_by=-1)
-
-    def increment_hash_value(self, key, value, raise_exception=False, incr_by=1):
-        key = prepare_value(key)
-        value = prepare_value(value)
-        if self.active:
-            try:
-                return self.redis_store.hincrby(key, value, incr_by)
-            except Exception as e:
-                self.__handle_exception(e, raise_exception, 'increment_hash_value', key)
-
-    def get_all_from_hash(self, key, raise_exception=False):
-        key = prepare_value(key)
-        if self.active:
-            try:
-                return self.redis_store.hgetall(key)
-            except Exception as e:
-                self.__handle_exception(e, raise_exception, 'get_all_from_hash', key)
-
-    def set_hash_and_expire(self, key, values, expire_in_seconds, raise_exception=False):
-        key = prepare_value(key)
-        values = {prepare_value(k): prepare_value(v) for k, v in values.items()}
-        if self.active:
-            try:
-                self.redis_store.hmset(key, values)
-                return self.redis_store.expire(key, expire_in_seconds)
-            except Exception as e:
-                self.__handle_exception(e, raise_exception, 'set_hash_and_expire', key)
-
-    def expire(self, key, expire_in_seconds, raise_exception=False):
-        key = prepare_value(key)
-        if self.active:
-            try:
-                self.redis_store.expire(key, expire_in_seconds)
-            except Exception as e:
-                self.__handle_exception(e, raise_exception, 'expire', key)
-
     def delete(self, *keys, raise_exception=False):
         keys = [prepare_value(k) for k in keys]
         if self.active:

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '51.3.1'  # fd6a1ca6d4a9967e4cd6e907b37ef628
+__version__ = '52.0.0'  # af824b781b5189401b5c0ad1e98b56ce

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -4,6 +4,7 @@ import argparse
 import hashlib
 import subprocess
 from pathlib import Path
+
 from notifications_utils.version import __version__
 
 version_parts = ('major', 'minor', 'patch')

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 """
 Python API client for GOV.UK Notify
 """
-import re
 import ast
-from setuptools import (setup, find_packages)
+import re
 
+from setuptools import find_packages, setup
 
 _version_re = re.compile(r'__version__\s+=\s+(.*)')
 


### PR DESCRIPTION
We don't use them, we haven't for a while since we simplified our redis usage.


* Deprecate the following unused `redis_client` functions:
  - `redis_client.increment_hash_value`
  - `redis_client.decrement_hash_value`
  - `redis_client.get_all_from_hash`
  - `redis_client.set_hash_and_expire`
  - `redis_client.expire`