### PR TITLE
Add odd/even class to all letter pages

### DIFF
--- a/notifications_utils/jinja_templates/letter_image_template.jinja2
+++ b/notifications_utils/jinja_templates/letter_image_template.jinja2
@@ -1,5 +1,5 @@
 {% for page_number in page_numbers %}
-  <div class="letter">
+  <div class="letter page--{{ loop.cycle('odd', 'even') }}">
     {% if loop.first and show_postage %}
       <p class="letter-postage {{ postage_class_value }}">
         Postage: {{ postage_description }}

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "62.1.0"  # d021a3af441d1e4f04f8d2631c3cfa60
+__version__ = "62.2.0"  # e6cd1b9a8572a94c4706c55a52aa329a


### PR DESCRIPTION
[This pull request on admin](https://github.com/alphagov/notifications-admin/pull/4648) introduced a visual bug due to its use of `nth-of-type` assuming `.letter:nth-of-type(even)` would affect even-numbered elements matching this selector: `div.letter`.

It actually matches even-numbered `div` elements, filtered by whether they have the `letter` class or not.

You will be able to match even-numbered pages in CSS in future (see https://css-tricks.com/css-nth-of-class-selector/) but until then, we can use Jinja to add ~~a specific class~~ classes to indicate if a page is odd or even this instead.

Uses BEM syntax to indicate a state of page. There is currently no CSS in admin targeting this class so this can be merged with no impact.

Edit: I've updated this so it adds either `page--odd` or `page--even` to all pages as this seemed useful (taken from https://jinja.palletsprojects.com/en/3.0.x/tricks/#alternating-rows). My branch name now sounds silly.