### PR TITLE
Add zendesk client methods for updating tickets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 61.1.0
+
+* Adds a method to the ZendeskClient to add a comment to a pre-existing ticket, including adding attachments.
+
 ## 61.0.0
 
 * Provide our own cache file for bank holidays data, which will help us keep it up-to-date. This is a breaking change

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "61.0.0"  # a2dfd99b3dd91067150288c8c5a40dd3
+__version__ = "61.1.0"  # a182bb4d81e1b455ee548bcd8e279852


### PR DESCRIPTION
Bump to version 61.1.0

---

This should get us a step closer to automatically sending DWP their weekly report.

## Test script

1) In `notifications-api`, `pip install -e ../notifications-utils`
2) `pip install flask-shell-ipython`
3) `flask shell`
4) ```python
    import datetime
    from io import StringIO
    
    from app import zendesk_client
    
    from notifications_utils.clients.zendesk.zendesk_client import *
    
    csvfile = StringIO('a,b,c\n1,2,3')
    
    comment = NotifySupportTicketComment(
        body='this is an automatic comment',
        attachments=[
            NotifySupportTicketAttachment(filename='blah.csv', filedata=csvfile, content_type='text/csv'),
        ],
        public=False
    )
    
    zendesk_client.update_ticket(
        ticket_id=5177772,
        comment=comment,
        status=NotifySupportTicketStatus.PENDING,
        due_at=datetime.datetime(2023, 2, 1, 12, 0, 0)
    )
    
    ```