### PR TITLE
Make path to international rates file absolute

### DIFF
--- a/notifications_utils/international_billing_rates.py
+++ b/notifications_utils/international_billing_rates.py
@@ -22,5 +22,5 @@ from pathlib import Path
 
 import yaml
 
-INTERNATIONAL_BILLING_RATES = yaml.safe_load(Path("notifications_utils/international_billing_rates.yml").read_text())
+INTERNATIONAL_BILLING_RATES = yaml.safe_load((Path(__file__).parent / "international_billing_rates.yml").read_text())
 COUNTRY_PREFIXES = list(reversed(sorted(INTERNATIONAL_BILLING_RATES.keys(), key=len)))

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "59.1.0"  # 50649b42fec46386b745a5d591b5eba8
+__version__ = "59.1.1"  # caeaba54ed4c25adfd2b4aa0afaaa9be


### PR DESCRIPTION
As a relative path it doesn’t work when utils is installed as a dependency in other apps – the file can’t be found

Example of the error in the API app:
```
E   FileNotFoundError: [Errno 2] No such file or directory: 'notifications_utils/international_billing_rates.yml'
```