### PR TITLE
Fix auto linking domains in email addresses

### DIFF
--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -48,9 +48,11 @@ HTML_ENTITY_MAPPING = (
 
 url = re.compile(
     r'(?i)'  # case insensitive
+    r'\b(?<!\@)'  # match must not start with @ (like @example.com)
     r'(https?:\/\/)?'  # optional http:// or https://
     r'([\w\-]+\.{1})+'  # one or more (sub)domains
     r'([a-z]{2,63})'  # top-level domain
+    r'(?!\@)\b'  # match must not end with @ (like firstname.lastname@)
     r'([/\?#][^<\s]*)?'  # start of path, query or fragment
 )
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '56.0.0'  # df3f02fc189b4182016e28d432322a2a
+__version__ = '56.0.1'  # 8cfddd76a4928ec7574e1f8fcd33bba7

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -460,7 +460,11 @@ def test_normalise_whitespace(value):
     (
         'http://foo.com/"bar"?x=1#2',
         '<a href="http://foo.com/%22bar%22?x=1#2">http://foo.com/"bar"?x=1#2</a>',
-    )
+    ),
+    (
+        'firstname.lastname@example.com',
+        'firstname.lastname@example.com',
+    ),
 ))
 def test_autolink_urls_matches_correctly(content, expected_html):
     assert autolink_urls(content) == expected_html


### PR DESCRIPTION
Email addresses have two things which could be interpreted as URLs which should be made in to links:

1. the domain name itself, eg @example.com
2. the local part when it contains a dot, eg firstname.lastname

Either the whole email address should be linked or none of it should be linked. This commit preserves the previous behaviour where no part of the email address was linked.

It does this by modifying the regular expression using word boundaries (`\b`) and negative lookahead/lookbehinds to sniff out when something that might be a link starts or ends with an `@`, suggesting it is part of an email address.

Before | After
---|---
<img width="521" alt="image" src="https://user-images.githubusercontent.com/355079/175520353-4677d721-0219-4e1e-90ab-0a4cc03f2b4c.png"> | <img width="523" alt="image" src="https://user-images.githubusercontent.com/355079/175520480-8bb1ee8d-8a7c-4725-9135-bcf61e4fcaec.png">
