### PR TITLE
Fix parts of email addresses wrongly being linked

### DIFF
--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -48,7 +48,7 @@ HTML_ENTITY_MAPPING = (
 
 url = re.compile(
     r'(?i)'  # case insensitive
-    r'\b(?<!\@)'  # match must not start with @ (like @example.com)
+    r'\b(?<![\@\.])'  # match must not start with @ or . (like @test.example.com)
     r'(https?:\/\/)?'  # optional http:// or https://
     r'([\w\-]+\.{1})+'  # one or more (sub)domains
     r'([a-z]{2,63})'  # top-level domain

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '56.0.1'  # 8cfddd76a4928ec7574e1f8fcd33bba7
+__version__ = '56.0.2'  # cad27eb81394eb5b28ca4c9803f07d53

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -458,12 +458,20 @@ def test_normalise_whitespace(value):
         '<a href="http://gov.uk?foo&amp;">gov.uk?foo&amp;</a>',
     ),
     (
+        'a .service.gov.uk domain',
+        'a .service.gov.uk domain',
+    ),
+    (
         'http://foo.com/"bar"?x=1#2',
         '<a href="http://foo.com/%22bar%22?x=1#2">http://foo.com/"bar"?x=1#2</a>',
     ),
     (
         'firstname.lastname@example.com',
         'firstname.lastname@example.com',
+    ),
+    (
+        'with-subdomain@test.example.com',
+        'with-subdomain@test.example.com',
     ),
 ))
 def test_autolink_urls_matches_correctly(content, expected_html):


### PR DESCRIPTION
We fixed the domain name being linked in email addresses when the address was in the format `test@example.com`.

However when the address was in the format `test@test.example.com` `example.com` was still being made into a link because the `.` between `test` and `example` is seen as a word boundary.

This commit fixes that by adding `.` to the negative lookbehind. This means anything which looks like a URL but starts with `.` or `@` will not be made into a link.