### PR TITLE
Change .visually-hidden class to .govuk-visually-hidden in letter image template

### DIFF
--- a/notifications_utils/jinja_templates/letter_image_template.jinja2
+++ b/notifications_utils/jinja_templates/letter_image_template.jinja2
@@ -9,7 +9,7 @@
   </div>
 {% endfor %}
 
-<div class="visually-hidden">
+<div class="govuk-visually-hidden">
   <h3>
     Recipient address
   </h3>

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '56.0.2'  # cad27eb81394eb5b28ca4c9803f07d53
+__version__ = '56.0.3'  # 149a7a20b681eeccda6fda65be37a3fb

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1002,7 +1002,7 @@ def test_letter_image_template_renders_visually_hidden_address():
         )),
         features='html.parser',
     )
-    assert str(template.select_one('.visually-hidden ul')) == (
+    assert str(template.select_one('.govuk-visually-hidden ul')) == (
         '<ul>'
         '<li>line 1</li>'
         '<li>line 2</li>'


### PR DESCRIPTION
This changes the letter_image_template.jinja template to use the `.govuk-visually-hidden` class instead of the `.visually-hidden` class. There is no difference in appearance, but we removed the styles for the `.visually-hidden` class in https://github.com/alphagov/notifications-admin/pull/4326 so can no longer use it.