### PR TITLE
Unpin pyproj

### DIFF
--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '55.1.1'  # 5de5f188bd7e19af1043b6ad8d0a3f56
+__version__ = '55.1.2'  # a211fdab928691f6860b8d49d96b87f7

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,14 +1,14 @@
 -r requirements.txt
 
-celery==5.2.5
+celery==5.2.6
 beautifulsoup4==4.10.0
-pytest==7.1.0
+pytest==7.1.1
 pytest-mock==3.7.0
 pytest-xdist==2.5.0
 requests-mock==1.9.3
 freezegun==1.2.1
 flake8==4.0.1
-flake8-bugbear==22.1.11
+flake8-bugbear==22.3.23
 flake8-print==4.0.0
 pytest-profiling==1.7.0
 snakeviz==2.1.1

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'Flask-Redis>=0.4.0',
         'pyyaml>=5.3.1',
         'phonenumbers>=8.12.13',
-        'pyproj==3.2.1',
+        'pyproj>=3.2.1',
         'pytz>=2020.4',
         'smartypants==2.0.1',
         'pypdf2>=1.26.0',


### PR DESCRIPTION
There's nothing in the latest version (3.3.0) that looks dangerous, so
by loosening the requirements here we can keep pyproj up to date in
notifications-admin.