### PR TITLE
Stop mangling pre-escaped URL hrefs

### DIFF
--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = '57.1.0'  # 65ac448c9dd1cef13a61edebb78680f2
+__version__ = '57.1.1'  # d3b47e9343c8e3275f5e90696c05d3a1

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -95,6 +95,11 @@ def test_handles_placeholders_in_urls():
             """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22onclick=%22alert%28%27hi">https://example.com"onclick="alert('hi</a>‘)""",  # noqa
         ),
         (
+            """https://example.com/login?redirect=%2Fhomepage%3Fsuccess=true%26page=blue""",
+            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com/login?redirect=%2Fhomepage%3Fsuccess=true%26page=blue">https://example.com/login?redirect=%2Fhomepage%3Fsuccess=true%26page=blue</a>""",  # noqa
+            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com/login?redirect=%2Fhomepage%3Fsuccess=true%26page=blue">https://example.com/login?redirect=%2Fhomepage%3Fsuccess=true%26page=blue</a>""",  # noqa
+        ),
+        (
             """https://example.com"style='text-decoration:blink'""",
             """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22style=%27text-decoration:blink">https://example.com"style='text-decoration:blink</a>'""",  # noqa
             """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22style=%27text-decoration:blink">https://example.com"style='text-decoration:blink</a>’""",  # noqa


### PR DESCRIPTION
Our quote/unquote dance when trying to sanitise URLs going into the `href` attribute of `<a>` tags is destructive and can break the semantics of the URL we've been provided.

An example of this is when we receive a link with a redirect query parameter. This parameter is likely to already be URL encoded - turning eg `/` into %2F. When we quote then unquote this, we turn it into a native `/` which isn't what we originally received. When a recipient clicks this link, the server might not expect it to have been unencoded. Or, if we unencoded `&` (%26) values - these could fundamentally change what the URL means.