### PR TITLE
Lower minimum version of boto3 dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 55.1.4
+
+* Downgrade min version of boto3 due to incompatibility with awscli-cwlogs dependency.
+
 ## 55.1.3
 
 * Unpin most dependencies and remove redundant ones (no action required).

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '55.1.3'  # 7d6f2f5b33723b0a0aeccd0a64f2a1be
+__version__ = '55.1.4'  # 1562bc67ae238b193c291c25d7cf6bf8

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(
         'govuk-bank-holidays>=0.10',
         'geojson>=2.5.0',
         'Shapely>=1.8.0',
-        'boto3>=1.21.36',
+        'boto3>=1.19.4',
     ]
 )


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181588331

Requiring a higher version leads to an error e.g. in API

    There are incompatible versions in the resolved dependencies:
      botocore<1.25.0,>=1.24.38 (from boto3==1.21.38->notifications-utils@ git+https://github.com/alphagov/notifications-utils.git@55.1.3->-r requirements.in (line 34))
      botocore==1.22.4 (from awscli==1.21.4->awscli-cwlogs==1.4.6->-r requirements.in (line 32))

There are no newer versions of awscli-cwlogs so for now we need to
accommodate the lower version of botocore it requires, which we can
with version 1.19.4 of boto3 [^1].

[^1]: https://github.com/boto/boto3/commit/a8ea399aff0adea0b09f0d2fda8a0b679fcc01f0#diff-fa602a8a75dc9dcc92261bac5f533c2a85e34fcceaff63b3a3a81d9acde2fc52R6