### PR TITLE
Remove auto-log formatting and standardise format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
   - id: check-yaml
   - id: debug-statements
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.0.261'
+  rev: 'v0.0.272'
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+# 65.0.0
+
+* Remove automatic formatting from JSONFormatter. Any log messages using `{}` to inject strings should be converted
+  to "old-style" log messages using %s and passing variables as arguments to the log function. Do not eagerly
+  interpolate the string (eg "log: {}" % ("string") - let Python's logging module do this itself. This is to provide
+  compatability with Sentry. Add the "G" rule to Ruff's checks to enforce this.
+* Removes `CustomLogFormatter` altogether, as its only purpose was the auto-formatting as above.
+
 ## 64.2.0
 
 * `LetterImageTemplate` now adds a hidden element marking the first page of any attachment

--- a/notifications_utils/celery.py
+++ b/notifications_utils/celery.py
@@ -34,7 +34,7 @@ def make_task(app):
             with self.app_context():
                 elapsed_time = time.monotonic() - self.start
 
-                app.logger.info(f"Celery task {self.name} (queue: {self.queue_name}) took {elapsed_time:.4f}")
+                app.logger.info("Celery task %s (queue: %s) took %.4f", self.name, self.queue_name, elapsed_time)
 
                 app.statsd_client.timing(
                     f"celery.{self.queue_name}.{self.name}.success",
@@ -44,7 +44,7 @@ def make_task(app):
         def on_failure(self, exc, task_id, args, kwargs, einfo):
             # enables request id tracing for these logs
             with self.app_context():
-                app.logger.exception(f"Celery task {self.name} (queue: {self.queue_name}) failed")
+                app.logger.exception("Celery task %s (queue: %s) failed", self.name, self.queue_name)
 
                 app.statsd_client.incr(f"celery.{self.queue_name}.{self.name}.failure")
 

--- a/notifications_utils/clients/antivirus/antivirus_client.py
+++ b/notifications_utils/clients/antivirus/antivirus_client.py
@@ -42,7 +42,7 @@ class AntivirusClient:
 
         except requests.RequestException as e:
             error = AntivirusError.from_exception(e)
-            current_app.logger.warning(f"Notify Antivirus API request failed with error: {error.message}")
+            current_app.logger.warning("Notify Antivirus API request failed with error: %s", error.message)
 
             raise error
         finally:

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -179,7 +179,7 @@ class RedisClient:
             return StubLock(redis=None, name="")
 
     def __handle_exception(self, e, raise_exception, operation, key_name):
-        current_app.logger.exception(f"Redis error performing {operation} on {key_name}")
+        current_app.logger.exception("Redis error performing %s on %s", operation, key_name)
         if raise_exception:
             raise e
 

--- a/notifications_utils/clients/statsd/statsd_client.py
+++ b/notifications_utils/clients/statsd/statsd_client.py
@@ -29,7 +29,7 @@ class NotifyStatsClient(StatsClientBase):
         except Exception as e:
             # if we get an error store None in the cache so that we don't keep trying to retrieve the DNS
             # if paas's dns server is having issues
-            current_app.logger.warning(f"Error resolving statsd dns: {e}")
+            current_app.logger.warning("Error resolving statsd dns: %s", e)
             return None
 
     def _send(self, data):
@@ -40,7 +40,7 @@ class NotifyStatsClient(StatsClientBase):
             if host:
                 self._sock.sendto(data.encode("ascii"), (host, self._port))
         except Exception as e:
-            current_app.logger.warning(f"Error sending statsd metric: {e}")
+            current_app.logger.warning("Error sending statsd metric: %s", e)
             pass
 
 

--- a/notifications_utils/clients/zendesk/zendesk_client.py
+++ b/notifications_utils/clients/zendesk/zendesk_client.py
@@ -73,13 +73,13 @@ class ZendeskClient:
                 current_app.logger.warning(f"Zendesk create ticket failed because user is suspended '{error_message}'")
                 return
             current_app.logger.error(
-                f"Zendesk create ticket request failed with {response.status_code} '{response.json()}'"
+                "Zendesk create ticket request failed with %s '%s'", response.status_code, response.json()
             )
             raise ZendeskError(response)
 
         ticket_id = response.json()["ticket"]["id"]
 
-        current_app.logger.info(f"Zendesk create ticket {ticket_id} succeeded")
+        current_app.logger.info("Zendesk create ticket %s succeeded", ticket_id)
 
     def _is_user_suspended(self, response):
         requester_error = response["details"].get("requester")
@@ -99,13 +99,13 @@ class ZendeskClient:
 
         if response.status_code != 201:
             current_app.logger.error(
-                f"Zendesk upload attachment request failed with {response.status_code} '{response.json()}'"
+                "Zendesk upload attachment request failed with %s '%s'", response.status_code, response.json()
             )
             raise ZendeskError(response)
 
         upload_token = response.json()["upload"]["token"]
 
-        current_app.logger.info(f"Zendesk upload attachment `{attachment.filename}` succeeded")
+        current_app.logger.info("Zendesk upload attachment `%s` succeeded", attachment.filename)
 
         return upload_token
 
@@ -144,13 +144,13 @@ class ZendeskClient:
 
         if response.status_code != 200:
             current_app.logger.error(
-                f"Zendesk update ticket request failed with {response.status_code} '{response.text}'"
+                "Zendesk update ticket request failed with %s '%s'", response.status_code, response.text
             )
             raise ZendeskError(response)
 
         ticket_id = response.json()["ticket"]["id"]
 
-        current_app.logger.info(f"Zendesk update ticket {ticket_id} succeeded")
+        current_app.logger.info("Zendesk update ticket %s succeeded", ticket_id)
 
 
 class NotifySupportTicket:

--- a/notifications_utils/clients/zendesk/zendesk_client.py
+++ b/notifications_utils/clients/zendesk/zendesk_client.py
@@ -70,7 +70,7 @@ class ZendeskClient:
         if response.status_code != 201:
             if response.status_code == 422 and self._is_user_suspended(response.json()):
                 error_message = response.json()["details"]
-                current_app.logger.warning(f"Zendesk create ticket failed because user is suspended '{error_message}'")
+                current_app.logger.warning("Zendesk create ticket failed because user is suspended '%s'", error_message)
                 return
             current_app.logger.error(
                 "Zendesk create ticket request failed with %s '%s'", response.status_code, response.json()

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -595,7 +595,7 @@ def try_validate_and_format_phone_number(number, international=None, log_msg=Non
         return validate_and_format_phone_number(number, international)
     except InvalidPhoneError as exc:
         if log_msg:
-            current_app.logger.warning(f"{log_msg}: {exc}")
+            current_app.logger.warning("%s: %s", log_msg, exc)
         return number
 
 

--- a/notifications_utils/s3.py
+++ b/notifications_utils/s3.py
@@ -30,7 +30,7 @@ def s3upload(
     try:
         key.put(**put_args)
     except botocore.exceptions.ClientError as e:
-        current_app.logger.error(f"Unable to upload file to S3 bucket {bucket_name}")
+        current_app.logger.error("Unable to upload file to S3 bucket %s", bucket_name)
         raise e
 
 

--- a/notifications_utils/statsd_decorators.py
+++ b/notifications_utils/statsd_decorators.py
@@ -18,7 +18,7 @@ def statsd(namespace):
             except Exception as e:
                 raise e
             else:
-                current_app.logger.debug(f"{namespace} call {func.__name__} took {elapsed_time:.4f}")
+                current_app.logger.debug("%s call %s took %.4f", namespace, func.__name__, elapsed_time)
                 return res
 
         wrapper.__wrapped__.__name__ = func.__name__

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "64.2.0"  # 0da4092243d5486e5b2a1d3ec7ef844d
+__version__ = "65.0.0"  # 18221bbd0d9219911715b9288cdaec44

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ select = [
     "I",  # isort
     "B",  # flake8-bugbear
     "C90",  # mccabe cyclomatic complexity
+    "G",  # flake8-logging-format
 ]
 ignore = []
 exclude = [

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -13,4 +13,4 @@ pytest-profiling==1.7.0
 redis>=4.3.4  # Earlier versions of redis miss features the tests need
 snakeviz==2.1.1
 black==22.10.0  # Also update `.pre-commit-config.yaml` if this changes
-ruff==0.0.261  # Also update `.pre-commit-config.yaml` if this changes
+ruff==0.0.272  # Also update `.pre-commit-config.yaml` if this changes

--- a/tests/clients/redis/test_redis_client.py
+++ b/tests/clients/redis/test_redis_client.py
@@ -1,7 +1,8 @@
 import inspect
+import logging
 import uuid
 from datetime import datetime
-from unittest.mock import Mock, call
+from unittest.mock import Mock
 
 import pytest
 import redis
@@ -57,25 +58,24 @@ def failing_redis_client(mocked_redis_client, delete_mock):
     return mocked_redis_client
 
 
-def test_should_not_raise_exception_if_raise_set_to_false(app, caplog, failing_redis_client, mocker):
-    mock_logger = mocker.patch("flask.Flask.logger")
+def test_should_not_raise_exception_if_raise_set_to_false(app, caplog, failing_redis_client):
+    with caplog.at_level(logging.ERROR):
+        assert failing_redis_client.get("get_key") is None
+        assert failing_redis_client.set("set_key", "set_value") is None
+        assert failing_redis_client.incr("incr_key") is None
+        assert failing_redis_client.exceeded_rate_limit("rate_limit_key", 100, 100) is False
+        assert failing_redis_client.delete("delete_key") is None
+        assert failing_redis_client.delete("a", "b", "c") is None
+        assert failing_redis_client.delete_by_pattern("pattern") == 0
 
-    assert failing_redis_client.get("get_key") is None
-    assert failing_redis_client.set("set_key", "set_value") is None
-    assert failing_redis_client.incr("incr_key") is None
-    assert failing_redis_client.exceeded_rate_limit("rate_limit_key", 100, 100) is False
-    assert failing_redis_client.delete("delete_key") is None
-    assert failing_redis_client.delete("a", "b", "c") is None
-    assert failing_redis_client.delete_by_pattern("pattern") == 0
-
-    assert mock_logger.mock_calls == [
-        call.exception("Redis error performing get on get_key"),
-        call.exception("Redis error performing set on set_key"),
-        call.exception("Redis error performing incr on incr_key"),
-        call.exception("Redis error performing rate-limit-pipeline on rate_limit_key"),
-        call.exception("Redis error performing delete on delete_key"),
-        call.exception("Redis error performing delete on a, b, c"),
-        call.exception("Redis error performing delete-by-pattern on pattern"),
+    assert caplog.messages == [
+        "Redis error performing get on get_key",
+        "Redis error performing set on set_key",
+        "Redis error performing incr on incr_key",
+        "Redis error performing rate-limit-pipeline on rate_limit_key",
+        "Redis error performing delete on delete_key",
+        "Redis error performing delete on a, b, c",
+        "Redis error performing delete-by-pattern on pattern",
     ]
 
 

--- a/tests/test_base64_uuid.py
+++ b/tests/test_base64_uuid.py
@@ -42,10 +42,10 @@ def test_base64_converter_to_url(python_val):
     ],
 )
 def test_base64_converter_to_python_raises_validation_error(url_val):
-    with pytest.raises(Exception):
+    with pytest.raises(Exception):  # noqa
         base64_to_uuid(url_val)
 
 
 def test_base64_converter_to_url_raises_validation_error():
-    with pytest.raises(Exception):
+    with pytest.raises(Exception):  # noqa
         uuid_to_base64(object())

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -18,7 +18,7 @@ def test_get_handlers_sets_up_logging_appropriately_with_debug(tmpdir):
 
     assert len(handlers) == 1
     assert type(handlers[0]) == builtin_logging.StreamHandler
-    assert type(handlers[0].formatter) == logging.CustomLogFormatter
+    assert type(handlers[0].formatter) == builtin_logging.Formatter
     assert not (tmpdir / "foo").exists()
 
 

--- a/tests/test_timezones.py
+++ b/tests/test_timezones.py
@@ -20,7 +20,7 @@ from notifications_utils.timezones import (
     ],
 )
 def test_utc_string_to_aware_gmt_datetime_rejects_bad_input(input_value):
-    with pytest.raises(Exception):
+    with pytest.raises(Exception):  # noqa
         utc_string_to_aware_gmt_datetime(input_value)
 
 


### PR DESCRIPTION
### ✅  ~Waiting for Ruff release including https://github.com/charliermarsh/ruff/pull/4253~

Removes the custom functionality to automatically try to inject variables into the log string. A whole host of our log messages were erroring out on this functionality because the variable didn't exist, or because we were logging out dictionaries which "".format() was trying, and failing, to handle.

Now that we've integrated Sentry, let's standardise on the "old-style" logging format, which looks something like this:

logger.info("Response %s took %.4f to generate", response.body, duration)

Python's logging system will automatically interpolate the message with the provided arguments, and sentry will group any error-level log messages as a single issue (the way we used to do things - like `logger.error(f"something went wrong: {exc}") would generate a unique sentry issue if exc generated a unique string for each instance of the error).

This is a breaking change: when pulling into any of the apps we should go through and systematically update all of the log messages to the "old-style" %s format. We can enforce this with the "G" rule in Ruff.