### PR TITLE
make HTMLEmailTemplate take brand_alt_text instead of brand_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 58.0.0
+
+* replace `brand_name` with `brand_alt_text` in HTMLEmailTemplate to more accurately reflect its purpose
+
 ## 57.1.0
 
 * Do not log to file when `NOTIFY_RUNTIME_PLATFORM` is set to `ecs`

--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -141,7 +141,7 @@
                     border="0"
                     style="display: block; border: 0;"
                     height="{% if brand_text -%} 27 {%- else -%} 54 {%- endif %}"
-                    alt="{% if brand_text %}{% else -%}{{ brand_name }}{%- endif %}"
+                    alt="{% if brand_text %}{% else -%}{{ brand_alt_text }}{%- endif %}"
                   />
                 </td>
               {% endif %}
@@ -199,7 +199,7 @@
                         <tr>
                           <td style="padding: 0 5px 0{% if brand_colour %} 7px; border-left: solid 2px {{ brand_colour }}{% else %} 0{% endif %}">
                             <img src="{{ brand_logo }}" style="display: block; border: 0" height="{% if brand_text -%} 27 {%- else -%} 54 {%- endif %}"
-                                 alt="{% if brand_text %}{% else -%}{{ brand_name }}{%- endif %}" />
+                                 alt="{% if brand_text %}{% else -%}{{ brand_alt_text }}{%- endif %}" />
                           </td>
                           <td width="100%" style="font-family: Helvetica, Arial, sans-serif; font-size: 18px; line-height: 23px;" valign="center">
                             {% if brand_text %}

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -556,7 +556,7 @@ class HTMLEmailTemplate(BaseEmailTemplate):
         brand_text=None,
         brand_colour=None,
         brand_banner=False,
-        brand_name=None,
+        brand_alt_text=None,
     ):
         super().__init__(template, values)
         self.govuk_banner = govuk_banner
@@ -565,7 +565,7 @@ class HTMLEmailTemplate(BaseEmailTemplate):
         self.brand_text = brand_text
         self.brand_colour = brand_colour
         self.brand_banner = brand_banner
-        self.brand_name = brand_name
+        self.brand_alt_text = brand_alt_text
 
     @property
     def preheader(self):
@@ -599,7 +599,7 @@ class HTMLEmailTemplate(BaseEmailTemplate):
                 "brand_text": self.brand_text,
                 "brand_colour": self.brand_colour,
                 "brand_banner": self.brand_banner,
-                "brand_name": self.brand_name,
+                "brand_alt_text": self.brand_alt_text,
             }
         )
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "57.1.1"  # d3b47e9343c8e3275f5e90696c05d3a1
+__version__ = "58.0.0"  # 826bceafe8a9bc13da357449ee384263

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -183,7 +183,7 @@ def test_alt_text_with_brand_text_and_govuk_banner_shown():
             brand_logo="http://example.com/image.png",
             brand_text="Example",
             brand_banner=True,
-            brand_name="Notify Logo",
+            brand_alt_text="Notify Logo",
         )
     )
     assert 'alt=""' in email
@@ -198,7 +198,7 @@ def test_alt_text_with_no_brand_text_and_govuk_banner_shown():
             brand_logo="http://example.com/image.png",
             brand_text=None,
             brand_banner=True,
-            brand_name="Notify Logo",
+            brand_alt_text="Notify Logo",
         )
     )
     assert 'alt=""' in email
@@ -222,7 +222,7 @@ def test_alt_text_with_no_govuk_banner(brand_banner, brand_text, expected_alt_te
             brand_logo="http://example.com/image.png",
             brand_text=brand_text,
             brand_banner=brand_banner,
-            brand_name="Notify Logo",
+            brand_alt_text="Notify Logo",
         )
     )
 


### PR DESCRIPTION
- [x] https://github.com/alphagov/notifications-utils/pull/1000

this is a breaking change, but is just a variable rename. It felt good to do just to avoid any confusion with what each field is for though.