### PR TITLE
Remove `Template.encoding`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 59.0.0
+
+* Remove `Template.encoding` (very unlikely to be used anywhere)
+
 ## 58.1.0
 
 * add a `message_as_html` parameter to `NotifySupportTicket` to enable creating tickets containing HTML (eg links).

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -58,9 +58,6 @@ template_env = Environment(
 
 
 class Template(ABC):
-
-    encoding = "utf-8"
-
     def __init__(
         self,
         template,

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "58.1.0"  # 9b490df99ae8581bd89006db14a9d189
+__version__ = "59.0.0"  # 2e8cf07fcae4b75a2eec8bfcd34da4a6


### PR DESCRIPTION
We added the `encoding` argument to `Template` when we started counting the length of template content:
https://github.com/alphagov/notifications-utils/blob/a9b09d841b0abf928c145225c279b0cc7ae217df/notifications_utils/template.py#L8-L13

We needed to do this because determined the length by encoding the template to bytes then counting how many bytes there were. This meant we needed to know what encoding the text was in otherwise we might miscount. So we referred to `self.encoding` here:
https://github.com/alphagov/notifications-utils/blob/1ab5a4428189dac8e3944bb74e7eeb8b83d9a52f/notifications_utils/template.py#L167-L174

Practically we always deal with text in UTF8, so this property was hard coded on the class in
https://github.com/alphagov/notifications-utils/blob/9653f28e0448c8a20b97a4097f5dd14c27d5eb3c/notifications_utils/template.py#L13-L15

We stopped counting bytes as a way of determining template length in aae1c82806fa6f5067d1dea4578648a0b5fd7567, which meant we stopped referring to `Template.encoding` anywhere, however we didn’t remove it at that time. This pull request now removes it.

This is technically a breaking change but there isn’t any code actually using the property as far as I can tell.