### PR TITLE
Support notification type in rate limit cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 59.2.0
+
+* Add support for creating redis cache keys for a specific notification type.
+
 ## 59.1.0
 
 * Add synonyms for sending letters to the Canary Islands

--- a/notifications_utils/clients/redis/__init__.py
+++ b/notifications_utils/clients/redis/__init__.py
@@ -3,8 +3,13 @@ from datetime import datetime
 from .request_cache import RequestCache  # noqa: F401 (unused import)
 
 
-def daily_limit_cache_key(service_id):
-    return f"{service_id}-{datetime.utcnow().strftime('%Y-%m-%d')}-count"
+def daily_limit_cache_key(service_id, notification_type=None):
+    yyyy_mm_dd = datetime.utcnow().strftime("%Y-%m-%d")
+
+    if not notification_type:
+        return f"{service_id}-{yyyy_mm_dd}-count"
+
+    return f"{service_id}-{notification_type}-{yyyy_mm_dd}-count"
 
 
 def rate_limit_cache_key(service_id, api_key_type):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "59.1.1"  # caeaba54ed4c25adfd2b4aa0afaaa9be
+__version__ = "59.2.0"  # 878ba4ddf0ee30577340afab610b7a34

--- a/tests/clients/test_redis.py
+++ b/tests/clients/test_redis.py
@@ -1,3 +1,4 @@
+import pytest
 from freezegun import freeze_time
 
 from notifications_utils.clients.redis import (
@@ -6,9 +7,21 @@ from notifications_utils.clients.redis import (
 )
 
 
-def test_daily_limit_cache_key(sample_service):
+@pytest.mark.parametrize(
+    "kwargs, expected_cache_key",
+    (
+        ({}, "{sample_service.id}-2016-01-01-count"),
+        ({"notification_type": None}, "{sample_service.id}-2016-01-01-count"),
+        ({"notification_type": "sms"}, "{sample_service.id}-sms-2016-01-01-count"),
+        ({"notification_type": "letter"}, "{sample_service.id}-letter-2016-01-01-count"),
+        ({"notification_type": "email"}, "{sample_service.id}-email-2016-01-01-count"),
+    ),
+)
+def test_daily_limit_cache_key(sample_service, kwargs, expected_cache_key):
     with freeze_time("2016-01-01 12:00:00.000000"):
-        assert daily_limit_cache_key(sample_service.id) == f"{sample_service.id}-2016-01-01-count"
+        assert daily_limit_cache_key(sample_service.id, **kwargs) == expected_cache_key.format(
+            sample_service=sample_service
+        )
 
 
 def test_rate_limit_cache_key(sample_service):


### PR DESCRIPTION
We want to move from having a single message limit per day to having daily limits based on the notification type. Let's support both for now so we can roll out backwards-compatible changes.