### PR TITLE
Log stacktrace when a task fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 51.3.0
+
+* Log exception and stacktrace when Celery tasks fail.
+
 ## 51.2.1
 
 * Revert 51.2.0.

--- a/notifications_utils/celery.py
+++ b/notifications_utils/celery.py
@@ -52,7 +52,7 @@ def make_task(app):
         def on_failure(self, exc, task_id, args, kwargs, einfo):
             # enables request id tracing for these logs
             with self.app_context():
-                app.logger.error(
+                app.logger.exception(
                     "Celery task {task_name} (queue: {queue_name}) failed".format(
                         task_name=self.name,
                         queue_name=self.queue_name,
@@ -65,8 +65,6 @@ def make_task(app):
                         queue_name=self.queue_name
                     )
                 )
-
-                super().on_failure(exc, task_id, args, kwargs, einfo)
 
         def __call__(self, *args, **kwargs):
             # ensure task has flask context to access config, logger, etc

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '51.2.1'  # 15d2163e4f04672521d384b17b1fecb2
+__version__ = '51.3.0'  # 3c8c051e0cabc33d9a2ee9f55811cb61

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -92,7 +92,10 @@ def test_failure_should_log_and_call_statsd(
     )
 
     statsd_mock.assert_called_once_with(f'celery.test-queue.{async_task.name}.failure')
-    logger_mock.assert_called_once_with(f'Celery task {async_task.name} (queue: test-queue) failed')
+
+    logger_mock.assert_called_once_with(
+        f'Celery task {async_task.name} (queue: test-queue) failed', exc_info=True
+    )
 
 
 def test_failure_queue_when_applied_synchronously(
@@ -108,7 +111,10 @@ def test_failure_queue_when_applied_synchronously(
     )
 
     statsd_mock.assert_called_once_with(f'celery.none.{celery_task.name}.failure')
-    logger_mock.assert_called_once_with(f'Celery task {celery_task.name} (queue: none) failed')
+
+    logger_mock.assert_called_once_with(
+        f'Celery task {celery_task.name} (queue: none) failed', exc_info=True
+    )
 
 
 def test_call_exports_request_id_from_headers(mocker, request_id_task):


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180693991

This should help debug the failures we're seeing for one of the
nightly tasks - create-nightly-notification-status-for-day - even
though the task gets to the point of logging a success.

It's worth noting Celery is probably emitting useful logs, but we
supress them [1]. It looks like we used to log an exception [2], 
but somehow this changed to 'error' in [3].

Logging an exception means we automatically get a stacktrace [4].

The call to "super()" is unnecessary:

- We don't do it for "on_success".
- It wasn't tested.
- The overridden method does nothing [5].
- None of the docs say to call "super()".

[1]: https://github.com/alphagov/notifications-api/blob/master/scripts/paas_app_wrapper.sh#L9
[2]: https://github.com/alphagov/notifications-api/commit/2622866622cb331f79e208dcee389bca480012f1#diff-76936416943346b5f691dac57a64acebc6a1227293820d1d9af4791087c9fb9eR10
[3]: https://github.com/alphagov/notifications-utils/commit/8765f84a613e5bc0036daf2f036cc950308810f3#diff-9f2919d5016ba611c744a546be5484fc79b037248a6a692dc14befe2534912f8R57
[4]: https://docs.python.org/3/library/logging.html#logging.Logger.debug
[5]: https://github.com/celery/celery/blob/5b698151d5e8da10f6706df42fb99fb3105ac025/celery/app/task.py#L1024
