### PR TITLE
Handle and normalise BFPO addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 62.0.0
+
+* Updated PostalAddress to parse BFPO addresses. Any validation done on PostalAddresses should be update to report on the new error property `has_invalid_country_for_bfpo_address`.
+
 ## 61.2.0
 
 * Adds `redis_client.get_lock` which returns a redis lock object (or a stub lock if redis is not enabled). See https://redis-py.readthedocs.io/en/v4.4.2/lock.html for functionality.

--- a/notifications_utils/postal_address.py
+++ b/notifications_utils/postal_address.py
@@ -168,10 +168,6 @@ def format_postcode_for_printing(postcode):
     :param String postcode: A postcode that's already been validated by _is_a_real_uk_postcode
     """
     postcode = normalise_postcode(postcode)
-    if "BFPOC/O" in postcode:
-        return postcode[:4] + " C/O " + postcode[7:]
-    elif "BFPO" in postcode:
-        return postcode[:4] + " " + postcode[4:]
     return postcode[:-3] + " " + postcode[-3:]
 
 

--- a/notifications_utils/postal_address.py
+++ b/notifications_utils/postal_address.py
@@ -170,6 +170,9 @@ class PostalAddress:
     @property
     def normalised_lines(self):
         if self.is_bfpo_address:
+            if self.postcode:
+                return self._lines_without_country_or_bfpo[:-1] + [self.postcode] + [f"BFPO {self._bfpo_number}"]
+
             return self._lines_without_country_or_bfpo + [f"BFPO {self._bfpo_number}"]
 
         if self.international:

--- a/notifications_utils/postal_address.py
+++ b/notifications_utils/postal_address.py
@@ -149,6 +149,10 @@ class PostalAddress:
         return self._bfpo_number is not None
 
     @property
+    def bfpo_number(self):
+        return self._bfpo_number
+
+    @property
     def normalised(self):
         return "\n".join(self.normalised_lines)
 

--- a/notifications_utils/postal_address.py
+++ b/notifications_utils/postal_address.py
@@ -41,11 +41,13 @@ class PostalAddress:
             if line.rstrip(" ,")
         ] or [""]
 
+        self._bfpo_number, self._lines_without_bfpo = self._parse_and_remove_bfpo(self._lines)
+
         try:
-            self.country = Country(self._lines[-1])
-            self._lines_without_country = self._lines[:-1]
+            self.country = Country(self._lines_without_bfpo[-1])
+            self._lines_without_country_or_bfpo = self._lines_without_bfpo[:-1]
         except CountryNotFoundError:
-            self._lines_without_country = self._lines
+            self._lines_without_country_or_bfpo = self._lines_without_bfpo
             self.country = country_UK
 
     def __bool__(self):
@@ -53,6 +55,19 @@ class PostalAddress:
 
     def __repr__(self):
         return f"{self.__class__.__name__}({repr(self.raw_address)})"
+
+    def _parse_and_remove_bfpo(self, lines):
+        bfpo_matcher = re.compile(r"^\s*bfpo\s*(?:c\/o)?(?:\s*(\d+))?\s*$")
+        bfpo_number_line = next(
+            filter(lambda l: bfpo_matcher.match(l.lower()) and bfpo_matcher.match(l.lower()).group(1), lines), None
+        )
+        if not bfpo_number_line:
+            return None, lines
+
+        bfpo_number = bfpo_matcher.match(bfpo_number_line.lower()).group(1)
+        lines = [line for line in lines if not bfpo_matcher.match(line.lower())]
+
+        return int(bfpo_number), lines
 
     @classmethod
     def from_personalisation(cls, personalisation_dict, allow_international_letters=False):
@@ -67,15 +82,21 @@ class PostalAddress:
 
     @property
     def as_personalisation(self):
+        postcode_offset = 2 if self.postcode and self.is_bfpo_address else 1
         lines = dict.fromkeys(address_lines_1_to_6_keys, "")
         lines.update(
             {
                 f"address_line_{index}": value
-                for index, value in enumerate(self.normalised_lines[:-1], start=1)
+                for index, value in enumerate(self.normalised_lines[:-postcode_offset], start=1)
                 if index < 7
             }
         )
         lines["postcode"] = lines["address_line_7"] = self.normalised_lines[-1]
+        if postcode_offset == 2:
+            lines["postcode"] = lines["address_line_6"] = self.postcode or ""
+        elif self.is_bfpo_address:
+            lines["postcode"] = ""
+
         return lines
 
     @property
@@ -100,7 +121,11 @@ class PostalAddress:
 
     @property
     def has_valid_last_line(self):
-        return (self.allow_international_letters and self.international) or self.has_valid_postcode
+        return (
+            (self.allow_international_letters and self.international and not self.is_bfpo_address)
+            or self.has_valid_postcode
+            or (self.is_bfpo_address and not self.has_invalid_country_for_bfpo_address)
+        )
 
     @property
     def has_invalid_characters(self):
@@ -109,8 +134,16 @@ class PostalAddress:
         )
 
     @property
+    def has_invalid_country_for_bfpo_address(self):
+        return self.international and self.is_bfpo_address
+
+    @property
     def international(self):
         return self.postage != Postage.UK
+
+    @property
+    def is_bfpo_address(self):
+        return self._bfpo_number is not None
 
     @property
     def normalised(self):
@@ -118,14 +151,27 @@ class PostalAddress:
 
     @property
     def normalised_lines(self):
+        if self.is_bfpo_address:
+            return self._lines_without_country_or_bfpo + [f"BFPO {self._bfpo_number}"]
 
         if self.international:
-            return self._lines_without_country + [self.country.canonical_name]
+            return self._lines_without_country_or_bfpo + [self.country.canonical_name]
 
         if self.postcode:
-            return self._lines_without_country[:-1] + [self.postcode]
+            return self._lines_without_country_or_bfpo[:-1] + [self.postcode]
 
-        return self._lines_without_country
+        return self._lines_without_country_or_bfpo
+
+    @property
+    def bfpo_normalised_lines(self):
+        """Removes the postcode and BFPO footer lines for BFPO addresses"""
+        if not self.is_bfpo_address:
+            raise ValueError("Cannot be used for non-BFPO addresses")
+
+        if self.postcode:
+            return self.normalised_lines[:-2]
+
+        return self.normalised_lines[:-1]
 
     @property
     def postage(self):
@@ -135,7 +181,7 @@ class PostalAddress:
     def postcode(self):
         if self.international:
             return None
-        return format_postcode_or_none(self._lines_without_country[-1])
+        return format_postcode_or_none(self._lines_without_country_or_bfpo[-1])
 
     @property
     def valid(self):
@@ -144,6 +190,7 @@ class PostalAddress:
             and self.has_enough_lines
             and not self.has_too_many_lines
             and not self.has_invalid_characters
+            and not (self.international and self.is_bfpo_address)
         )
 
 
@@ -152,13 +199,8 @@ def normalise_postcode(postcode):
 
 
 def _is_a_real_uk_postcode(postcode):
-    pattern = re.compile(
-        r"([A-Z]{1,2}[0-9][0-9A-Z]?[0-9][A-BD-HJLNP-UW-Z]{2})"  # Standard
-        r"|"
-        r"(BFPO?(C\/O)?[0-9]{1,4})"  # BFPO
-        r"|"
-        r"(GIR0AA)"  # Girobank
-    )
+    # GIR0AA is Girobank
+    pattern = re.compile(r"([A-Z]{1,2}[0-9][0-9A-Z]?[0-9][A-BD-HJLNP-UW-Z]{2})|(GIR0AA)")
     return bool(pattern.fullmatch(normalise_postcode(postcode)))
 
 

--- a/notifications_utils/postal_address.py
+++ b/notifications_utils/postal_address.py
@@ -151,7 +151,7 @@ def normalise_postcode(postcode):
     return remove_whitespace(postcode).upper()
 
 
-def is_a_real_uk_postcode(postcode):
+def _is_a_real_uk_postcode(postcode):
     pattern = re.compile(
         r"([A-Z]{1,2}[0-9][0-9A-Z]?[0-9][A-BD-HJLNP-UW-Z]{2})"  # Standard
         r"|"
@@ -165,7 +165,7 @@ def is_a_real_uk_postcode(postcode):
 def format_postcode_for_printing(postcode):
     """
     This function formats the postcode so that it is ready for automatic sorting by Royal Mail.
-    :param String postcode: A postcode that's already been validated by is_a_real_uk_postcode
+    :param String postcode: A postcode that's already been validated by _is_a_real_uk_postcode
     """
     postcode = normalise_postcode(postcode)
     if "BFPOC/O" in postcode:
@@ -181,5 +181,5 @@ def format_postcode_for_printing(postcode):
 # power of 2
 @lru_cache(maxsize=8)
 def format_postcode_or_none(postcode):
-    if is_a_real_uk_postcode(postcode):
+    if _is_a_real_uk_postcode(postcode):
         return format_postcode_for_printing(postcode)

--- a/notifications_utils/postal_address.py
+++ b/notifications_utils/postal_address.py
@@ -82,7 +82,9 @@ class PostalAddress:
 
     @property
     def as_personalisation(self):
-        postcode_offset = 2 if self.postcode and self.is_bfpo_address else 1
+        bfpo_with_postcode = self.postcode and self.is_bfpo_address
+        postcode_offset = 2 if bfpo_with_postcode else 1
+
         lines = dict.fromkeys(address_lines_1_to_6_keys, "")
         lines.update(
             {
@@ -92,7 +94,8 @@ class PostalAddress:
             }
         )
         lines["postcode"] = lines["address_line_7"] = self.normalised_lines[-1]
-        if postcode_offset == 2:
+
+        if bfpo_with_postcode:
             lines["postcode"] = lines["address_line_6"] = self.postcode or ""
         elif self.is_bfpo_address:
             lines["postcode"] = ""

--- a/notifications_utils/postal_address.py
+++ b/notifications_utils/postal_address.py
@@ -188,7 +188,7 @@ class PostalAddress:
         return self._lines_without_country_or_bfpo
 
     @property
-    def bfpo_normalised_lines(self):
+    def bfpo_address_lines(self):
         """Removes the postcode and BFPO footer lines for BFPO addresses"""
         if not self.is_bfpo_address:
             raise ValueError("Cannot be used for non-BFPO addresses")

--- a/notifications_utils/postal_address.py
+++ b/notifications_utils/postal_address.py
@@ -53,6 +53,17 @@ class PostalAddress:
     def __bool__(self):
         return bool(self.normalised)
 
+    def __eq__(self, other):
+        if not isinstance(other, PostalAddress):
+            return False
+
+        return (
+            self.normalised_lines == other.normalised_lines
+            and self.allow_international_letters == other.allow_international_letters
+            and self.bfpo_number == other.bfpo_number
+            and self.country == other.country
+        )
+
     def __repr__(self):
         return f"{self.__class__.__name__}({repr(self.raw_address)})"
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "61.2.0"  # ebed3566e1b75d99bee9eb9e99e0b574
+__version__ = "62.0.0"  # 21e3362eb37366b9cadff927e56a4a68

--- a/tests/test_postal_address.py
+++ b/tests/test_postal_address.py
@@ -854,6 +854,22 @@ def test_valid_from_personalisation_with_international_parameter(international, 
     )
 
 
+def test_from_personalisation_to_normalisation_doesnt_stringify_nones():
+    assert PostalAddress.from_personalisation(
+        InsensitiveDict(
+            {
+                "addressline1": "Notify user",
+                "addressline2": "Notifyland",
+                "addressline3": None,
+                "addressline4": None,
+                "addressline5": None,
+                "addressline6": None,
+                "addressline7": "SW1 1AA",
+            }
+        )
+    ).normalised_lines == ["Notify user", "Notifyland", "SW1 1AA"]
+
+
 @pytest.mark.parametrize(
     "address, is_bfpo",
     (

--- a/tests/test_postal_address.py
+++ b/tests/test_postal_address.py
@@ -561,14 +561,17 @@ def test_normalise_postcode(postcode, normalised_postcode):
         ("SO14 6WBA", False),
         ("", False),
         ("Bad postcode", False),
-        # valid British Forces postcodes
-        ("BFPO1234", True),
-        ("BFPO C/O 1234", True),
-        ("BFPO 1234", True),
-        ("BFPO1", True),
-        # invalid British Forces postcodes
+        # British Forces Post Office numbers are not postcodes
+        ("BFPO1234", False),
+        ("BFPO C/O 1234", False),
+        ("BFPO 1234", False),
+        ("BFPO1", False),
         ("BFPO", False),
         ("BFPO12345", False),
+        # But actual BFPO post codes are still valid post codes
+        ("BF1 3AA", True),
+        ("BF13AA", True),
+        (" BF2 0FR ", True),
         # Giro Bank valid postcode and invalid postcode
         ("GIR0AA", True),
         ("GIR0AB", False),
@@ -595,11 +598,6 @@ def test_if_postcode_is_a_real_uk_postcode_normalises_before_checking_postcode(m
         ("n53Ef", "N5 3EF"),
         ("n5 \u00A0 \t 3Ef", "N5 3EF"),
         ("SO146WB", "SO14 6WB"),
-        ("BFPO2", "BFPO 2"),
-        ("BFPO232", "BFPO 232"),
-        ("BFPO 2432", "BFPO 2432"),
-        ("BFPO C/O 2", "BFPO C/O 2"),
-        ("BFPO c/o 232", "BFPO C/O 232"),
         ("GIR0AA", "GIR 0AA"),
     ],
 )

--- a/tests/test_postal_address.py
+++ b/tests/test_postal_address.py
@@ -895,7 +895,7 @@ def test_bfpo_addresses(address, is_bfpo):
     ),
 )
 def test_bfpo_number_parsing(address, bfpo_number):
-    assert PostalAddress(address)._bfpo_number == bfpo_number
+    assert PostalAddress(address).bfpo_number == bfpo_number
 
 
 @pytest.mark.parametrize(

--- a/tests/test_postal_address.py
+++ b/tests/test_postal_address.py
@@ -933,7 +933,7 @@ def test_normalised_lines(address, expected_normalised_lines):
 
 
 @pytest.mark.parametrize(
-    "address, expected_bfpo_normalised_lines",
+    "address, expected_bfpo_address_lines",
     (
         ("Mr X\nBFPO 1", ["Mr X"]),
         ("Mr X\nBFPO 1\nBF1 1AA", ["Mr X"]),
@@ -941,13 +941,13 @@ def test_normalised_lines(address, expected_normalised_lines):
         ("Mr X\nbfpo\nBF1 1AA\nbfpo1", ["Mr X"]),
     ),
 )
-def test_bfpo_normalised_lines(address, expected_bfpo_normalised_lines):
-    assert PostalAddress(address).bfpo_normalised_lines == expected_bfpo_normalised_lines
+def test_bfpo_address_lines(address, expected_bfpo_address_lines):
+    assert PostalAddress(address).bfpo_address_lines == expected_bfpo_address_lines
 
 
-def test_bfpo_normalised_lines_error():
+def test_bfpo_address_lines_error():
     with pytest.raises(ValueError):
-        assert PostalAddress("Mr X\nLondon\nSW1 1AA").bfpo_normalised_lines
+        assert PostalAddress("Mr X\nLondon\nSW1 1AA").bfpo_address_lines
 
 
 def test_postal_address_equality():

--- a/tests/test_postal_address.py
+++ b/tests/test_postal_address.py
@@ -946,3 +946,15 @@ def test_bfpo_normalised_lines(address, expected_bfpo_normalised_lines):
 def test_bfpo_normalised_lines_error():
     with pytest.raises(ValueError):
         assert PostalAddress("Mr X\nLondon\nSW1 1AA").bfpo_normalised_lines
+
+
+def test_postal_address_equality():
+    assert PostalAddress("A\nB\nC") == PostalAddress("A\nB\nC"), "The same raw address should match"
+    assert PostalAddress("A\nB\nC") != PostalAddress("A\nB\nC\nD"), "Different addresses should not match"
+    assert PostalAddress("A\nB\nC") == PostalAddress("\nA\n  B  \nC\n"), "Extra lines/whitespace should be ignored"
+    assert PostalAddress("A\nB\nC", allow_international_letters=True) != PostalAddress(
+        "A\nB\nC", allow_international_letters=False
+    ), "Different international states don't match"
+    assert PostalAddress.from_personalisation(
+        {"address_line_1": "A", "address_line_2": "B", "address_line_3": "C"}
+    ) == PostalAddress("A\nB\nC"), "Different instantiation of the same address should still match"

--- a/tests/test_postal_address.py
+++ b/tests/test_postal_address.py
@@ -5,8 +5,8 @@ from notifications_utils.countries.data import Postage
 from notifications_utils.insensitive_dict import InsensitiveDict
 from notifications_utils.postal_address import (
     PostalAddress,
+    _is_a_real_uk_postcode,
     format_postcode_for_printing,
-    is_a_real_uk_postcode,
     normalise_postcode,
 )
 
@@ -575,13 +575,13 @@ def test_normalise_postcode(postcode, normalised_postcode):
     ],
 )
 def test_if_postcode_is_a_real_uk_postcode(postcode, result):
-    assert is_a_real_uk_postcode(postcode) is result
+    assert _is_a_real_uk_postcode(postcode) is result
 
 
 def test_if_postcode_is_a_real_uk_postcode_normalises_before_checking_postcode(mocker):
     normalise_postcode_mock = mocker.patch("notifications_utils.postal_address.normalise_postcode")
     normalise_postcode_mock.return_value = "SW11AA"
-    assert is_a_real_uk_postcode("sw1  1aa") is True
+    assert _is_a_real_uk_postcode("sw1  1aa") is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_postal_address.py
+++ b/tests/test_postal_address.py
@@ -924,6 +924,8 @@ def test_bfpo_number_parsing(address, bfpo_number):
         ("Mr X\nBFPO\nBFPO 1", ["Mr X", "BFPO 1"]),
         # BFPO capitalisation and spacing is normalised
         ("Mr X\nbfpo\nBF1 1AA\nbfpo1", ["Mr X", "BF1 1AA", "BFPO 1"]),
+        # Postcodes for BFPO addresses are still normalised
+        ("Mr X\nbfpo\nbf11aa\nbfpo1", ["Mr X", "BF1 1AA", "BFPO 1"]),
     ),
 )
 def test_normalised_lines(address, expected_normalised_lines):


### PR DESCRIPTION
This will let us annotate addresses as BFPO addresses and help our print provider process the letters more efficiently. In theory this change is optional - we could send these across as standard unstructuredAddresses, but it will require more manual work by our print provider/royal mail so it would be nice to not do that.

This shouldn't reject any addresses that were previously accepted, but it will change the normalised form of BFPO addresses.

Ideally we'll update admin, api and template-preview all in fairly quick succession (and the same day) but in _theory_ I think this should be safe to go out separately. The address might be normalised differently in different places (eg DB vs letter address block) but nothing should _break_. I think I've tested various combinations fairly thoroughly but it also does deserve a close inspection.

---

Add PostalAddress support for BFPO addresses.

There's quite a lot of potential variation in how BFPO addresses can be
supplied, but a relatively clear format for how they should be output:

https://www.gov.uk/bfpo/how-to-address-bfpo-mail

At the moment we require postcodes to be supplied for all addresses, and
this should be the last line. But BFPO addresses expect, for postage,
the last line to be a BFPO number. This adds support for accepting that
format.

If a BFPO postcode is used without a BFPO number line, it won't be
detected as a BFPO address or handled in any special way, but it should
still get delivered properly by Royal Mail. We just won't be able to
mark it up nicely for DVLA to help them sort it automatically.

---

Some anonymised examples of BFPO address formats we've received recently:

| Raw Address | Normalised to |
|---|---|
| Name<br>BRITISH FORCES<br>BFPO 123<br>BFPO<br>BF1 1AA | Name<br>BRITISH FORCES<br>BF1 1AA<br>BFPO 123 |
| Name<br>Location<br>Bfpo 26<br>BFPO<br>London<br>BF11AA | Name<br>Location<br>London<br>BF1 1AA<br>BFPO 26 |
| Name<br>BFPO 10<br>BFPO<br>BF1 1AA | Name<br>BF1 1AA<br>BFPO 10 |
| Name<br>BRITISH FORCES<br>BFPO 5311<br>BFPO<br>BF1 1AA | Name<br>BRITISH FORCES<br>BF1 1AA<br>BFPO 5311 |
| Name<br>Location<br>Bfpo 58<br>Bfpo<br>BF1 1AA | Name<br>Location<br>BF1 1AA<br>BFPO 58 |

We don't often see a format without postcodes at the moment, but this is currently supported and will continue to be supported:

| Raw Address | Normalised to |
|---|---|
| Name<br>Location<br>BFPO<br>BFPO 123 | Name<br>Location<br>BFPO 123 |

For API calls to our print provider we can provide address lines 1-4, plus a postcode, plus a bfpoNumber, so we add a helper method to return the normalised address lines without the postcode+bfpoNumber, allowing those to be injected separately. Otherwise we would have to do some detection in the app for how many lines to remove (just bfpo number or postcode + bfpo number).

## To manually test
Install this change on the api, admin, template-preview apps (`pip install -e ../notifications-utils`). Edit the `Makefile` for `template-preview` for step `run-flask-with-docker` to run `bash` instead of the `flask` command. Run `make flask-with-docker` and then `pip install notifications-utils@git+https://github.com/alphagov/notifications-utils.git@e59ba4eae236aa19e836f16707fb5e052fc6e5bb` and `flask run -h 0.0.0.0 -p 6013`

Then use admin to run through letter flows and test various addresses to send to.