### PR TITLE
Bump govuk-bank-holidays to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 51.3.1
+
+* Bump govuk-bank-holidays to cache holidays for next year.
+
 ## 51.3.0
 
 * Log exception and stacktrace when Celery tasks fail.

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '51.3.0'  # 3c8c051e0cabc33d9a2ee9f55811cb61
+__version__ = '51.3.1'  # fd6a1ca6d4a9967e4cd6e907b37ef628

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'smartypants==2.0.1',
         'pypdf2>=1.26.0',
         'itsdangerous>=1.1.0',
-        'govuk-bank-holidays>=0.8',
+        'govuk-bank-holidays>=0.10',
         'geojson>=2.5.0',
         'Shapely>=1.7.1',
 


### PR DESCRIPTION
While the package can always fetch new holidays via the GOV.UK API,
the latest version of the packages also caches ones for next year,
which means we can avoid unnecessary web requests.