### PR TITLE
Ampersand placeholder fix

### DIFF
--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -108,7 +108,7 @@ class Field:
 
     @values.setter
     def values(self, value):
-        self._values = InsensitiveDict(value) if value else {}
+        self._values = InsensitiveDict({self.sanitizer(k): value[k] for k in value}) if value else {}
 
     def format_match(self, match):
         return self.format_placeholder(Placeholder.from_match(match))

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -111,8 +111,9 @@ class Field:
         self._values = InsensitiveDict(value) if value else {}
 
     def format_match(self, match):
-        placeholder = Placeholder.from_match(match)
+        return self.format_placeholder(Placeholder.from_match(match))
 
+    def format_placeholder(self, placeholder):
         if self.redact_missing_personalisation:
             return self.placeholder_tag_redacted
 
@@ -131,7 +132,7 @@ class Field:
         replacement = self.get_replacement(placeholder)
 
         if replacement is None:
-            return self.format_match(match)
+            return self.format_placeholder(placeholder)
 
         if placeholder.is_conditional():
             return placeholder.get_conditional_body(replacement)

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -128,16 +128,15 @@ class Field:
 
     def replace_match(self, match):
         placeholder = Placeholder.from_match(match)
-        replacement = self.values.get(placeholder.name)
+        replacement = self.get_replacement(placeholder)
 
-        if placeholder.is_conditional() and replacement is not None:
+        if replacement is None:
+            return self.format_match(match)
+
+        if placeholder.is_conditional():
             return placeholder.get_conditional_body(replacement)
 
-        replaced_value = self.get_replacement(placeholder)
-        if replaced_value is not None:
-            return self.get_replacement(placeholder)
-
-        return self.format_match(match)
+        return replacement
 
     def get_replacement(self, placeholder):
         replacement = self.values.get(placeholder.name)

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -80,15 +80,15 @@ class Field:
         markdown_lists=False,
         redact_missing_personalisation=False,
     ):
+        self.sanitizer = {
+            'escape': escape_html,
+            'passthrough': str,
+        }[html]
         self.content = content
         self.values = values
         self.markdown_lists = markdown_lists
         if not with_brackets:
             self.placeholder_tag = self.placeholder_tag_no_brackets
-        self.sanitizer = {
-            'escape': escape_html,
-            'passthrough': str,
-        }[html]
         self.redact_missing_personalisation = redact_missing_personalisation
 
     def __str__(self):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '57.0.0'  # 72dbfa4fbbd779a50a862674ee0d0873
+__version__ = '57.0.1'  # 578d19dbd49ee204e0ef3f6828fb713d

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -116,6 +116,26 @@ def test_returns_a_string_without_placeholders(content):
             {"warning": False},
             ""
         ),
+        (
+            "Please report to the ((>location)) office at ((&time)) on ((<day)).",
+            {">location": "London", "&time": "09:00", "<day": "Monday"},
+            "Please report to the London office at 09:00 on Monday."
+        ),
+        (
+            "Please report to the ((&gt;location)) office at ((&amp;time)) on ((&lt;day)).",
+            {"&gt;location": "Manchester", "&amp;time": "08:00", "&lt;day": "Thursday"},
+            "Please report to the Manchester office at 08:00 on Thursday."
+        ),
+        (
+            "Dear ((\name)), your passport is now ready for collection from ((/collection_point)).",
+            {"\name": "Jane Doe", "/collection_point": "Point A"},
+            "Dear Jane Doe, your passport is now ready for collection from Point A."
+        ),
+        (
+            "Dear ((/\name)), your passport is now ready for collection from ((//collection_point)).",
+            {"/\name": "John Doe", "//collection_point": "Point B"},
+            "Dear John Doe, your passport is now ready for collection from Point B."
+        ),
     ]
 )
 def test_replacement_of_placeholders(template_content, data, expected):

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1779,6 +1779,21 @@ def test_templates_extract_placeholders(
     assert template_instance.placeholders == OrderedSet(expected_placeholders)
 
 
+def test_html_template_can_inject_personalisation_with_special_characters():
+    template_content = "This is something text with (( this&that )) HTML special character personalisation <>."
+    personalisation = {"this&that": "some very lovely &"}
+
+    result = str(
+        HTMLEmailTemplate(
+            {'content': template_content, 'subject': '', 'template_type': 'email'},
+            personalisation
+        )
+    )
+    assert (
+        "This is something text with some very lovely &amp; HTML special character personalisation &lt;&gt;." in result
+    )
+
+
 @pytest.mark.parametrize('extra_args', [
     {
         'from_name': 'Example service'


### PR DESCRIPTION
Presently the use of ampersands "&" in placeholders does not work as expected. This is because Jinja converts it to its special entity "&amp;". 

I have made adjustments to the Placeholder class so that this is done before hand.
