### PR TITLE
Move `postage` argument to base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 63.1.0
+
+* Let `postage` and `contact_block` be set on `LetterPreviewTemplate`
+
 # 63.0.0
 
 * Remove the `technical_ticket` parameter from NotifySupportTicket; replace with an optional `notify_ticket_type`

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -681,8 +681,17 @@ class BaseLetterTemplate(SubjectMixin, Template):
         self.admin_base_url = admin_base_url
         self.logo_file_name = logo_file_name
         self.date = date or datetime.utcnow()
+        self.postage = postage
 
-        if postage not in [None] + list(self.allowed_postage_types):
+    @property
+    def postage(self):
+        if self.postal_address.international:
+            return self.postal_address.postage
+        return self._postage
+
+    @postage.setter
+    def postage(self, value):
+        if value not in [None] + list(self.allowed_postage_types):
             raise TypeError(
                 "postage must be None, {}".format(
                     formatted_list(
@@ -693,14 +702,7 @@ class BaseLetterTemplate(SubjectMixin, Template):
                     )
                 )
             )
-
-        self._postage = postage
-
-    @property
-    def postage(self):
-        if self.postal_address.international:
-            return self.postal_address.postage
-        return self._postage
+        self._postage = value
 
     @property
     def subject(self):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "63.0.0"  # 2a69b770ac0e9f901019b5d33eef375b
+__version__ = "63.1.0"  # 4df8fe724bcd211aa7f11e8a5e8d10d9

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -996,6 +996,39 @@ def test_letter_image_renderer(
 
 
 @pytest.mark.parametrize(
+    "postage_args",
+    (
+        {},
+        {"postage": None},
+        {"postage": "first"},
+        {"postage": "second"},
+        {"postage": "europe"},
+        {"postage": "rest-of-world"},
+        pytest.param(
+            {"postage": "third"},
+            marks=pytest.mark.xfail(raises=TypeError),
+        ),
+    ),
+)
+@pytest.mark.parametrize(
+    "contact_block_args, expected_contact_block",
+    (
+        ({}, ""),
+        ({"contact_block": None}, ""),
+        ({"contact_block": "Example"}, "Example"),
+    ),
+)
+def test_postage_for_letter_preview_template(postage_args, contact_block_args, expected_contact_block):
+    template = LetterPreviewTemplate(
+        {"content": "Content", "subject": "Subject", "template_type": "letter"},
+        **contact_block_args,
+        **postage_args,
+    )
+    assert template.postage == postage_args.get("postage")
+    assert template.contact_block == expected_contact_block
+
+
+@pytest.mark.parametrize(
     "page_count, expected_classes",
     (
         (


### PR DESCRIPTION
At the moment we are forced to use `LetterImageTemplate` in a few places in the admin app because it’s the only one that has a `postage` attribute. The code would be less complex if we could use `LetterPreviewTemplate` everywhere.

Moving the handling of the `postage` argument to the base class gets the classes a bit closer to being polymorphic. This means that any subclass (including `LetterImageTemplate` and `LetterPreviewTemplate`) will always have a `postage` attribute.