### PR TITLE
Include country for normalised BFPO

### DIFF
--- a/notifications_utils/postal_address.py
+++ b/notifications_utils/postal_address.py
@@ -172,6 +172,11 @@ class PostalAddress:
     @property
     def normalised_lines(self):
         if self.is_bfpo_address:
+            if self.international:
+                return (
+                    self._lines_without_country_or_bfpo + [f"BFPO {self._bfpo_number}"] + [self.country.canonical_name]
+                )
+
             if self.postcode:
                 # Replace the raw postcode with the normalised (eg uppercase with spaces) postcode
                 return self._lines_without_country_or_bfpo[:-1] + [self.postcode] + [f"BFPO {self._bfpo_number}"]

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "62.0.0"  # 21e3362eb37366b9cadff927e56a4a68
+__version__ = "62.0.1"  # ba64fe26af18ef50bb7a7f31afcc8b18

--- a/tests/test_postal_address.py
+++ b/tests/test_postal_address.py
@@ -950,6 +950,23 @@ def test_bfpo_address_lines_error():
         assert PostalAddress("Mr X\nLondon\nSW1 1AA").bfpo_address_lines
 
 
+def test_bfpo_address_with_country_still_shows_country_in_normalised_lines_even_if_invalid():
+    assert (
+        PostalAddress(
+            """International BFPO
+            BFPO 1
+            BF1 1AA
+            usa"""
+        ).normalised_lines
+        == [
+            "International BFPO",
+            "BF1 1AA",
+            "BFPO 1",
+            "United States",
+        ]
+    )
+
+
 def test_postal_address_equality():
     assert PostalAddress("A\nB\nC") == PostalAddress("A\nB\nC"), "The same raw address should match"
     assert PostalAddress("A\nB\nC") != PostalAddress("A\nB\nC\nD"), "Different addresses should not match"


### PR DESCRIPTION
Although we consider this an invalid address, we should still include the country in the output as it was provided coming in.

Some apps, eg admin, process the address multiple times and so if we drop off the country, the latter processing steps won't consider the address invalid. We may want to fix that separately, but let's be safe on this side.