### PR TITLE
Unpin most dependencies and remove redundant ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 55.1.3
+
+* Unpin most dependencies and remove redundant ones (no action required).
+
 ## 55.1.1
 
 * Bump shapely to 1.8.0 to support Mac M1 installation of geos.

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '55.1.2'  # a211fdab928691f6860b8d49d96b87f7
+__version__ = '55.1.3'  # 7d6f2f5b33723b0a0aeccd0a64f2a1be

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         'bleach>=4.1.0',
         'cachetools>=4.1.1',
-        'mistune==0.8.4',
+        'mistune>=0.8.4',
         'requests>=2.25.0',
         'python-json-logger>=2.0.1',
         'Flask>=1.1.1',
@@ -37,15 +37,11 @@ setup(
         'phonenumbers>=8.12.13',
         'pyproj>=3.2.1',
         'pytz>=2020.4',
-        'smartypants==2.0.1',
+        'smartypants>=2.0.1',
         'pypdf2>=1.26.0',
         'itsdangerous>=1.1.0',
         'govuk-bank-holidays>=0.10',
         'geojson>=2.5.0',
         'Shapely>=1.8.0',
-
-        # required by both api and admin
-        'awscli',
-        'boto3',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,6 @@ setup(
         'govuk-bank-holidays>=0.10',
         'geojson>=2.5.0',
         'Shapely>=1.8.0',
+        'boto3>=1.21.36',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         'bleach>=4.1.0',
         'cachetools>=4.1.1',
-        'mistune==0.8.4',  # next version is v2, which is totally different
+        'mistune<2.0.0',  # v2 is totally incompatible with unclear benefit
         'requests>=2.25.0',
         'python-json-logger>=2.0.1',
         'Flask>=1.1.1',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         'bleach>=4.1.0',
         'cachetools>=4.1.1',
-        'mistune>=0.8.4',
+        'mistune==0.8.4',  # next version is v2, which is totally different
         'requests>=2.25.0',
         'python-json-logger>=2.0.1',
         'Flask>=1.1.1',


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181588331

We decided we prefer to use unpinned dependencies in this repo [^1]
so this makes all of them consistent.

I've also removed two dependencies which were added in response to
PyUp generating to many update PRs [^2]. Since we now have a strategy
I think we should put them back and solve the issue more explicitly
in the apps that need them.

[^1]: https://docs.google.com/document/d/1DO6nFV9E7Qr94_NnUfYsMKFrKTvcjn0ESjjDHodfQUk/edit#heading=h.pohfahyz07ro
[^2]: https://github.com/alphagov/notifications-utils/commit/d0fa02026d525ea537785b91255db182b01e6caf