### PR TITLE
Add support for HTML support tickets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 58.1.0
+
+* add a `message_as_html` parameter to `NotifySupportTicket` to enable creating tickets containing HTML (eg links).
+
 ## 58.0.0
 
 * replace `brand_name` with `brand_alt_text` in HTMLEmailTemplate to more accurately reflect its purpose

--- a/notifications_utils/clients/zendesk/zendesk_client.py
+++ b/notifications_utils/clients/zendesk/zendesk_client.py
@@ -70,6 +70,7 @@ class NotifySupportTicket:
         org_type=None,
         service_id=None,
         email_ccs=None,
+        message_as_html=False,
     ):
         self.subject = subject
         self.message = message
@@ -84,6 +85,7 @@ class NotifySupportTicket:
         self.org_type = org_type
         self.service_id = service_id
         self.email_ccs = email_ccs
+        self.message_as_html = message_as_html
 
     @property
     def request_data(self):
@@ -91,7 +93,7 @@ class NotifySupportTicket:
             "ticket": {
                 "subject": self.subject,
                 "comment": {
-                    "body": self.message,
+                    ("html_body" if self.message_as_html else "body"): self.message,
                     "public": self.requester_sees_message_content,
                 },
                 "group_id": self.NOTIFY_GROUP_ID,

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "58.0.0"  # 826bceafe8a9bc13da357449ee384263
+__version__ = "58.1.0"  # 9b490df99ae8581bd89006db14a9d189

--- a/tests/clients/zendesk/test_zendesk_client.py
+++ b/tests/clients/zendesk/test_zendesk_client.py
@@ -180,3 +180,30 @@ def test_notify_support_ticket_request_data_email_ccs():
     assert notify_ticket_form.request_data["ticket"]["email_ccs"] == [
         {"user_email": "someone@example.com", "action": "put"},
     ]
+
+
+def test_notify_support_ticket_with_html_body():
+    notify_ticket_form = NotifySupportTicket("subject", "message", "task", message_as_html=True)
+
+    assert notify_ticket_form.request_data == {
+        "ticket": {
+            "subject": "subject",
+            "comment": {
+                "html_body": "message",
+                "public": True,
+            },
+            "group_id": NotifySupportTicket.NOTIFY_GROUP_ID,
+            "organization_id": NotifySupportTicket.NOTIFY_ORG_ID,
+            "ticket_form_id": NotifySupportTicket.NOTIFY_TICKET_FORM_ID,
+            "priority": "normal",
+            "tags": ["govuk_notify_support"],
+            "type": "task",
+            "custom_fields": [
+                {"id": "1900000744994", "value": "notify_ticket_type_non_technical"},
+                {"id": "360022836500", "value": []},
+                {"id": "360022943959", "value": None},
+                {"id": "360022943979", "value": None},
+                {"id": "1900000745014", "value": None},
+            ],
+        }
+    }


### PR DESCRIPTION
Zendesk supports creating tickets with HTML:
https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#create-ticket

We'd like to generate a report about email brandings and it would be nice to include links to them (but with the brand name as the clickable text).