### PR TITLE
Make URL autolinking more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 55.2.0
+
+* Links in previews of text messages and emergency alerts now have the correct CSS
+  classes added automatically
+* URLs in previews of text messages and emergency alerts will now become links even
+  if they don’t have `http://` or `https://` at the start
+
 ## 55.1.7
 
 * Move some functions and variable from the `notifications_utils.formatters` module to

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -7,7 +7,10 @@ import mistune
 import smartypants
 from markupsafe import Markup
 
-from notifications_utils.markdown import create_sanitised_html_for_url
+from notifications_utils.markdown import (
+    LINK_STYLE,
+    create_sanitised_html_for_url,
+)
 from notifications_utils.sanitise_text import SanitiseSMS
 
 from . import email_with_smart_quotes_regex
@@ -50,6 +53,15 @@ HTML_ENTITY_MAPPING = (
 # The Mistune URL regex only matches URLs at the start of a string,
 # using `^`, so we slice that off and recompile
 url = re.compile(mistune.InlineGrammar.url.pattern[1:])
+url_with_optional_protocol = re.compile(
+    r'(?i)'  # case insensitive
+    r'(https?:\/\/)?'  # optional http:// or https://
+    r'([\w\-])+\.{1}'  # one or more (sub)domains
+    r'([a-z]{2,63})'  # top-level domain
+    r'([\/\w-]*)*\/?'  # path with optional trailing slash
+    r'\??([^#\n\r\<]*)?'  # optional query string
+    r'#?([^\n\r\<]*)'  # optional #fragment
+)
 
 more_than_two_newlines_in_a_row = re.compile(r'\n{3,}')
 
@@ -73,10 +85,23 @@ def add_prefix(body, prefix=None):
 
 
 def autolink_sms(body):
-    return url.sub(
-        lambda match: create_sanitised_html_for_url(match.group(1)),
-        body,
-    )
+    return autolink_urls(body, style=LINK_STYLE)
+
+
+def autolink_urls(value, *, protocol_optional=False, classes='', style=''):
+    if protocol_optional:
+        regex, match_group = url_with_optional_protocol, 0
+    else:
+        regex, match_group = url, 1
+
+    return Markup(regex.sub(
+        lambda match: create_sanitised_html_for_url(
+            match.group(match_group),
+            classes=classes,
+            style=style,
+        ),
+        value,
+    ))
 
 
 def prepend_subject(body, subject):

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -3,7 +3,6 @@ import string
 from html import _replace_charref, escape
 
 import bleach
-import mistune
 import smartypants
 from markupsafe import Markup
 
@@ -47,10 +46,7 @@ HTML_ENTITY_MAPPING = (
     ('&rpar;', "▶️🐦🥴"),
 )
 
-# The Mistune URL regex only matches URLs at the start of a string,
-# using `^`, so we slice that off and recompile
-url = re.compile(mistune.InlineGrammar.url.pattern[1:])
-url_with_optional_protocol = re.compile(
+url = re.compile(
     r'(?i)'  # case insensitive
     r'(https?:\/\/)?'  # optional http:// or https://
     r'([\w\-])+\.{1}'  # one or more (sub)domains
@@ -81,15 +77,10 @@ def add_prefix(body, prefix=None):
     return body
 
 
-def autolink_urls(value, *, protocol_optional=False, classes=''):
-    if protocol_optional:
-        regex, match_group = url_with_optional_protocol, 0
-    else:
-        regex, match_group = url, 1
-
-    return Markup(regex.sub(
+def autolink_urls(value, *, classes=''):
+    return Markup(url.sub(
         lambda match: create_sanitised_html_for_url(
-            match.group(match_group),
+            match.group(0),
             classes=classes,
         ),
         value,

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -7,10 +7,7 @@ import mistune
 import smartypants
 from markupsafe import Markup
 
-from notifications_utils.markdown import (
-    LINK_STYLE,
-    create_sanitised_html_for_url,
-)
+from notifications_utils.markdown import create_sanitised_html_for_url
 from notifications_utils.sanitise_text import SanitiseSMS
 
 from . import email_with_smart_quotes_regex
@@ -82,10 +79,6 @@ def add_prefix(body, prefix=None):
     if prefix:
         return "{}: {}".format(prefix.strip(), body)
     return body
-
-
-def autolink_sms(body):
-    return autolink_urls(body, style=LINK_STYLE)
 
 
 def autolink_urls(value, *, protocol_optional=False, classes='', style=''):

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -81,7 +81,7 @@ def add_prefix(body, prefix=None):
     return body
 
 
-def autolink_urls(value, *, protocol_optional=False, classes='', style=''):
+def autolink_urls(value, *, protocol_optional=False, classes=''):
     if protocol_optional:
         regex, match_group = url_with_optional_protocol, 0
     else:
@@ -91,7 +91,6 @@ def autolink_urls(value, *, protocol_optional=False, classes='', style=''):
         lambda match: create_sanitised_html_for_url(
             match.group(match_group),
             classes=classes,
-            style=style,
         ),
         value,
     ))

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -1,11 +1,11 @@
 import re
-import urllib
 from itertools import count
 
 import mistune
 from orderedset import OrderedSet
 
 from notifications_utils import MAGIC_SEQUENCE, magic_sequence_regex
+from notifications_utils.formatters import create_sanitised_html_for_url
 
 LINK_STYLE = 'word-wrap: break-word; color: #1D70B8;'
 
@@ -50,33 +50,6 @@ mistune.InlineLexer.inline_html_rules = list(
         'code',
     ))
 )
-
-
-def create_sanitised_html_for_url(link, *, classes='', style=''):
-    """
-    takes a link and returns an a tag to that link.  does the quote/unquote dance to ensure that " quotes are escaped
-    correctly to prevent xss
-
-    input: `http://foo.com/"bar"?x=1#2`
-    output: `<a style=... href="http://foo.com/%22bar%22?x=1#2">http://foo.com/"bar"?x=1#2</a>`
-    """
-    link_text = link
-
-    if not link.lower().startswith('http'):
-        link = f'http://{link}'
-
-    class_attribute = f'class="{classes}" ' if classes else ''
-    style_attribute = f'style="{style}" ' if style else ''
-
-    return '<a {}{}href="{}">{}</a>'.format(
-        class_attribute,
-        style_attribute,
-        urllib.parse.quote(
-            urllib.parse.unquote(link),
-            safe=':/?#=&;'
-        ),
-        link_text,
-    )
 
 
 class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -52,7 +52,7 @@ mistune.InlineLexer.inline_html_rules = list(
 )
 
 
-def create_sanitised_html_for_url(link):
+def create_sanitised_html_for_url(link, *, classes='', style=''):
     """
     takes a link and returns an a tag to that link.  does the quote/unquote dance to ensure that " quotes are escaped
     correctly to prevent xss
@@ -60,13 +60,22 @@ def create_sanitised_html_for_url(link):
     input: `http://foo.com/"bar"?x=1#2`
     output: `<a style=... href="http://foo.com/%22bar%22?x=1#2">http://foo.com/"bar"?x=1#2</a>`
     """
-    return '<a style="{}" href="{}">{}</a>'.format(
-        LINK_STYLE,
+    link_text = link
+
+    if not link.lower().startswith('http'):
+        link = f'http://{link}'
+
+    class_attribute = f'class="{classes}" ' if classes else ''
+    style_attribute = f'style="{style}" ' if style else ''
+
+    return '<a {}{}href="{}">{}</a>'.format(
+        class_attribute,
+        style_attribute,
         urllib.parse.quote(
             urllib.parse.unquote(link),
             safe=':/?#=&;'
         ),
-        link
+        link_text,
     )
 
 
@@ -217,7 +226,7 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
     def autolink(self, link, is_email=False):
         if is_email:
             return link
-        return create_sanitised_html_for_url(link)
+        return create_sanitised_html_for_url(link, style=LINK_STYLE)
 
 
 class NotifyPlainTextEmailMarkdownRenderer(NotifyEmailMarkdownRenderer):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -370,6 +370,7 @@ class SMSPreviewTemplate(BaseSMSTemplate):
             ).then(
                 autolink_urls,
                 classes="govuk-link govuk-link--no-visited-state",
+                protocol_optional=True,
             )
         }))
 

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -37,7 +37,6 @@ from notifications_utils.formatters import (
 )
 from notifications_utils.insensitive_dict import InsensitiveDict
 from notifications_utils.markdown import (
-    LINK_STYLE,
     notify_email_markdown,
     notify_email_preheader_markdown,
     notify_letter_preview_markdown,
@@ -369,7 +368,8 @@ class SMSPreviewTemplate(BaseSMSTemplate):
             ).then(
                 nl2br
             ).then(
-                autolink_urls, style=LINK_STYLE
+                autolink_urls,
+                style='word-wrap: break-word;',
             )
         }))
 

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -370,7 +370,6 @@ class SMSPreviewTemplate(BaseSMSTemplate):
             ).then(
                 autolink_urls,
                 classes="govuk-link govuk-link--no-visited-state",
-                protocol_optional=True,
             )
         }))
 

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -18,7 +18,7 @@ from notifications_utils.field import Field, PlainTextField
 from notifications_utils.formatters import (
     add_prefix,
     add_trailing_newline,
-    autolink_sms,
+    autolink_urls,
     escape_html,
     formatted_list,
     make_quotes_smart,
@@ -37,6 +37,7 @@ from notifications_utils.formatters import (
 )
 from notifications_utils.insensitive_dict import InsensitiveDict
 from notifications_utils.markdown import (
+    LINK_STYLE,
     notify_email_markdown,
     notify_email_preheader_markdown,
     notify_letter_preview_markdown,
@@ -368,7 +369,7 @@ class SMSPreviewTemplate(BaseSMSTemplate):
             ).then(
                 nl2br
             ).then(
-                autolink_sms
+                autolink_urls, style=LINK_STYLE
             )
         }))
 

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -369,7 +369,7 @@ class SMSPreviewTemplate(BaseSMSTemplate):
                 nl2br
             ).then(
                 autolink_urls,
-                style='word-wrap: break-word;',
+                classes="govuk-link govuk-link--no-visited-state",
             )
         }))
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '55.1.7'  # 295e875afb45f75e06a06f1328f1af73
+__version__ = '55.2.0'  # f38cabf9feb09279caa4f3ad70d250c4

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -384,13 +384,6 @@ def test_normalise_whitespace(value):
     (
         "example.com",
         {},
-        'example.com',
-    ),
-    (
-        "example.com",
-        {
-            'protocol_optional': True,
-        },
         '<a href="http://example.com">example.com</a>',
     ),
 ))

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -28,11 +28,11 @@ from notifications_utils.template import (
     "url, expected_html", [
         (
             """https://example.com"onclick="alert('hi')""",
-            """<a class="govuk-link govuk-link--no-visited-state" href="https://example.com%22onclick=%22alert%28%27hi">https://example.com"onclick="alert('hi</a>')""",  # noqa
+            """<a class="govuk-link govuk-link--no-visited-state" href="https://example.com%22onclick=%22alert%28%27hi%27%29">https://example.com"onclick="alert('hi')</a>""",  # noqa
         ),
         (
             """https://example.com"style='text-decoration:blink'""",
-            """<a class="govuk-link govuk-link--no-visited-state" href="https://example.com%22style=%27text-decoration:blink">https://example.com"style='text-decoration:blink</a>'""",  # noqa
+            """<a class="govuk-link govuk-link--no-visited-state" href="https://example.com%22style=%27text-decoration:blink%27">https://example.com"style='text-decoration:blink'</a>""",  # noqa
         ),
     ]
 )

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -2,6 +2,7 @@ import pytest
 from markupsafe import Markup
 
 from notifications_utils.formatters import (
+    autolink_urls,
     escape_html,
     formatted_list,
     make_quotes_smart,
@@ -365,3 +366,56 @@ def test_strip_unsupported_characters():
 ])
 def test_normalise_whitespace(value):
     assert normalise_whitespace(value) == 'Your tax is due'
+
+
+@pytest.mark.parametrize("content, extra_kwargs, expected_html", (
+    (
+        "http://example.com",
+        {},
+        '<a href="http://example.com">http://example.com</a>',
+    ),
+    (
+        "http://example.com",
+        {
+            'style': 'text-decoration: blink',
+        },
+        '<a style="text-decoration: blink" href="http://example.com">http://example.com</a>',
+    ),
+    (
+        "http://example.com",
+        {
+            'classes': 'govuk-link',
+        },
+        '<a class="govuk-link" href="http://example.com">http://example.com</a>',
+    ),
+    (
+        "http://example.com",
+        {
+            'classes': 'govuk-link',
+            'style': 'text-decoration: blink',
+        },
+        '<a class="govuk-link" style="text-decoration: blink" href="http://example.com">http://example.com</a>',
+    ),
+    (
+        "example.com",
+        {},
+        'example.com',
+    ),
+    (
+        "example.com",
+        {
+            'protocol_optional': True,
+        },
+        '<a href="http://example.com">example.com</a>',
+    ),
+))
+def test_autolink_urls(content, extra_kwargs, expected_html):
+    assert autolink_urls(content, **extra_kwargs) == expected_html
+
+
+@pytest.mark.parametrize('content', (
+    'without link',
+    'with link to https://example.com'
+))
+def test_autolink_urls_returns_markup(content):
+    assert isinstance(autolink_urls(content), Markup)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -28,11 +28,11 @@ from notifications_utils.template import (
     "url, expected_html", [
         (
             """https://example.com"onclick="alert('hi')""",
-            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22onclick=%22alert%28%27hi">https://example.com"onclick="alert('hi</a>')""",  # noqa
+            """<a style="word-wrap: break-word;" href="https://example.com%22onclick=%22alert%28%27hi">https://example.com"onclick="alert('hi</a>')""",  # noqa
         ),
         (
             """https://example.com"style='text-decoration:blink'""",
-            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22style=%27text-decoration:blink">https://example.com"style='text-decoration:blink</a>'""",  # noqa
+            """<a style="word-wrap: break-word;" href="https://example.com%22style=%27text-decoration:blink">https://example.com"style='text-decoration:blink</a>'""",  # noqa
         ),
     ]
 )

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -28,11 +28,11 @@ from notifications_utils.template import (
     "url, expected_html", [
         (
             """https://example.com"onclick="alert('hi')""",
-            """<a style="word-wrap: break-word;" href="https://example.com%22onclick=%22alert%28%27hi">https://example.com"onclick="alert('hi</a>')""",  # noqa
+            """<a class="govuk-link govuk-link--no-visited-state" href="https://example.com%22onclick=%22alert%28%27hi">https://example.com"onclick="alert('hi</a>')""",  # noqa
         ),
         (
             """https://example.com"style='text-decoration:blink'""",
-            """<a style="word-wrap: break-word;" href="https://example.com%22style=%27text-decoration:blink">https://example.com"style='text-decoration:blink</a>'""",  # noqa
+            """<a class="govuk-link govuk-link--no-visited-state" href="https://example.com%22style=%27text-decoration:blink">https://example.com"style='text-decoration:blink</a>'""",  # noqa
         ),
     ]
 )
@@ -377,24 +377,9 @@ def test_normalise_whitespace(value):
     (
         "http://example.com",
         {
-            'style': 'text-decoration: blink',
-        },
-        '<a style="text-decoration: blink" href="http://example.com">http://example.com</a>',
-    ),
-    (
-        "http://example.com",
-        {
             'classes': 'govuk-link',
         },
         '<a class="govuk-link" href="http://example.com">http://example.com</a>',
-    ),
-    (
-        "http://example.com",
-        {
-            'classes': 'govuk-link',
-            'style': 'text-decoration: blink',
-        },
-        '<a class="govuk-link" style="text-decoration: blink" href="http://example.com">http://example.com</a>',
     ),
     (
         "example.com",

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -402,12 +402,12 @@ def test_markdown_in_templates(
 
 
 @pytest.mark.parametrize(
-    'template_class, template_type', [
-        (HTMLEmailTemplate, 'email'),
-        (EmailPreviewTemplate, 'email'),
-        (SMSPreviewTemplate, 'sms'),
-        (BroadcastPreviewTemplate, 'broadcast'),
-        pytest.param(SMSBodyPreviewTemplate, 'sms', marks=pytest.mark.xfail),
+    'template_class, template_type, extra_attributes', [
+        (HTMLEmailTemplate, 'email', 'style="word-wrap: break-word; color: #1D70B8;"'),
+        (EmailPreviewTemplate, 'email', 'style="word-wrap: break-word; color: #1D70B8;"'),
+        (SMSPreviewTemplate, 'sms', 'style="word-wrap: break-word;"'),
+        (BroadcastPreviewTemplate, 'broadcast', 'style="word-wrap: break-word;"'),
+        pytest.param(SMSBodyPreviewTemplate, 'sms', 'style="word-wrap: break-word;', marks=pytest.mark.xfail),
     ]
 )
 @pytest.mark.parametrize(
@@ -431,9 +431,9 @@ def test_markdown_in_templates(
         pytest.param("mailto:test@example.com", "mailto:test@example.com", marks=pytest.mark.xfail),
     ]
 )
-def test_makes_links_out_of_URLs(template_class, template_type, url, url_with_entities_replaced):
-    assert '<a style="word-wrap: break-word; color: #1D70B8;" href="{}">{}</a>'.format(
-        url_with_entities_replaced, url_with_entities_replaced
+def test_makes_links_out_of_URLs(extra_attributes, template_class, template_type, url, url_with_entities_replaced):
+    assert '<a {} href="{}">{}</a>'.format(
+        extra_attributes, url_with_entities_replaced, url_with_entities_replaced
     ) in str(template_class({'content': url, 'subject': '', 'template_type': template_type}))
 
 

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -437,6 +437,35 @@ def test_makes_links_out_of_URLs(extra_attributes, template_class, template_type
     ) in str(template_class({'content': url, 'subject': '', 'template_type': template_type}))
 
 
+@pytest.mark.parametrize('template_class, template_type', (
+    (SMSPreviewTemplate, 'sms'),
+    (BroadcastPreviewTemplate, 'broadcast'),
+))
+@pytest.mark.parametrize("url, url_with_entities_replaced", (
+    ("example.com", "example.com"),
+    ("www.gov.uk/", "www.gov.uk/"),
+    ("service.gov.uk", "service.gov.uk"),
+    ("gov.uk/coronavirus", "gov.uk/coronavirus"),
+    (
+        "service.gov.uk/blah.ext?q=a%20b%20c&order=desc#fragment",
+        "service.gov.uk/blah.ext?q=a%20b%20c&amp;order=desc#fragment",
+    ),
+))
+def test_makes_links_out_of_URLs_without_protocol_in_sms_and_broadcast(
+    template_class,
+    template_type,
+    url,
+    url_with_entities_replaced,
+):
+    assert (
+        f'<a '
+        f'class="govuk-link govuk-link--no-visited-state" '
+        f'href="http://{url_with_entities_replaced}">'
+        f'{url_with_entities_replaced}'
+        f'</a>'
+    ) in str(template_class({'content': url, 'subject': '', 'template_type': template_type}))
+
+
 @pytest.mark.parametrize('content, html_snippet', (
     (
         (

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -405,8 +405,8 @@ def test_markdown_in_templates(
     'template_class, template_type, extra_attributes', [
         (HTMLEmailTemplate, 'email', 'style="word-wrap: break-word; color: #1D70B8;"'),
         (EmailPreviewTemplate, 'email', 'style="word-wrap: break-word; color: #1D70B8;"'),
-        (SMSPreviewTemplate, 'sms', 'style="word-wrap: break-word;"'),
-        (BroadcastPreviewTemplate, 'broadcast', 'style="word-wrap: break-word;"'),
+        (SMSPreviewTemplate, 'sms', 'class="govuk-link govuk-link--no-visited-state"'),
+        (BroadcastPreviewTemplate, 'broadcast', 'class="govuk-link govuk-link--no-visited-state"'),
         pytest.param(SMSBodyPreviewTemplate, 'sms', 'style="word-wrap: break-word;', marks=pytest.mark.xfail),
     ]
 )


### PR DESCRIPTION
So that we can reuse this in other places (specifically gov.uk/alerts) it needs to be a more bit flexible.

In short, this pull request makes it so that:
- `autolink_sms` is renamed to `autolink_urls`
- consumers of the `autolink_urls` function can specify which classes get applied to the `<a>` element, so that the link can be styled with CSS
- the `autolink_urls` function also picks up URLs which don’t start with `http://` or `https://`, to match what mobile phones do when showing text messages or emergency alerts
