### PR TITLE
# Do not modify or remove the line above. # Everything below it will be ignored.

### DIFF
--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -62,7 +62,7 @@ class RedisClient:
             """
         )
 
-    def delete_cache_keys_by_pattern(self, pattern):
+    def delete_cache_keys_by_pattern(self, pattern, raise_exception=False):
         r"""
         Deletes all keys matching a given pattern, and returns how many keys were deleted.
         Pattern is defined as in the KEYS command: https://redis.io/commands/keys
@@ -76,7 +76,11 @@ class RedisClient:
         Use \ to escape special characters if you want to match them verbatim
         """
         if self.active:
-            return self.scripts['delete-keys-by-pattern'](args=[pattern])
+            try:
+                return self.scripts['delete-keys-by-pattern'](args=[pattern])
+            except Exception as e:
+                self.__handle_exception(e, raise_exception, 'delete-by-pattern', pattern)
+
         return 0
 
     def exceeded_rate_limit(self, cache_key, limit, interval, raise_exception=False):

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -62,7 +62,7 @@ class RedisClient:
             """
         )
 
-    def delete_cache_keys_by_pattern(self, pattern, raise_exception=False):
+    def delete_by_pattern(self, pattern, raise_exception=False):
         r"""
         Deletes all keys matching a given pattern, and returns how many keys were deleted.
         Pattern is defined as in the KEYS command: https://redis.io/commands/keys

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -113,27 +113,27 @@ def test_should_raise_exception_if_raise_set_to_true(
     assert str(e.value) == 'delete failed'
 
 
-def test_should_not_call_set_if_not_enabled(mocked_redis_client):
+def test_should_not_call_if_not_enabled(mocked_redis_client, delete_mock):
     mocked_redis_client.active = False
-    assert not mocked_redis_client.set('key', 'value')
+
+    assert mocked_redis_client.get('get_key') is None
+    assert mocked_redis_client.set('set_key', 'set_value') is None
+    assert mocked_redis_client.incr('incr_key') is None
+    assert mocked_redis_client.exceeded_rate_limit('rate_limit_key', 100, 100) is False
+    assert mocked_redis_client.delete('delete_key') is None
+    assert mocked_redis_client.delete_cache_keys_by_pattern('pattern') == 0
+
+    mocked_redis_client.redis_store.get.assert_not_called()
     mocked_redis_client.redis_store.set.assert_not_called()
+    mocked_redis_client.redis_store.incr.assert_not_called()
+    mocked_redis_client.redis_store.delete.assert_not_called()
+    mocked_redis_client.redis_store.pipeline.assert_not_called()
+    delete_mock.assert_not_called()
 
 
 def test_should_call_set_if_enabled(mocked_redis_client):
     mocked_redis_client.set('key', 'value')
     mocked_redis_client.redis_store.set.assert_called_with('key', 'value', None, None, False, False)
-
-
-def test_should_not_call_get_if_not_enabled(mocked_redis_client):
-    mocked_redis_client.active = False
-    mocked_redis_client.get('key')
-    mocked_redis_client.redis_store.get.assert_not_called()
-
-
-def test_should_not_call_redis_if_not_enabled_for_rate_limit_check(mocked_redis_client):
-    mocked_redis_client.active = False
-    mocked_redis_client.exceeded_rate_limit('key', 100, 200)
-    mocked_redis_client.redis_store.pipeline.assert_not_called()
 
 
 def test_should_call_get_if_enabled(mocked_redis_client):

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -23,21 +23,23 @@ def mocked_redis_pipeline():
 @pytest.fixture(scope='function')
 def mocked_redis_client(app, mocked_redis_pipeline, mocker):
     app.config['REDIS_ENABLED'] = True
-    return build_redis_client(app, mocked_redis_pipeline, mocker)
 
-
-def build_redis_client(app, mocked_redis_pipeline, mocker):
     redis_client = RedisClient()
     redis_client.init_app(app)
+
     mocker.patch.object(redis_client.redis_store, 'get', return_value=100)
     mocker.patch.object(redis_client.redis_store, 'set')
     mocker.patch.object(redis_client.redis_store, 'hincrby')
-    mocker.patch.object(redis_client.redis_store, 'hgetall',
-                        return_value={b'template-1111': b'8', b'template-2222': b'8'})
     mocker.patch.object(redis_client.redis_store, 'hmset')
     mocker.patch.object(redis_client.redis_store, 'expire')
     mocker.patch.object(redis_client.redis_store, 'delete')
     mocker.patch.object(redis_client.redis_store, 'pipeline', return_value=mocked_redis_pipeline)
+
+    mocker.patch.object(
+        redis_client.redis_store,
+        'hgetall',
+        return_value={b'template-1111': b'8', b'template-2222': b'8'}
+    )
 
     return redis_client
 

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -78,7 +78,7 @@ def test_should_not_raise_exception_if_raise_set_to_false(
     assert failing_redis_client.exceeded_rate_limit('rate_limit_key', 100, 100) is False
     assert failing_redis_client.delete('delete_key') is None
     assert failing_redis_client.delete('a', 'b', 'c') is None
-    assert failing_redis_client.delete_cache_keys_by_pattern('pattern') == 0
+    assert failing_redis_client.delete_by_pattern('pattern') == 0
 
     assert mock_logger.mock_calls == [
         call.exception('Redis error performing get on get_key'),
@@ -116,7 +116,7 @@ def test_should_raise_exception_if_raise_set_to_true(
     assert str(e.value) == 'delete failed'
 
     with pytest.raises(Exception) as e:
-        failing_redis_client.delete_cache_keys_by_pattern('pattern', raise_exception=True)
+        failing_redis_client.delete_by_pattern('pattern', raise_exception=True)
     assert str(e.value) == 'delete by pattern failed'
 
 
@@ -128,7 +128,7 @@ def test_should_not_call_if_not_enabled(mocked_redis_client, delete_mock):
     assert mocked_redis_client.incr('incr_key') is None
     assert mocked_redis_client.exceeded_rate_limit('rate_limit_key', 100, 100) is False
     assert mocked_redis_client.delete('delete_key') is None
-    assert mocked_redis_client.delete_cache_keys_by_pattern('pattern') == 0
+    assert mocked_redis_client.delete_by_pattern('pattern') == 0
 
     mocked_redis_client.redis_store.get.assert_not_called()
     mocked_redis_client.redis_store.set.assert_not_called()
@@ -217,15 +217,15 @@ def test_prepare_value(input, output):
     assert prepare_value(input) == output
 
 
-def test_delete_cache_keys_by_pattern(mocked_redis_client, delete_mock):
-    ret = mocked_redis_client.delete_cache_keys_by_pattern('foo')
+def test_delete_by_pattern(mocked_redis_client, delete_mock):
+    ret = mocked_redis_client.delete_by_pattern('foo')
     assert ret == 4
     delete_mock.assert_called_once_with(args=['foo'])
 
 
-def test_delete_cache_keys_by_pattern_returns_zero_when_redis_disabled(mocked_redis_client, delete_mock):
+def test_delete_by_pattern_returns_zero_when_redis_disabled(mocked_redis_client, delete_mock):
     mocked_redis_client.active = False
-    ret = mocked_redis_client.delete_cache_keys_by_pattern('foo')
+    ret = mocked_redis_client.delete_by_pattern('foo')
 
     assert delete_mock.called is False
     assert ret == 0

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -141,17 +141,17 @@ def test_should_call_get_if_enabled(mocked_redis_client):
     mocked_redis_client.redis_store.get.assert_called_with('key')
 
 
-def test_should_build_cache_key_service_and_action(sample_service):
+def test_daily_limit_cache_key(sample_service):
     with freeze_time("2016-01-01 12:00:00.000000"):
         assert daily_limit_cache_key(sample_service.id) == '{}-2016-01-01-count'.format(sample_service.id)
 
 
-def test_should_build_daily_limit_cache_key(sample_service):
+def test_rate_limit_cache_key(sample_service):
     assert rate_limit_cache_key(sample_service.id, 'TEST') == '{}-TEST'.format(sample_service.id)
 
 
 @freeze_time("2001-01-01 12:00:00.000000")
-def test_should_add_correct_calls_to_the_pipe(mocked_redis_client, mocked_redis_pipeline):
+def test_exceeded_rate_limit_should_add_correct_calls_to_the_pipe(mocked_redis_client, mocked_redis_pipeline):
     mocked_redis_client.exceeded_rate_limit("key", 100, 100)
     assert mocked_redis_client.redis_store.pipeline.called
     mocked_redis_pipeline.zadd.assert_called_with("key", {978350400.0: 978350400.0})
@@ -162,24 +162,24 @@ def test_should_add_correct_calls_to_the_pipe(mocked_redis_client, mocked_redis_
 
 
 @freeze_time("2001-01-01 12:00:00.000000")
-def test_should_fail_request_if_over_limit(mocked_redis_client, mocked_redis_pipeline):
+def test_exceeded_rate_limit_should_fail_request_if_over_limit(mocked_redis_client, mocked_redis_pipeline):
     mocked_redis_pipeline.execute.return_value = [True, True, 100, True]
     assert mocked_redis_client.exceeded_rate_limit("key", 99, 100)
 
 
 @freeze_time("2001-01-01 12:00:00.000000")
-def test_should_allow_request_if_not_over_limit(mocked_redis_client, mocked_redis_pipeline):
+def test_exceeded_rate_limit_should_allow_request_if_not_over_limit(mocked_redis_client, mocked_redis_pipeline):
     mocked_redis_pipeline.execute.return_value = [True, True, 100, True]
     assert not mocked_redis_client.exceeded_rate_limit("key", 101, 100)
 
 
 @freeze_time("2001-01-01 12:00:00.000000")
-def test_rate_limit_not_exceeded(mocked_redis_client, mocked_redis_pipeline):
+def test_exceeded_rate_limit_not_exceeded(mocked_redis_client, mocked_redis_pipeline):
     mocked_redis_pipeline.execute.return_value = [True, True, 80, True]
     assert not mocked_redis_client.exceeded_rate_limit("key", 90, 100)
 
 
-def test_should_not_call_rate_limit_if_not_enabled(mocked_redis_client, mocked_redis_pipeline):
+def test_exceeded_rate_limit_should_not_call_if_not_enabled(mocked_redis_client, mocked_redis_pipeline):
     mocked_redis_client.active = False
 
     assert not mocked_redis_client.exceeded_rate_limit('key', 100, 100)
@@ -192,7 +192,7 @@ def test_delete(mocked_redis_client):
     mocked_redis_client.redis_store.delete.assert_called_with(key)
 
 
-def test_multi_delete(mocked_redis_client):
+def test_delete_multi(mocked_redis_client):
     mocked_redis_client.delete('a', 'b', 'c')
     mocked_redis_client.redis_store.delete.assert_called_with('a', 'b', 'c')
 
@@ -210,13 +210,13 @@ def test_prepare_value(input, output):
     assert prepare_value(input) == output
 
 
-def test_delete_cache_keys(mocked_redis_client, delete_mock):
+def test_delete_cache_keys_by_pattern(mocked_redis_client, delete_mock):
     ret = mocked_redis_client.delete_cache_keys_by_pattern('foo')
     assert ret == 4
     delete_mock.assert_called_once_with(args=['foo'])
 
 
-def test_delete_cache_keys_returns_zero_when_redis_disabled(mocked_redis_client, delete_mock):
+def test_delete_cache_keys_by_pattern_returns_zero_when_redis_disabled(mocked_redis_client, delete_mock):
     mocked_redis_client.active = False
     ret = mocked_redis_client.delete_cache_keys_by_pattern('foo')
 


### PR DESCRIPTION
Requesting a pull to alphagov:master from alphagov:consistent-delete-handling-180663519

Write a message for this pull request. The first block
of text is the title and the rest is the description.

Changes:

51584b3 (Ben Thorner, 2 minutes ago)
   Shorten name of delete function to promote reuse

   This will need to be updated in Admin - the only consumer of this function.

718b445 (Ben Thorner, 41 minutes ago)
   Unify behaviour of Redis delete functions

   Previously the main "delete" function would just log exceptions, whereas
   the -by-pattern version would let them bubble up. This is surprising and we
   think it's an oversight when -by-pattern was introduced [1]. In particular,
   if Redis goes down any usages of this method will lead to 500s, unlike all
   the others.

   We debated which behaviour is better:

   - Letting errors propagate will help prevent any updates while Redis is
   down, which means the data in it is still valid when it returns. This
   prevents a message being sent with a stale template [2].

   - Logging errors means users can continue using Notify transparently to the
   outage, which is important for things like broadcasts. It does mean we need
   to rush to clear the cache when it returns.

   For the time being, we think it's worth at least making the behaviour
   consistent, so here we go with the majority (log only).

   [1]:
   https://github.com/alphagov/notifications-utils/commit/8cb43fc145c70e0ba838b8bedfdc20538b0cccc2
   [2]:
   https://github.com/alphagov/notifications-admin/commit/01a3df6edce08e3cf0cca42b60dcf95127155497#diff-9a4bee453dcac10f7fa51a00a0f5e25db3947c68bacbc898c9d0f7bad00109c7R216

ea05e7f (Ben Thorner, 48 minutes ago)
   Rename tests to start with function under test

   This is consistent with the majority of tests we write and makes it easier
   to spot tests for a given function.

3d0a39a (Ben Thorner, 49 minutes ago)
   DRY-up and add missing tests for inactive Redis

   Previously the "active" flag wasn't tested for "incr" or "delete".

c4e747a (Ben Thorner, 55 minutes ago)
   DRY-up setup for redis client with exceptions

ae19bf7 (Ben Thorner, 67 minutes ago)
   Standardise tests to use mocked_redis_client

   This is shorter and will make it easier to adapt the tests after unifying
   the two delete methods.

a05eb90 (Ben Thorner, 87 minutes ago)
   Move scripts mock into general Redis client setup

   This will make it easier to unify the two kinds of delete function.

79969ec (Ben Thorner, 2 hours ago)
   Remove redundant "build" test helper function

   This is only used once. Using it directly in the fixture will make it
   easier to add further fixture dependencies.