### PR TITLE
Allow zendesk ticket creation without notify type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+# 63.0.0
+
+* Remove the `technical_ticket` parameter from NotifySupportTicket; replace with an optional `notify_ticket_type`
+  that takes a NotifyTicketType enum value. If provided, this will maintain the existing behaviour where tickets are
+  tagged as technical/non-technical on creation. If omitted, then tickets will have no ticket type, which may help
+  us have a clearer process around triaging tickets.
+
 ## 62.4.0
 
 * Add `class="page--first"` and `class="page--last"` to the first and last

--- a/notifications_utils/clients/zendesk/zendesk_client.py
+++ b/notifications_utils/clients/zendesk/zendesk_client.py
@@ -18,8 +18,9 @@ DATETIME_FORMAT_ISO8601 = "%Y-%m-%dT%H:%M:%SZ"
 
 
 class NotifyTicketType(enum.Enum):
-    TECHNICAL = "technical"
-    NON_TECHNICAL = "non-technical"
+    # If you're adding a new value here, make sure it matches the custom field value in Zendesk.
+    TECHNICAL = "notify_ticket_type_technical"
+    NON_TECHNICAL = "notify_ticket_type_non_technical"
 
 
 class NotifySupportTicketStatus(enum.Enum):
@@ -234,9 +235,7 @@ class NotifySupportTicket:
         ]
 
         if self.notify_ticket_type:
-            technical_ticket_tag = (
-                f'notify_ticket_type_{"" if self.notify_ticket_type == NotifyTicketType.TECHNICAL else "non_"}technical'
-            )
-            custom_fields.append({"id": "1900000744994", "value": technical_ticket_tag})  # Notify Ticket type field
+            # Notify Ticket type field
+            custom_fields.append({"id": "1900000744994", "value": self.notify_ticket_type.value})
 
         return custom_fields

--- a/notifications_utils/clients/zendesk/zendesk_client.py
+++ b/notifications_utils/clients/zendesk/zendesk_client.py
@@ -17,6 +17,11 @@ class ZendeskError(Exception):
 DATETIME_FORMAT_ISO8601 = "%Y-%m-%dT%H:%M:%SZ"
 
 
+class NotifyTicketType(enum.Enum):
+    TECHNICAL = "technical"
+    NON_TECHNICAL = "non-technical"
+
+
 class NotifySupportTicketStatus(enum.Enum):
     NEW = "new"
     OPEN = "open"
@@ -168,7 +173,7 @@ class NotifySupportTicket:
         user_name=None,
         user_email=None,
         requester_sees_message_content=True,
-        technical_ticket=False,
+        notify_ticket_type: Optional[NotifyTicketType] = None,
         ticket_categories=None,
         org_id=None,
         org_type=None,
@@ -183,7 +188,7 @@ class NotifySupportTicket:
         self.user_name = user_name
         self.user_email = user_email
         self.requester_sees_message_content = requester_sees_message_content
-        self.technical_ticket = technical_ticket
+        self.notify_ticket_type = notify_ticket_type
         self.ticket_categories = ticket_categories or []
         self.org_id = org_id
         self.org_type = org_type
@@ -220,13 +225,18 @@ class NotifySupportTicket:
         return data
 
     def _get_custom_fields(self):
-        technical_ticket_tag = f'notify_ticket_type_{"" if self.technical_ticket else "non_"}technical'
         org_type_tag = f"notify_org_type_{self.org_type}" if self.org_type else None
-
-        return [
-            {"id": "1900000744994", "value": technical_ticket_tag},  # Notify Ticket type field
+        custom_fields = [
             {"id": "360022836500", "value": self.ticket_categories},  # Notify Ticket category field
             {"id": "360022943959", "value": self.org_id},  # Notify Organisation ID field
             {"id": "360022943979", "value": org_type_tag},  # Notify Organisation type field
             {"id": "1900000745014", "value": self.service_id},  # Notify Service ID field
         ]
+
+        if self.notify_ticket_type:
+            technical_ticket_tag = (
+                f'notify_ticket_type_{"" if self.notify_ticket_type == NotifyTicketType.TECHNICAL else "non_"}technical'
+            )
+            custom_fields.append({"id": "1900000744994", "value": technical_ticket_tag})  # Notify Ticket type field
+
+        return custom_fields

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "62.4.1"  # f8087bc97755a36a5ffa29acb7d7f6ed
+__version__ = "63.0.0"  # 2a69b770ac0e9f901019b5d33eef375b


### PR DESCRIPTION
At the moment all support tickets are raised with a notify ticket type assigned immediately (generally, non-technical). This is often misleading as we get technical queries through this channel as well. We can have a clearer triage process if tickets come in with no type, and then the first person to look at the ticket can assign it to either non-technical (product/design/research/general support) or technical (requiring dev input).