### PR TITLE
Add some useful properties to letter template classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
 
+## 63.2.0
+
+* `LetterImageTemplate.page_count` is now a property which can be overriden by subclasses
+* New attributes and properties on `BaseLetterTemplate` (and its subclasses):
+  - `max_page_count`
+  - `max_sheet_count`
+  - `too_many_pages` (requires subclasses to implement `page_count`)
+
 ## 63.1.0
 
 * argument `image_url` to `LetterImageTemplate` is now optional unless calling `str(LetterImageTemplate(…))`

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -813,8 +813,12 @@ class LetterImageTemplate(BaseLetterTemplate):
                 )
             )
         self.image_url = image_url
-        self.page_count = int(page_count)
+        self._page_count = int(page_count)
         self._postage = postage
+
+    @property
+    def page_count(self):
+        return self._page_count
 
     @property
     def postage(self):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -782,6 +782,7 @@ class LetterImageTemplate(BaseLetterTemplate):
 
     jinja_template = template_env.get_template("letter_image_template.jinja2")
     first_page_number = 1
+    max_page_count = LETTER_MAX_PAGE_COUNT
     allowed_postage_types = (
         Postage.FIRST,
         Postage.SECOND,
@@ -828,7 +829,7 @@ class LetterImageTemplate(BaseLetterTemplate):
 
     @property
     def last_page_number(self):
-        return min(self.page_count, LETTER_MAX_PAGE_COUNT) + self.first_page_number
+        return min(self.page_count, self.max_page_count) + self.first_page_number
 
     @property
     def page_numbers(self):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -823,6 +823,10 @@ class LetterImageTemplate(BaseLetterTemplate):
         return self._page_count
 
     @property
+    def too_many_pages(self):
+        return self.page_count > self.max_page_count
+
+    @property
     def postage(self):
         if self.postal_address.international:
             return self.postal_address.postage

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -655,6 +655,8 @@ class EmailPreviewTemplate(BaseEmailTemplate):
 class BaseLetterTemplate(SubjectMixin, Template):
 
     template_type = "letter"
+    max_page_count = LETTER_MAX_PAGE_COUNT
+    max_sheet_count = max_page_count // 2
 
     address_block = "\n".join(f'(({line.replace("_", " ")}))' for line in address_lines_1_to_7_keys)
 
@@ -692,6 +694,10 @@ class BaseLetterTemplate(SubjectMixin, Template):
     @property
     def placeholders(self):
         return get_placeholders(self.contact_block) | super().placeholders
+
+    @property
+    def too_many_pages(self):
+        return self.page_count > self.max_page_count
 
     @property
     def postal_address(self):
@@ -782,8 +788,6 @@ class LetterImageTemplate(BaseLetterTemplate):
 
     jinja_template = template_env.get_template("letter_image_template.jinja2")
     first_page_number = 1
-    max_page_count = LETTER_MAX_PAGE_COUNT
-    max_sheet_count = max_page_count // 2
     allowed_postage_types = (
         Postage.FIRST,
         Postage.SECOND,
@@ -821,10 +825,6 @@ class LetterImageTemplate(BaseLetterTemplate):
     @property
     def page_count(self):
         return self._page_count
-
-    @property
-    def too_many_pages(self):
-        return self.page_count > self.max_page_count
 
     @property
     def postage(self):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -656,7 +656,7 @@ class BaseLetterTemplate(SubjectMixin, Template):
 
     template_type = "letter"
     max_page_count = LETTER_MAX_PAGE_COUNT
-    max_sheet_count = max_page_count // 2
+    max_sheet_count = LETTER_MAX_PAGE_COUNT // 2
 
     address_block = "\n".join(f'(({line.replace("_", " ")}))' for line in address_lines_1_to_7_keys)
 

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -783,6 +783,7 @@ class LetterImageTemplate(BaseLetterTemplate):
     jinja_template = template_env.get_template("letter_image_template.jinja2")
     first_page_number = 1
     max_page_count = LETTER_MAX_PAGE_COUNT
+    max_sheet_count = max_page_count // 2
     allowed_postage_types = (
         Postage.FIRST,
         Postage.SECOND,

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "63.1.0"  # 4f32fb168420d1a1e3eb068aa8bc7064
+__version__ = "63.2.0"  # 17e2409a5bac307076f017ff83632b76

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1040,6 +1040,26 @@ def test_letter_image_renderer_adds_classes_to_pages(
     assert [page["class"] for page in template.select(".letter")] == expected_classes
 
 
+@pytest.mark.parametrize(
+    "page_count, expected_too_many_pages",
+    (
+        (1, False),
+        (10, False),
+        (11, True),
+        (99, True),
+    ),
+)
+def test_letter_image_renderer_knows_if_letter_is_too_long(
+    page_count,
+    expected_too_many_pages,
+):
+    template = LetterImageTemplate(
+        {"content": "Content", "subject": "Subject", "template_type": "letter"},
+        page_count=page_count,
+    )
+    assert template.too_many_pages is expected_too_many_pages
+
+
 @freeze_time("2012-12-12 12:12:12")
 @mock.patch("notifications_utils.template.LetterImageTemplate.jinja_template.render")
 @pytest.mark.parametrize(

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1058,6 +1058,35 @@ def test_letter_image_renderer_knows_if_letter_is_too_long(
         page_count=page_count,
     )
     assert template.too_many_pages is expected_too_many_pages
+    assert template.max_page_count == 10
+    assert template.max_sheet_count == 5
+
+
+@pytest.mark.parametrize(
+    "template_class",
+    (
+        BaseLetterTemplate,
+        LetterPreviewTemplate,
+        LetterPrintTemplate,
+        LetterImageTemplate,
+    ),
+)
+def test_max_page_count_on_all_types_of_letter_template(template_class):
+    assert template_class.max_page_count == 10
+    assert template_class.max_sheet_count == 5
+
+
+@pytest.mark.parametrize(
+    "template_class",
+    (
+        LetterPreviewTemplate,
+        LetterPrintTemplate,
+    ),
+)
+def test_too_many_pages_raises_for_unknown_page_count(template_class):
+    template = template_class({"content": "Content", "subject": "Subject", "template_type": "letter"})
+    with pytest.raises(AttributeError):
+        template.too_many_pages  # noqa
 
 
 @freeze_time("2012-12-12 12:12:12")


### PR DESCRIPTION
This means that it can be overidden by subclasses.

Previously if a subclass tried to implement a `page_count` property then it would cause an exception where the `__init__` method is trying to assign to `self.page_count`.

Letting subclasses define their own `page_count` will mean there’s a nice place to put logic about how many pages are in a templated letter with an attachment, and on what page the attachment starts.

***

For convenience we can then add the following useful attributes and properties to all letter template classes:
- `max_page_count`
- `max_sheet_count`
- `too_many_pages` (requires subclasses to implement `page_count`)