### PR TITLE
Update code for version 3.4.1 onwards of pyproj dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 60.0.0
+
+* Bump pyproj to be version 3.4.1  or greater. This changes the ESPG codes to be upper case, which affects the how
+  `Polygons` class transforms data.
+
 ## 59.3.0
 
 * Add tooling to bump utils version in apps

--- a/notifications_utils/polygons.py
+++ b/notifications_utils/polygons.py
@@ -24,11 +24,11 @@ transformers = {
         # earth because the earth is not a perfect sphere.
         # —
         # The UK, west to east
-        "epsg:32629",  # Zone 29N: Between 12°W and 6°W, equator and 84°N
-        "epsg:32630",  # Zone 30N: Between 6°W and 0°W, equator and 84°N
-        "epsg:32631",  # Zone 31N: Between 0°E and 6°E, equator and 84°N
+        "EPSG:32629",  # Zone 29N: Between 12°W and 6°W, equator and 84°N
+        "EPSG:32630",  # Zone 30N: Between 6°W and 0°W, equator and 84°N
+        "EPSG:32631",  # Zone 31N: Between 0°E and 6°E, equator and 84°N
         # Santa Claus village (Finland)
-        "epsg:32635",  # Zone 35N: Between 24°E and 30°E, equator and 84°N
+        "EPSG:32635",  # Zone 35N: Between 24°E and 30°E, equator and 84°N
     }
 }
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "59.3.0"  # 9a88d4e7655fc7856a9729df319308cd
+__version__ = "60.0.0"  # 1c189ff4f7ebf35bd931914807f89b19

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         "Flask-Redis>=0.4.0",
         "pyyaml>=5.3.1",
         "phonenumbers>=8.12.13",
-        "pyproj>=3.2.1,<=3.4.0",
+        "pyproj>=3.4.1",
         "pytz>=2020.4",
         "smartypants>=2.0.1",
         "pypdf2>=2.0.0",

--- a/tests/test_polygons.py
+++ b/tests/test_polygons.py
@@ -407,7 +407,7 @@ def test_precision():
 
 def test_passes_through_coordinates_without_converting_to_crs():
     without_crs = Polygons([HACKNEY_MARSHES])
-    with_crs = Polygons([HACKNEY_MARSHES], utm_crs="epsg:32630")
+    with_crs = Polygons([HACKNEY_MARSHES], utm_crs="EPSG:32630")
 
     assert without_crs.as_coordinate_pairs_lat_long == with_crs.as_coordinate_pairs_lat_long
 


### PR DESCRIPTION
Version 3.4.1 of pyproj changed the ESPG codes to be upper case, which means that our tests now fail (https://github.com/pyproj4/pyproj/pull/1162).

This change updates our code to also use upper case codes, and bumps the minimum version of pyproj to ensure that we're always using a version which also uses the upper case codes.