### PR TITLE
Treat narrow no break space like non breaking space when normalising and sanitising 

### DIFF
--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -22,6 +22,7 @@ OBSCURE_ZERO_WIDTH_WHITESPACE = (
 
 OBSCURE_FULL_WIDTH_WHITESPACE = (
     '\u00A0'  # non breaking space
+    '\u202F'  # narrow no break space
 )
 
 ALL_WHITESPACE = string.whitespace + OBSCURE_ZERO_WIDTH_WHITESPACE + OBSCURE_FULL_WIDTH_WHITESPACE

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -19,6 +19,7 @@ class SanitiseText:
         '\u2060': '',  # word joiner
         '\uFEFF': '',  # zero width non-breaking space
         '\u00A0': ' ',  # NON BREAKING WHITE SPACE (U+200B)
+        '\u202F': ' ',  # narrow no break space
         '\t': ' ',  # TAB
     }
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '56.0.3'  # 149a7a20b681eeccda6fda65be37a3fb
+__version__ = '56.0.4'  # d8eb8a825b232bda9801fb01fc0f330f

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -359,6 +359,8 @@ def test_strip_unsupported_characters():
     '  Your tax is due  ',
     # Non breaking spaces replaced by single spaces
     '\u00A0Your\u00A0tax\u00A0 is\u00A0\u00A0due\u00A0',
+    # Narrow no break spaces replaced by single spaces
+    '\u202FYour\u202Ftax\u202F is\u202F\u202Fdue\u202F',
     # zero width spaces are removed
     '\u180EYour \u200Btax\u200C is \u200D\u2060due \uFEFF',
     # tabs are replaced by single spaces

--- a/tests/test_sanitise_text.py
+++ b/tests/test_sanitise_text.py
@@ -91,6 +91,7 @@ def test_encode_string(content, expected):
     ('Ŵêlsh chârâctêrs ârê cômpâtîblê wîth SanitiseSMS', SanitiseSMS, set()),
     ('Lots of GSM chars that arent ascii compatible:\n\r€', SanitiseSMS, set()),
     ('Lots of GSM chars that arent ascii compatible:\n\r€', SanitiseASCII, {'\n', '\r', '€'}),
+    ('Obscure\u00A0whitespace\u202Fcharacters which we normalise o\u180Eut', SanitiseSMS, set()),
 ])
 def test_sms_encoding_get_non_compatible_characters(content, cls, expected):
     assert cls.get_non_compatible_characters(content) == expected


### PR DESCRIPTION
This is a new whitespace character we didn’t know about. It appears to perform the same function as a non-breaking space (i.e. preventing a line break between words when used instead of a normal space).

If we don’t specifically account for it then it gets treated like any other unusual unicode character. This means when a user tries copies some text into their template which uses this character they see this error:

> 'You cannot use  in text messages. It will not show up properly on everyone's phones.'

…which is unhelpful because it’s not obvious that the space between ‘use’ and ‘in’ is what’s being referred to.

Only a change in `sanitise_text.py` is required to fix this, but it seems reasonable to change it in `formatters.py` too where we use a different method to normalise the same set of whitespace characters.