### PR TITLE
Add `class="page--first"` and `class="page--last"`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 62.4.0
+
+* Add `class="page--first"` and `class="page--last"` to the first and last
+  pages (respectively) of letters rendered with `LetterImageTemplate`
+
 ## 62.3.1
 
 * Change `logger.exception` to `logger.warning` for log formatting error.

--- a/notifications_utils/jinja_templates/letter_image_template.jinja2
+++ b/notifications_utils/jinja_templates/letter_image_template.jinja2
@@ -1,5 +1,5 @@
 {% for page_number in page_numbers %}
-  <div class="letter page--{{ loop.cycle('odd', 'even') }}">
+  <div class="letter page--{{ loop.cycle('odd', 'even') }}{% if loop.first %} page--first{% elif loop.last %} page--last{% endif %}">
     {% if loop.first and show_postage %}
       <p class="letter-postage {{ postage_class_value }}">
         Postage: {{ postage_description }}

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "62.3.1"  # bfb3be3a3d597455291535e651bb86d7
+__version__ = "62.4.0"  # 7cbb18bb981fe4b54b5aab26d51e9c55

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -995,6 +995,26 @@ def test_letter_image_renderer(
     )
 
 
+def test_letter_image_renderer_adds_classes_to_pages():
+    template = BeautifulSoup(
+        str(
+            LetterImageTemplate(
+                {"content": "Content", "subject": "Subject", "template_type": "letter"},
+                image_url="http://example.com/endpoint.png",
+                page_count=5,
+            )
+        ),
+        features="html.parser",
+    )
+    assert [page["class"] for page in template.select(".letter")] == [
+        ["letter", "page--odd", "page--first"],
+        ["letter", "page--even"],
+        ["letter", "page--odd"],
+        ["letter", "page--even"],
+        ["letter", "page--odd", "page--last"],
+    ]
+
+
 @freeze_time("2012-12-12 12:12:12")
 @mock.patch("notifications_utils.template.LetterImageTemplate.jinja_template.render")
 @pytest.mark.parametrize(


### PR DESCRIPTION
…to the first and last pages (respectively) of letters rendered with `LetterImageTemplate`.

This will let us target them with CSS which we can’t always do at the moment because of the limitations of selectors like `:first-child` and `:first-of-type`

Extends the approach taken in https://github.com/alphagov/notifications-utils/pull/1025

This will let us fix a bug where at the moment all letter pages have `0` bottom margin if the attach pages button is visible, whereas this was supposed to apply to the last page only:

![www notifications service gov uk_services_ea3b5c2d-d954-4907-a3ac-5bb9cef05005_templates_2ae6f848-ab56-487b-92cd-21e352cb05c0(iPad-Air)-(1)](https://github.com/alphagov/notifications-utils/assets/355079/f462674f-a86a-458b-9066-9c71abbda267)

