### PR TITLE
Pin pyproj below 3.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "Flask-Redis>=0.4.0",
         "pyyaml>=5.3.1",
         "phonenumbers>=8.12.13",
-        "pyproj>=3.2.1",
+        "pyproj>=3.2.1,<=3.4.0",
         "pytz>=2020.4",
         "smartypants>=2.0.1",
         "pypdf2>=2.0.0",


### PR DESCRIPTION
We started to get a lot of test failures in utils after the release of pyproj 3.4.1. We pulled in the latest release automatically for tests directly on the utils repo.

Let's pin to below that version for now, so that tests can pass. We should investigate further:

1) What's changed
2) Whether the 'issue' will be fixed in pyproj or if we should look at updating our use of the lib to become compatible with what's changed.