### PR TITLE
Remove use of OrderedDict

### DIFF
--- a/notifications_utils/insensitive_dict.py
+++ b/notifications_utils/insensitive_dict.py
@@ -1,10 +1,9 @@
-from collections import OrderedDict
 from functools import lru_cache
 
 from orderedset import OrderedSet
 
 
-class InsensitiveDict(OrderedDict):
+class InsensitiveDict(dict):
 
     """
     `InsensitiveDict` behaves like an ordered dictionary, except it normalises
@@ -32,7 +31,7 @@ class InsensitiveDict(OrderedDict):
         - it stores the original, unnormalised key as the value of the
           item so it can be retrieved later
         """
-        return cls(OrderedDict([(key, key) for key in keys]))
+        return cls({key: key for key in keys})
 
     def keys(self):
         return OrderedSet(super().keys())

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -1,7 +1,7 @@
 import csv
 import re
 import sys
-from collections import OrderedDict, namedtuple
+from collections import namedtuple
 from contextlib import suppress
 from functools import lru_cache
 from io import StringIO
@@ -176,7 +176,7 @@ class RecipientCSV():
                 yield None
                 continue
 
-            output_dict = OrderedDict()
+            output_dict = {}
 
             for column_name, column_value in zip(column_headers, row):
 
@@ -389,10 +389,10 @@ class Row(InsensitiveDict):
                 self.message_too_long = template.is_message_too_long()
             self.message_empty = template.is_message_empty()
 
-        super().__init__(OrderedDict(
-            (key, Cell(key, value, error_fn, self.placeholders))
+        super().__init__({
+            key: Cell(key, value, error_fn, self.placeholders)
             for key, value in row_dict.items()
-        ))
+        })
 
     def __getitem__(self, key):
         return super().__getitem__(key) if key in self else Cell()

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '55.1.4'  # 1562bc67ae238b193c291c25d7cf6bf8
+__version__ = '55.1.5'  # e3dbf8855950d01cb65333b31fc9e5a5

--- a/tests/test_insensitive_dict.py
+++ b/tests/test_insensitive_dict.py
@@ -73,3 +73,14 @@ def test_set_item(key_in, lookup_key):
     columns = InsensitiveDict({})
     columns[key_in] = 'bar'
     assert columns[lookup_key] == 'bar'
+
+
+def test_maintains_insertion_order():
+    d = InsensitiveDict({
+        'B': None,
+        'A': None,
+        'C': None,
+    })
+    assert d.keys() == ['b', 'a', 'c']
+    d['BB'] = None
+    assert d.keys() == ['b', 'a', 'c', 'bb']


### PR DESCRIPTION
Dicts became insertion-ordered in Python 3.6. This behaviour was considered ‘guaranteed’ in Python 3.7<sup>1</sup>. At the moment we use Python 3.9 in production.

This means we no-longer need `OrderedDict` as an extra import.

---

1. https://mail.python.org/pipermail/python-dev/2017-December/151283.html