### PR TITLE
Stop logging formatting issues as errors/exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 62.3.1
+
+* Change `logger.exception` to `logger.warning` for log formatting error.
+
 ## 62.3.0
 
 * Adds support for Chinese character sets in letters

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -168,7 +168,7 @@ class CustomLogFormatter(logging.Formatter):
         try:
             record.msg = str(record.msg).format(**record.__dict__)
         except (KeyError, IndexError) as e:
-            logger.exception(f"failed to format log message: {e} not found")
+            logger.warning(f"failed to format log message: {e} not found")
         return super(CustomLogFormatter, self).format(record)
 
 
@@ -186,5 +186,5 @@ class JSONFormatter(BaseJSONFormatter):
         try:
             log_record["message"] = log_record["message"].format(**log_record)
         except (KeyError, IndexError) as e:
-            logger.exception(f"failed to format log message: {e} not found")
+            logger.warning(f"failed to format log message: {e} not found")
         return log_record

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "62.3.0"  # 2e1c4021b37c145e5ee6f1f2e64a201e
+__version__ = "62.3.1"  # bfb3be3a3d597455291535e651bb86d7


### PR DESCRIPTION
This will eat through our logging allowance and we definitely don't treat them as exceptions.