### PR TITLE
Downgrade errors when a suspended user tries to create a Zendesk ticket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 61.3.0
+* Only log a warning and no longer raise an error if creating a Zendesk ticket fails because the user is suspended.
+
 ## 61.2.0
 
 * Adds `redis_client.get_lock` which returns a redis lock object (or a stub lock if redis is not enabled). See https://redis-py.readthedocs.io/en/v4.4.2/lock.html for functionality.

--- a/notifications_utils/clients/zendesk/zendesk_client.py
+++ b/notifications_utils/clients/zendesk/zendesk_client.py
@@ -62,6 +62,10 @@ class ZendeskClient:
         )
 
         if response.status_code != 201:
+            if response.status_code == 422 and self._is_user_suspended(response.json()):
+                error_message = response.json()["details"]
+                current_app.logger.warning(f"Zendesk create ticket failed because user is suspended '{error_message}'")
+                return
             current_app.logger.error(
                 f"Zendesk create ticket request failed with {response.status_code} '{response.json()}'"
             )
@@ -70,6 +74,10 @@ class ZendeskClient:
         ticket_id = response.json()["ticket"]["id"]
 
         current_app.logger.info(f"Zendesk create ticket {ticket_id} succeeded")
+
+    def _is_user_suspended(self, response):
+        requester_error = response["details"].get("requester")
+        return requester_error and ("suspended" in requester_error[0]["description"])
 
     def _upload_attachment(self, attachment: NotifySupportTicketAttachment):
         query_params = {"filename": attachment.filename}

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "61.2.0"  # ebed3566e1b75d99bee9eb9e99e0b574
+__version__ = "61.3.0"  # 5a5b131872aef7a8ded97b7d2f45a74c

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -11,6 +11,7 @@ flake8==5.0.4  # Also update `.pre-commit-config.yaml` if this changes
 flake8-bugbear==22.10.27
 flake8-print==5.0.0
 pytest-profiling==1.7.0
+redis>=4.3.4  # Earlier versions of redis miss features the tests need
 snakeviz==2.1.1
 isort==5.12.0  # Also update `.pre-commit-config.yaml` if this changes
 black==22.10.0  # Also update `.pre-commit-config.yaml` if this changes


### PR DESCRIPTION
We're seeing increasing numbers of errors in our logs because the Zendesk client has returned a `422` status code. This happens when a user has been suspended due to submitting spam tickets.

When this happens, we now log a warning and not an error.