### PR TITLE
Bump celery requirement to version 5

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 
-celery==4.4.0 # pyup: ignore
+celery==5.2.2
 beautifulsoup4==4.10.0
 pytest==7.0.0
 pytest-mock==3.7.0


### PR DESCRIPTION
No reason for it to be pinned, nothing interesting in the git
history. Brings it up to parralel with our other apps.

Also remove the pyup ignore as again no reason for this to be
ignored.