### PR TITLE
Prefer f-string formatting

### DIFF
--- a/notifications_utils/celery.py
+++ b/notifications_utils/celery.py
@@ -34,30 +34,19 @@ def make_task(app):
             with self.app_context():
                 elapsed_time = time.monotonic() - self.start
 
-                app.logger.info(
-                    "Celery task {task_name} (queue: {queue_name}) took {time}".format(
-                        task_name=self.name, queue_name=self.queue_name, time="{0:.4f}".format(elapsed_time)
-                    )
-                )
+                app.logger.info(f"Celery task {self.name} (queue: {self.queue_name}) took {elapsed_time:.4f}")
 
                 app.statsd_client.timing(
-                    "celery.{queue_name}.{task_name}.success".format(task_name=self.name, queue_name=self.queue_name),
+                    f"celery.{self.queue_name}.{self.name}.success",
                     elapsed_time,
                 )
 
         def on_failure(self, exc, task_id, args, kwargs, einfo):
             # enables request id tracing for these logs
             with self.app_context():
-                app.logger.exception(
-                    "Celery task {task_name} (queue: {queue_name}) failed".format(
-                        task_name=self.name,
-                        queue_name=self.queue_name,
-                    )
-                )
+                app.logger.exception(f"Celery task {self.name} (queue: {self.queue_name}) failed")
 
-                app.statsd_client.incr(
-                    "celery.{queue_name}.{task_name}.failure".format(task_name=self.name, queue_name=self.queue_name)
-                )
+                app.statsd_client.incr(f"celery.{self.queue_name}.{self.name}.failure")
 
         def __call__(self, *args, **kwargs):
             # ensure task has flask context to access config, logger, etc

--- a/notifications_utils/clients/antivirus/antivirus_client.py
+++ b/notifications_utils/clients/antivirus/antivirus_client.py
@@ -31,9 +31,9 @@ class AntivirusClient:
     def scan(self, document_stream):
         try:
             response = requests.post(
-                "{}/scan".format(self.api_host),
+                f"{self.api_host}/scan",
                 headers={
-                    "Authorization": "Bearer {}".format(self.auth_token),
+                    "Authorization": f"Bearer {self.auth_token}",
                 },
                 files={"document": document_stream},
             )
@@ -42,7 +42,7 @@ class AntivirusClient:
 
         except requests.RequestException as e:
             error = AntivirusError.from_exception(e)
-            current_app.logger.warning("Notify Antivirus API request failed with error: {}".format(error.message))
+            current_app.logger.warning(f"Notify Antivirus API request failed with error: {error.message}")
 
             raise error
         finally:

--- a/notifications_utils/clients/redis/__init__.py
+++ b/notifications_utils/clients/redis/__init__.py
@@ -4,8 +4,8 @@ from .request_cache import RequestCache  # noqa: F401 (unused import)
 
 
 def daily_limit_cache_key(service_id):
-    return "{}-{}-{}".format(str(service_id), datetime.utcnow().strftime("%Y-%m-%d"), "count")
+    return f"{service_id}-{datetime.utcnow().strftime('%Y-%m-%d')}-count"
 
 
 def rate_limit_cache_key(service_id, api_key_type):
-    return "{}-{}".format(str(service_id), api_key_type)
+    return f"{service_id}-{api_key_type}"

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -33,7 +33,7 @@ def prepare_value(val):
     elif isinstance(val, (uuid.UUID,)):
         return str(val)
     else:
-        raise ValueError("cannot cast {} to a string".format(type(val)))
+        raise ValueError(f"cannot cast {type(val)} to a string")
 
 
 class RedisClient:
@@ -169,6 +169,6 @@ class RedisClient:
                 self.__handle_exception(e, raise_exception, "delete", ", ".join(keys))
 
     def __handle_exception(self, e, raise_exception, operation, key_name):
-        current_app.logger.exception("Redis error performing {} on {}".format(operation, key_name))
+        current_app.logger.exception(f"Redis error performing {operation} on {key_name}")
         if raise_exception:
             raise e

--- a/notifications_utils/clients/redis/request_cache.py
+++ b/notifications_utils/clients/redis/request_cache.py
@@ -25,7 +25,7 @@ class RequestCache:
         with suppress(KeyError):
             return signature(client_method).parameters[argument_name].default
 
-        raise TypeError("{}() takes no argument called '{}'".format(client_method.__name__, argument_name))
+        raise TypeError("{client_method.__name__}() takes no argument called '{argument_name}'")
 
     @staticmethod
     def _make_key(key_format, client_method, args, kwargs):

--- a/notifications_utils/clients/statsd/statsd_client.py
+++ b/notifications_utils/clients/statsd/statsd_client.py
@@ -29,7 +29,7 @@ class NotifyStatsClient(StatsClientBase):
         except Exception as e:
             # if we get an error store None in the cache so that we don't keep trying to retrieve the DNS
             # if paas's dns server is having issues
-            current_app.logger.warning("Error resolving statsd dns: {}".format(str(e)))
+            current_app.logger.warning(f"Error resolving statsd dns: {e}")
             return None
 
     def _send(self, data):
@@ -40,7 +40,7 @@ class NotifyStatsClient(StatsClientBase):
             if host:
                 self._sock.sendto(data.encode("ascii"), (host, self._port))
         except Exception as e:
-            current_app.logger.warning("Error sending statsd metric: {}".format(str(e)))
+            current_app.logger.warning(f"Error sending statsd metric: {e}")
             pass
 
 
@@ -51,9 +51,7 @@ class StatsdClient:
     def init_app(self, app, *args, **kwargs):
         app.statsd_client = self
         self.active = app.config.get("STATSD_ENABLED")
-        self.namespace = "{}.notifications.{}.".format(
-            app.config.get("NOTIFY_ENVIRONMENT"), app.config.get("NOTIFY_APP_NAME")
-        )
+        self.namespace = f"{app.config.get('NOTIFY_ENVIRONMENT')}.notifications.{app.config.get('NOTIFY_APP_NAME')}."
 
         if self.active:
             self.statsd_client = NotifyStatsClient(

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -34,17 +34,17 @@ class Placeholder:
             # ((a?? b??c)) returns " b??c"
             return "??".join(self.body.split("??")[1:])
         else:
-            raise ValueError("{} not conditional".format(self))
+            raise ValueError(f"{self} not conditional")
 
     def get_conditional_body(self, show_conditional):
         # note: unsanitised/converted
         if self.is_conditional():
             return self.conditional_text if str2bool(show_conditional) else ""
         else:
-            raise ValueError("{} not conditional".format(self))
+            raise ValueError(f"{self} not conditional")
 
     def __repr__(self):
-        return "Placeholder({})".format(self.body)
+        return f"Placeholder({self.body})"
 
 
 class Field:
@@ -97,7 +97,7 @@ class Field:
         return self.formatted
 
     def __repr__(self):
-        return '{}("{}", {})'.format(self.__class__.__name__, self.content, self.values)  # TODO: more real
+        return f'{self.__class__.__name__}("{self.content}", {self.values})'
 
     def splitlines(self):
         return str(self).splitlines()
@@ -150,7 +150,7 @@ class Field:
 
     def get_replacement_as_list(self, replacement):
         if self.markdown_lists:
-            return "\n\n" + "\n".join("* {}".format(item) for item in replacement)
+            return "\n\n" + "\n".join(f"* {item}" for item in replacement)
         return unescaped_formatted_list(replacement, before_each="", after_each="")
 
     @property

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -63,7 +63,7 @@ def nl2br(value):
 
 def add_prefix(body, prefix=None):
     if prefix:
-        return "{}: {}".format(prefix.strip(), body)
+        return f"{prefix.strip()}: {body}"
     return body
 
 
@@ -134,16 +134,11 @@ def create_sanitised_html_for_url(link, *, classes="", style=""):
 
     safe_link = urllib.parse.quote(link, safe=":/?#=&;%")
 
-    return '<a {}{}href="{}">{}</a>'.format(
-        class_attribute,
-        style_attribute,
-        safe_link,
-        link_text,
-    )
+    return f'<a {class_attribute}{style_attribute}href="{safe_link}">{link_text}</a>'
 
 
 def prepend_subject(body, subject):
-    return "# {}\n\n{}".format(subject, body)
+    return f"# {subject}\n\n{body}"
 
 
 def sms_encode(content):
@@ -194,13 +189,13 @@ def unescaped_formatted_list(
         prefix_plural += " "
 
     if len(items) == 1:
-        return "{prefix}{before_each}{items[0]}{after_each}".format(**locals())
+        return f"{prefix}{before_each}{items[0]}{after_each}"
     elif items:
-        formatted_items = ["{}{}{}".format(before_each, item, after_each) for item in items]
+        formatted_items = [f"{before_each}{item}{after_each}" for item in items]
 
         first_items = separator.join(formatted_items[:-1])
         last_item = formatted_items[-1]
-        return ("{prefix_plural}{first_items} {conjunction} {last_item}").format(**locals())
+        return f"{prefix_plural}{first_items} {conjunction} {last_item}"
 
 
 def formatted_list(
@@ -267,7 +262,7 @@ def strip_leading_whitespace(value):
 
 
 def add_trailing_newline(value):
-    return "{}\n".format(value)
+    return f"{value}\n"
 
 
 def remove_smart_quotes_from_email_addresses(value):

--- a/notifications_utils/international_billing_rates.py
+++ b/notifications_utils/international_billing_rates.py
@@ -18,12 +18,9 @@ Format of the yaml file looks like:
   - Dominican Republic
 """
 
-import os
+from pathlib import Path
 
 import yaml
 
-dir_path = os.path.dirname(os.path.realpath(__file__))
-
-with open("{}/international_billing_rates.yml".format(dir_path)) as f:
-    INTERNATIONAL_BILLING_RATES = yaml.safe_load(f)
-    COUNTRY_PREFIXES = list(reversed(sorted(INTERNATIONAL_BILLING_RATES.keys(), key=len)))
+INTERNATIONAL_BILLING_RATES = yaml.safe_load(Path("notifications_utils/international_billing_rates.yml").read_text())
+COUNTRY_PREFIXES = list(reversed(sorted(INTERNATIONAL_BILLING_RATES.keys(), key=len)))

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -79,7 +79,7 @@ def get_handlers(app):
     # only write json to file if we're not running on ECS
     if app.config["NOTIFY_RUNTIME_PLATFORM"] != "ecs":
         # machine readable json to both file and stdout
-        file_handler = logging.handlers.WatchedFileHandler(filename="{}.json".format(app.config["NOTIFY_LOG_PATH"]))
+        file_handler = logging.handlers.WatchedFileHandler(filename=f"{app.config['NOTIFY_LOG_PATH']}.json")
         handlers.append(configure_handler(file_handler, app, json_formatter))
 
     return handlers
@@ -150,7 +150,7 @@ class CustomLogFormatter(logging.Formatter):
         try:
             record.msg = str(record.msg).format(**record.__dict__)
         except (KeyError, IndexError) as e:
-            logger.exception("failed to format log message: {} not found".format(e))
+            logger.exception(f"failed to format log message: {e} not found")
         return super(CustomLogFormatter, self).format(record)
 
 
@@ -168,5 +168,5 @@ class JSONFormatter(BaseJSONFormatter):
         try:
             log_record["message"] = log_record["message"].format(**log_record)
         except (KeyError, IndexError) as e:
-            logger.exception("failed to format log message: {} not found".format(e))
+            logger.exception(f"failed to format log message: {e} not found")
         return log_record

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -74,14 +74,15 @@ class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
 
     def paragraph(self, text):
         if text.strip():
-            return "<p>{}</p>".format(text)
+            return f"<p>{text}</p>"
         return ""
 
     def table(self, header, body):
         return ""
 
     def autolink(self, link, is_email=False):
-        return "<strong>{}</strong>".format(link.replace("http://", "").replace("https://", ""))
+        link = link.replace("http://", "").replace("https://", "")
+        return f"<strong>{link}</strong>"
 
     def image(self, src, title, alt_text):
         return ""
@@ -93,10 +94,10 @@ class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
         return self.linebreak()
 
     def list_item(self, text):
-        return "<li>{}</li>\n".format(text.strip())
+        return f"<li>{text.strip()}</li>\n"
 
     def link(self, link, title, content):
-        return "{}: {}".format(content, self.autolink(link))
+        return f"{content}: {self.autolink(link)}"
 
     def footnote_ref(self, key, index):
         return ""
@@ -114,9 +115,9 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
             return (
                 '<h2 style="Margin: 0 0 20px 0; padding: 0; '
                 'font-size: 27px; line-height: 35px; font-weight: bold; color: #0B0C0C;">'
-                "{}"
+                f"{text}"
                 "</h2>"
-            ).format(text)
+            )
         return self.paragraph(text)
 
     def hrule(self):
@@ -132,39 +133,37 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
                 "<tr>"
                 '<td style="font-family: Helvetica, Arial, sans-serif;">'
                 '<ol style="Margin: 0 0 0 20px; padding: 0; list-style-type: decimal;">'
-                "{}"
+                f"{body}"
                 "</ol>"
                 "</td>"
                 "</tr>"
                 "</table>"
-            ).format(body)
+            )
             if ordered
             else (
                 '<table role="presentation" style="padding: 0 0 20px 0;">'
                 "<tr>"
                 '<td style="font-family: Helvetica, Arial, sans-serif;">'
                 '<ul style="Margin: 0 0 0 20px; padding: 0; list-style-type: disc;">'
-                "{}"
+                f"{body}"
                 "</ul>"
                 "</td>"
                 "</tr>"
                 "</table>"
-            ).format(body)
+            )
         )
 
     def list_item(self, text):
         return (
             '<li style="Margin: 5px 0 5px; padding: 0 0 0 5px; font-size: 19px;'
             'line-height: 25px; color: #0B0C0C;">'
-            "{}"
+            f"{text.strip()}"
             "</li>"
-        ).format(text.strip())
+        )
 
     def paragraph(self, text):
         if text.strip():
-            return ('<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">{}</p>').format(
-                text
-            )
+            return f'<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">{text}</p>'
         return ""
 
     def block_quote(self, text):
@@ -173,17 +172,14 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
             'style="Margin: 0 0 20px 0; border-left: 10px solid #B1B4B6;'
             'padding: 15px 0 0.1px 15px; font-size: 19px; line-height: 25px;"'
             ">"
-            "{}"
+            f"{text}"
             "</blockquote>"
-        ).format(text)
+        )
 
     def link(self, link, title, content):
-        return ('<a style="{}"{}{}>{}</a>').format(
-            LINK_STYLE,
-            ' href="{}"'.format(link),
-            ' title="{}"'.format(title) if title else "",
-            content,
-        )
+        if title:
+            return f'<a style="{LINK_STYLE}" href="{link}" title="{title}">{content}</a>'
+        return f'<a style="{LINK_STYLE}" href="{link}">{content}</a>'
 
     def autolink(self, link, is_email=False):
         if is_email:
@@ -216,7 +212,7 @@ class NotifyPlainTextEmailMarkdownRenderer(NotifyEmailMarkdownRenderer):
     def list(self, body, ordered=True):
         def _get_list_marker():
             decimal = count(1)
-            return lambda _: "{}.".format(next(decimal)) if ordered else "•"
+            return lambda _: f"{next(decimal)}." if ordered else "•"
 
         return "".join(
             (
@@ -256,7 +252,7 @@ class NotifyPlainTextEmailMarkdownRenderer(NotifyEmailMarkdownRenderer):
         return "".join(
             (
                 content,
-                " ({})".format(title) if title else "",
+                f" ({title})" if title else "",
                 ": ",
                 link,
             )
@@ -277,7 +273,7 @@ class NotifyEmailPreheaderMarkdownRenderer(NotifyPlainTextEmailMarkdownRenderer)
         return "".join(
             (
                 content,
-                " ({})".format(title) if title else "",
+                f" ({title})" if title else "",
             )
         )
 

--- a/notifications_utils/pdf.py
+++ b/notifications_utils/pdf.py
@@ -41,9 +41,7 @@ def extract_page_from_pdf(src_pdf, page_number):
     pdf = PyPDF2.PdfReader(src_pdf)
 
     if len(pdf.pages) < page_number:
-        raise PdfReadError(
-            "Page number requested: {} of {} does not exist in document".format(str(page_number), str(len(pdf.pages)))
-        )
+        raise PdfReadError(f"Page number requested: {page_number} of {len(pdf.pages)} does not exist in document")
 
     writer = PdfWriter()
     writer.add_page(pdf.pages[page_number])

--- a/notifications_utils/postal_address.py
+++ b/notifications_utils/postal_address.py
@@ -152,12 +152,14 @@ def normalise_postcode(postcode):
 
 
 def is_a_real_uk_postcode(postcode):
-    standard = r"([A-Z]{1,2}[0-9][0-9A-Z]?[0-9][A-BD-HJLNP-UW-Z]{2})"
-    bfpo = r"(BFPO?(C\/O)?[0-9]{1,4})"
-    girobank = r"(GIR0AA)"
-    pattern = r"{}|{}|{}".format(standard, bfpo, girobank)
-
-    return bool(re.fullmatch(pattern, normalise_postcode(postcode)))
+    pattern = re.compile(
+        r"([A-Z]{1,2}[0-9][0-9A-Z]?[0-9][A-BD-HJLNP-UW-Z]{2})"  # Standard
+        r"|"
+        r"(BFPO?(C\/O)?[0-9]{1,4})"  # BFPO
+        r"|"
+        r"(GIR0AA)"  # Girobank
+    )
+    return bool(pattern.fullmatch(normalise_postcode(postcode)))
 
 
 def format_postcode_for_printing(postcode):

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -561,7 +561,7 @@ def validate_uk_phone_number(number):
     if len(number) < 10:
         raise InvalidPhoneError("Not enough digits")
 
-    return "{}{}".format(uk_prefix, number)
+    return f"{uk_prefix}{number}"
 
 
 def validate_phone_number(number, international=False):
@@ -595,7 +595,7 @@ def try_validate_and_format_phone_number(number, international=None, log_msg=Non
         return validate_and_format_phone_number(number, international)
     except InvalidPhoneError as exc:
         if log_msg:
-            current_app.logger.warning("{}: {}".format(log_msg, exc))
+            current_app.logger.warning(f"{log_msg}: {exc}")
         return number
 
 

--- a/notifications_utils/request_helper.py
+++ b/notifications_utils/request_helper.py
@@ -118,6 +118,6 @@ def _check_proxy_header_secret(request, secrets, header="X-Custom-Forwarder"):
 
     for i, secret in enumerate(secrets):
         if header_secret == secret:
-            return True, "Key used: {}".format(i + 1)  # add 1 to make it human-compatible
+            return True, f"Key used: {i + 1}"  # add 1 to make it human-compatible
 
     return False, "Header didn't match any keys"

--- a/notifications_utils/s3.py
+++ b/notifications_utils/s3.py
@@ -30,7 +30,7 @@ def s3upload(
     try:
         key.put(**put_args)
     except botocore.exceptions.ClientError as e:
-        current_app.logger.error("Unable to upload file to S3 bucket {}".format(bucket_name))
+        current_app.logger.error(f"Unable to upload file to S3 bucket {bucket_name}")
         raise e
 
 

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -45,8 +45,8 @@ class SanitiseText:
         """
         # lets just make sure we aren't evaling anything weird
         if not set(codepoint) <= set("0123456789ABCDEF") or not len(codepoint) == 4:
-            raise ValueError("{} is not a valid unicode codepoint".format(codepoint))
-        return eval('"\\u{}"'.format(codepoint))
+            raise ValueError(f"{codepoint} is not a valid unicode codepoint")
+        return eval(f'"\\u{codepoint}"')
 
     @classmethod
     def downgrade_character(cls, c):

--- a/notifications_utils/statsd_decorators.py
+++ b/notifications_utils/statsd_decorators.py
@@ -12,19 +12,13 @@ def statsd(namespace):
             try:
                 res = func(*args, **kwargs)
                 elapsed_time = time.monotonic() - start_time
-                current_app.statsd_client.incr("{namespace}.{func}".format(namespace=namespace, func=func.__name__))
-                current_app.statsd_client.timing(
-                    "{namespace}.{func}".format(namespace=namespace, func=func.__name__), elapsed_time
-                )
+                current_app.statsd_client.incr(f"{namespace}.{func.__name__}")
+                current_app.statsd_client.timing(f"{namespace}.{func.__name__}", elapsed_time)
 
             except Exception as e:
                 raise e
             else:
-                current_app.logger.debug(
-                    "{namespace} call {func} took {time}".format(
-                        namespace=namespace, func=func.__name__, time="{0:.4f}".format(elapsed_time)
-                    )
-                )
+                current_app.logger.debug(f"{namespace} call {func.__name__} took {elapsed_time:.4f}")
                 return res
 
         wrapper.__wrapped__.__name__ = func.__name__

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -80,7 +80,7 @@ class Template(ABC):
         self.redact_missing_personalisation = redact_missing_personalisation
 
     def __repr__(self):
-        return '{}("{}", {})'.format(self.__class__.__name__, self.content, self.values)
+        return f'{self.__class__.__name__}("{self.content}", {self.values})'
 
     @abstractmethod
     def __str__(self):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "59.0.0"  # 2e8cf07fcae4b75a2eec8bfcd34da4a6
+__version__ = "59.0.1"  # 5b91317bc969e4148d4178a801018668

--- a/tests/clients/test_redis.py
+++ b/tests/clients/test_redis.py
@@ -8,8 +8,8 @@ from notifications_utils.clients.redis import (
 
 def test_daily_limit_cache_key(sample_service):
     with freeze_time("2016-01-01 12:00:00.000000"):
-        assert daily_limit_cache_key(sample_service.id) == "{}-2016-01-01-count".format(sample_service.id)
+        assert daily_limit_cache_key(sample_service.id) == f"{sample_service.id}-2016-01-01-count"
 
 
 def test_rate_limit_cache_key(sample_service):
-    assert rate_limit_cache_key(sample_service.id, "TEST") == "{}-TEST".format(sample_service.id)
+    assert rate_limit_cache_key(sample_service.id, "TEST") == f"{sample_service.id}-TEST"

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -20,10 +20,10 @@ from notifications_utils.template import HTMLEmailTemplate
     ],
 )
 def test_makes_links_out_of_URLs(url):
-    link = '<a style="word-wrap: break-word; color: #1D70B8;" href="{}">{}</a>'.format(url, url)
+    link = f'<a style="word-wrap: break-word; color: #1D70B8;" href="{url}">{url}</a>'
     assert notify_email_markdown(url) == (
-        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">' "{}" "</p>"
-    ).format(link)
+        f'<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">{link}</p>'
+    )
 
 
 @pytest.mark.parametrize(
@@ -48,8 +48,8 @@ def test_makes_links_out_of_URLs(url):
 )
 def test_makes_links_out_of_URLs_in_context(input, output):
     assert notify_email_markdown(input) == (
-        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">' "{}" "</p>"
-    ).format(output)
+        f'<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">{output}</p>'
+    )
 
 
 @pytest.mark.parametrize(
@@ -65,8 +65,8 @@ def test_makes_links_out_of_URLs_in_context(input, output):
 )
 def test_doesnt_make_links_out_of_invalid_urls(url):
     assert notify_email_markdown(url) == (
-        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">' "{}" "</p>"
-    ).format(url)
+        f'<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">{url}</p>'
+    )
 
 
 def test_handles_placeholders_in_urls():
@@ -102,8 +102,8 @@ def test_handles_placeholders_in_urls():
 )
 def test_URLs_get_escaped(url, expected_html, expected_html_in_template):
     assert notify_email_markdown(url) == (
-        '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">' "{}" "</p>"
-    ).format(expected_html)
+        f'<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">{expected_html}</p>'
+    )
     assert expected_html_in_template in str(
         HTMLEmailTemplate(
             {

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -925,7 +925,7 @@ def test_ignores_leading_whitespace_in_file(character, name):
         assert unicodedata.name(character) == name
 
     recipients = RecipientCSV(
-        "{}emailaddress\ntest@example.com".format(character),
+        f"{character}emailaddress\ntest@example.com",
         template=_sample_template("email"),
     )
     first_row = recipients[0]
@@ -1031,12 +1031,10 @@ def test_multiple_sms_recipient_columns(international_sms):
 )
 def test_multiple_sms_recipient_columns_with_missing_data(column_name):
     recipients = RecipientCSV(
-        """
-            names, phone number, {}
+        f"""
+            names, phone number, {column_name}
             "Joanna and Steve", 07900 900111
-        """.format(
-            column_name
-        ),
+        """,
         template=_sample_template("sms"),
         allow_international_sms=True,
     )

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -163,7 +163,7 @@ invalid_email_addresses = (
     "local-with-”-quotes@domain.com",
     "domain-starts-with-a-dot@.domain.com",
     "brackets(in)local@domain.com",
-    "email-too-long-{}@example.com".format("a" * 320),
+    f"email-too-long-{'a' * 320}@example.com",
     "incorrect-punycode@xn---something.com",
 )
 

--- a/tests/test_take.py
+++ b/tests/test_take.py
@@ -10,7 +10,7 @@ def _append(value, to_append):
 
 
 def _prepend_with_service_name(value, service_name=None):
-    return "{}: {}".format(service_name, value)
+    return f"{service_name}: {value}"
 
 
 def test_take():

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -172,7 +172,7 @@ def test_brand_data_shows(brand_logo, brand_text, brand_colour):
     if brand_text:
         assert brand_text in email
     if brand_colour:
-        assert 'bgcolor="{}"'.format(brand_colour) in email
+        assert f'bgcolor="{brand_colour}"' in email
 
 
 def test_alt_text_with_brand_text_and_govuk_banner_shown():
@@ -427,9 +427,9 @@ def test_markdown_in_templates(
     ],
 )
 def test_makes_links_out_of_URLs(extra_attributes, template_class, template_type, url, url_with_entities_replaced):
-    assert '<a {} href="{}">{}</a>'.format(
-        extra_attributes, url_with_entities_replaced, url_with_entities_replaced
-    ) in str(template_class({"content": url, "subject": "", "template_type": template_type}))
+    assert f'<a {extra_attributes} href="{url_with_entities_replaced}">{url_with_entities_replaced}</a>' in str(
+        template_class({"content": url, "subject": "", "template_type": template_type})
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
f-strings were added in Python 3.6. Some of our older code predates Python 3.6 and therefore couldn’t use f-strings where it was written.

This pull request replaces uses of `str.format()` to use f-strings, which are generally easier to read and result in fewer lines of code.

The only ones I’ve left are where `str.format` was being passed several complex expressions, which are easier to read line by line as separate arguments.