### PR TITLE
Standardise behaviour of Redis "delete" functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 55.0.0
+
+* Shortened "delete_cache_keys_by_pattern" to "delete_by_pattern".
+* "delete_by_pattern" has a new "raise_exception" parameter (default False).
+
 ## 54.1.0
 
 * Add should_validate flag to `notifications_utils.recipients.RecipientCSV`. Defaults to `True`.

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -62,7 +62,7 @@ class RedisClient:
             """
         )
 
-    def delete_cache_keys_by_pattern(self, pattern):
+    def delete_cache_keys_by_pattern(self, pattern, raise_exception=False):
         r"""
         Deletes all keys matching a given pattern, and returns how many keys were deleted.
         Pattern is defined as in the KEYS command: https://redis.io/commands/keys
@@ -76,7 +76,11 @@ class RedisClient:
         Use \ to escape special characters if you want to match them verbatim
         """
         if self.active:
-            return self.scripts['delete-keys-by-pattern'](args=[pattern])
+            try:
+                return self.scripts['delete-keys-by-pattern'](args=[pattern])
+            except Exception as e:
+                self.__handle_exception(e, raise_exception, 'delete-by-pattern', pattern)
+
         return 0
 
     def exceeded_rate_limit(self, cache_key, limit, interval, raise_exception=False):

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -62,7 +62,7 @@ class RedisClient:
             """
         )
 
-    def delete_cache_keys_by_pattern(self, pattern, raise_exception=False):
+    def delete_by_pattern(self, pattern, raise_exception=False):
         r"""
         Deletes all keys matching a given pattern, and returns how many keys were deleted.
         Pattern is defined as in the KEYS command: https://redis.io/commands/keys

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '54.1.0'  # abd46212abb7ba9624b0cae73ef0984b
+__version__ = '55.0.0'  # 5568605a0a138ed2231ae2ae2a13beae

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -23,21 +23,23 @@ def mocked_redis_pipeline():
 @pytest.fixture(scope='function')
 def mocked_redis_client(app, mocked_redis_pipeline, mocker):
     app.config['REDIS_ENABLED'] = True
-    return build_redis_client(app, mocked_redis_pipeline, mocker)
 
-
-def build_redis_client(app, mocked_redis_pipeline, mocker):
     redis_client = RedisClient()
     redis_client.init_app(app)
+
     mocker.patch.object(redis_client.redis_store, 'get', return_value=100)
     mocker.patch.object(redis_client.redis_store, 'set')
     mocker.patch.object(redis_client.redis_store, 'hincrby')
-    mocker.patch.object(redis_client.redis_store, 'hgetall',
-                        return_value={b'template-1111': b'8', b'template-2222': b'8'})
     mocker.patch.object(redis_client.redis_store, 'hmset')
     mocker.patch.object(redis_client.redis_store, 'expire')
     mocker.patch.object(redis_client.redis_store, 'delete')
     mocker.patch.object(redis_client.redis_store, 'pipeline', return_value=mocked_redis_pipeline)
+
+    mocker.patch.object(
+        redis_client.redis_store,
+        'hgetall',
+        return_value={b'template-1111': b'8', b'template-2222': b'8'}
+    )
 
     return redis_client
 

--- a/tests/test_redis_client.py
+++ b/tests/test_redis_client.py
@@ -78,7 +78,7 @@ def test_should_not_raise_exception_if_raise_set_to_false(
     assert failing_redis_client.exceeded_rate_limit('rate_limit_key', 100, 100) is False
     assert failing_redis_client.delete('delete_key') is None
     assert failing_redis_client.delete('a', 'b', 'c') is None
-    assert failing_redis_client.delete_cache_keys_by_pattern('pattern') == 0
+    assert failing_redis_client.delete_by_pattern('pattern') == 0
 
     assert mock_logger.mock_calls == [
         call.exception('Redis error performing get on get_key'),
@@ -116,7 +116,7 @@ def test_should_raise_exception_if_raise_set_to_true(
     assert str(e.value) == 'delete failed'
 
     with pytest.raises(Exception) as e:
-        failing_redis_client.delete_cache_keys_by_pattern('pattern', raise_exception=True)
+        failing_redis_client.delete_by_pattern('pattern', raise_exception=True)
     assert str(e.value) == 'delete by pattern failed'
 
 
@@ -128,7 +128,7 @@ def test_should_not_call_if_not_enabled(mocked_redis_client, delete_mock):
     assert mocked_redis_client.incr('incr_key') is None
     assert mocked_redis_client.exceeded_rate_limit('rate_limit_key', 100, 100) is False
     assert mocked_redis_client.delete('delete_key') is None
-    assert mocked_redis_client.delete_cache_keys_by_pattern('pattern') == 0
+    assert mocked_redis_client.delete_by_pattern('pattern') == 0
 
     mocked_redis_client.redis_store.get.assert_not_called()
     mocked_redis_client.redis_store.set.assert_not_called()
@@ -217,7 +217,7 @@ def test_prepare_value(input, output):
     assert prepare_value(input) == output
 
 
-def test_delete_cache_keys_by_pattern(mocked_redis_client, delete_mock):
-    ret = mocked_redis_client.delete_cache_keys_by_pattern('foo')
+def test_delete_by_pattern(mocked_redis_client, delete_mock):
+    ret = mocked_redis_client.delete_by_pattern('foo')
     assert ret == 4
     delete_mock.assert_called_once_with(args=['foo'])


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180663519

This renames the "delete_cache_keys_by_pattern" function
and makes it behave the same as all the other functions:
exceptions are caught and logged by default.

There are pros and cons to ignoring Redis errors:

- Users get a better experience (fallback to the DB).
- Redis may end up with stale data (due to updates).

At the moment we're not sure which is better, but we can
at least be consistent. The new "raise_exception" parameter
also means we can override the default behaviour.

Please review commit by commit, as there are quite a few
refactoring steps to support the change.