### PR TITLE
Add support for Chinese character sets in letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 62.3.0
+
+* Adds support for Chinese character sets in letters
+
 ## 62.2.1
 
 * Injects the celery task ID into logging output if no requestId is present.

--- a/notifications_utils/jinja_templates/letter_pdf/_main_css.jinja2
+++ b/notifications_utils/jinja_templates/letter_pdf/_main_css.jinja2
@@ -17,7 +17,7 @@
     }
   }
   body {
-    font-family: 'Nimbus Sans L', 'FreeSans', sans-serif;
+    font-family: 'Nimbus Sans L', 'FreeSans', 'WenQuanYi Zen Hei', sans-serif;
     font-size: 12.5pt;
     line-height: {{ line_height }};
     letter-spacing: 0.01em;

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "62.2.1"  # 185e5f50a452d6d3758a6422bcb0b052
+__version__ = "62.3.0"  # 2e1c4021b37c145e5ee6f1f2e64a201e


### PR DESCRIPTION
The fonts we use in letters support all character sets we have tested, except for Chinese.

This commit adds WenQuanYi Zen Hei<sup>1</sup> to our font stack. This is a font which:
- is open source and [can be installed in our Docker images](https://github.com/alphagov/notifications-template-preview/pull/725)
- has glyphs for Chinese character sets

The way CSS works is that if the first font in the stack doesn’t have glyphs for a particular character it will fall back to the next font, then the next font, etc.

# Before

<img width="769" alt="image" src="https://user-images.githubusercontent.com/355079/234045318-0ec4b857-dca1-4806-9e3d-0060865f78b0.png">

# After

<img width="752" alt="image" src="https://user-images.githubusercontent.com/355079/234044724-38409bd0-9146-4070-be8c-5d8e53fc328f.png">

***

1. https://en.wikipedia.org/wiki/WenQuanYi