### PR TITLE
Bump PyPDF2 to version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 56.0.0
+
+* Breaking: upgrade PyPDF2 to version 2.0.0. You will need to:
+
+  - Change error class imports from `pypdf2.utils` to `pypdf2.errors`.
+  - Run the tests and make changes based on the deprecation warnings.
+
 ## 55.2.0
 
 * Links in previews of text messages and emergency alerts now have the correct CSS

--- a/notifications_utils/pdf.py
+++ b/notifications_utils/pdf.py
@@ -1,8 +1,8 @@
 import io
 
 import PyPDF2
-from PyPDF2 import PdfFileWriter
-from PyPDF2.utils import PdfReadError
+from PyPDF2 import PdfWriter
+from PyPDF2.errors import PdfReadError
 
 from notifications_utils import LETTER_MAX_PAGE_COUNT
 
@@ -11,14 +11,14 @@ def pdf_page_count(src_pdf):
     """
     Returns number of pages in a pdf file
 
-    :param PyPDF2.PdfFileReader src_pdf: A File object or an object that supports the standard read and seek methods
+    :param PyPDF2.PdfReader src_pdf: A File object or an object that supports the standard read and seek methods
     """
     try:
-        pdf = PyPDF2.PdfFileReader(src_pdf)
+        pdf = PyPDF2.PdfReader(src_pdf)
     except AttributeError as e:
         raise PdfReadError("Could not open PDF file, stream is null", e)
 
-    return pdf.numPages
+    return len(pdf.pages)
 
 
 def is_letter_too_long(page_count):
@@ -38,16 +38,16 @@ def extract_page_from_pdf(src_pdf, page_number):
     :param src_pdf: File object or an object that supports the standard read and seek methods similar to a File object.
     :param page_number: The page number to retrieve (pages begin at zero)
     """
-    pdf = PyPDF2.PdfFileReader(src_pdf)
+    pdf = PyPDF2.PdfReader(src_pdf)
 
-    if pdf.numPages < page_number:
+    if len(pdf.pages) < page_number:
         raise PdfReadError("Page number requested: {} of {} does not exist in document".format(
             str(page_number),
-            str(pdf.numPages)
+            str(len(pdf.pages))
         ))
 
-    writer = PdfFileWriter()
-    writer.addPage(pdf.getPage(page_number))
+    writer = PdfWriter()
+    writer.add_page(pdf.pages[page_number])
 
     pdf_bytes = io.BytesIO()
     writer.write(pdf_bytes)

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '55.2.0'  # f38cabf9feb09279caa4f3ad70d250c4
+__version__ = '56.0.0'  # df3f02fc189b4182016e28d432322a2a

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'pyproj>=3.2.1',
         'pytz>=2020.4',
         'smartypants>=2.0.1',
-        'pypdf2>=1.27.5',
+        'pypdf2>=2.0.0',
         'itsdangerous>=1.1.0',
         'govuk-bank-holidays>=0.10',
         'geojson>=2.5.0',

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -3,7 +3,7 @@ from io import BytesIO
 
 import PyPDF2
 import pytest
-from PyPDF2.utils import PdfReadError
+from PyPDF2.errors import PdfReadError
 
 from notifications_utils.pdf import (
     extract_page_from_pdf,
@@ -47,23 +47,23 @@ def test_extract_page_from_pdf_one_page_pdf():
     file_data = base64.b64decode(one_page_pdf)
     pdf_page = extract_page_from_pdf(BytesIO(file_data), 0)
 
-    pdf_original = PyPDF2.PdfFileReader(BytesIO(file_data))
+    pdf_original = PyPDF2.PdfReader(BytesIO(file_data))
 
-    pdf_new = PyPDF2.PdfFileReader(BytesIO(pdf_page))
+    pdf_new = PyPDF2.PdfReader(BytesIO(pdf_page))
 
-    assert pdf_original.getPage(0).extractText() == pdf_new.getPage(0).extractText()
+    assert pdf_original.pages[0].extract_text() == pdf_new.pages[0].extract_text()
 
 
 def test_extract_page_from_pdf_multi_page_pdf():
     file_data = base64.b64decode(multi_page_pdf)
     pdf_page = extract_page_from_pdf(BytesIO(file_data), 4)
 
-    pdf_original = PyPDF2.PdfFileReader(BytesIO(file_data))
+    pdf_original = PyPDF2.PdfReader(BytesIO(file_data))
 
-    pdf_new = PyPDF2.PdfFileReader(BytesIO(pdf_page))
+    pdf_new = PyPDF2.PdfReader(BytesIO(pdf_page))
 
-    assert pdf_original.getPage(4).extractText() == pdf_new.getPage(0).extractText()
-    assert pdf_original.getPage(3).extractText() != pdf_new.getPage(0).extractText()
+    assert pdf_original.pages[4].extract_text() == pdf_new.pages[0].extract_text()
+    assert pdf_original.pages[3].extract_text() != pdf_new.pages[0].extract_text()
 
 
 def test_extract_page_from_pdf_request_page_out_of_bounds():


### PR DESCRIPTION
This is happening automatically with the rebuild of this library,
but we're seeing failures due to one of the breaking changes [^1].
I've also fixed all the deprecation warnings - the warnings contain
the alternate code to use in place of what we had.

I can't see any functionality changes in the changelog so I think
this is safe to distribute. I've locked the version to v2+ to ensure
all apps consistently pick it up in their requirements.

[^1]: https://raw.githubusercontent.com/py-pdf/PyPDF2/main/CHANGELOG