### PR TITLE
Bump shapely to 1.8.0 to support geos on Mac M1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 55.1.1
+
+* Bump shapely to 1.8.0 to support Mac M1 installation of geos.
+
 ## 55.1.0
 
 * Added "delete_by_pattern" wrapper to RequestCache decorator group.

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '55.1.0'  # aaa1b86c488c4e25c842f0a443f9a26b
+__version__ = '55.1.1'  # 5de5f188bd7e19af1043b6ad8d0a3f56

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'itsdangerous>=1.1.0',
         'govuk-bank-holidays>=0.10',
         'geojson>=2.5.0',
-        'Shapely>=1.7.1',
+        'Shapely>=1.8.0',
 
         # required by both api and admin
         'awscli',


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181498273

This fixes:

      OSError: Could not find lib geos_c or load any of its variants ['/Library/Frameworks/GEOS.framework/Versions/Current/GEOS', '/opt/local/lib/libgeos_c.dylib', '/usr/local/lib/libgeos_c.dylib'].

Relevant line in CHANGES.txt [^1]:

      - Add /opt/homebrew/lib to the list of directories to be searched for the GEOS shared library.

Other changes are (apparently) just bug fixes and new features. I
didn't see any deprecation warnings when running the tests.

[^1]: https://github.com/shapely/shapely/blob/main/CHANGES.txt