### PR TITLE
Bump isort to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   - id: flake8
     name: flake8 (python)
 - repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
     - id: isort
       name: isort (python)

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -12,5 +12,5 @@ flake8-bugbear==22.10.27
 flake8-print==5.0.0
 pytest-profiling==1.7.0
 snakeviz==2.1.1
-isort==5.10.1
+isort==5.12.0
 black==22.10.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -7,10 +7,10 @@ pytest-mock==3.9.0
 pytest-xdist==3.0.2
 requests-mock==1.10.0
 freezegun==1.2.2
-flake8==5.0.4
+flake8==5.0.4  # Also update `.pre-commit-config.yaml` if this changes
 flake8-bugbear==22.10.27
 flake8-print==5.0.0
 pytest-profiling==1.7.0
 snakeviz==2.1.1
-isort==5.12.0
-black==22.10.0
+isort==5.12.0  # Also update `.pre-commit-config.yaml` if this changes
+black==22.10.0  # Also update `.pre-commit-config.yaml` if this changes


### PR DESCRIPTION
Installing isort from scratch via pre-commit has broken due to a release from Poetry.

https://levelup.gitconnected.com/fix-runtimeerror-poetry-isort-5db7c67b60ff

The solution is to bump to the latest isort version.