### PR TITLE
Downgrade errors when a suspended user tries to create a Zendesk ticket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 63.3.0
+
+* Only log a warning and no longer raise an error if creating a Zendesk ticket fails because the user is suspended.
 
 ## 63.2.0
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "63.2.0"  # 17e2409a5bac307076f017ff83632b76
+__version__ = "63.3.0"  # 5b5a3b842c5e27a2189eb119352261fe

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -10,6 +10,7 @@ freezegun==1.2.2
 flake8-bugbear==22.10.27
 flake8-print==5.0.0
 pytest-profiling==1.7.0
+redis>=4.3.4  # Earlier versions of redis miss features the tests need
 snakeviz==2.1.1
 black==22.10.0  # Also update `.pre-commit-config.yaml` if this changes
 ruff==0.0.261  # Also update `.pre-commit-config.yaml` if this changes


### PR DESCRIPTION
We're seeing increasing numbers of errors in our logs because the Zendesk client has returned a 422 status code. This happens when a user has been suspended due to submitting spam tickets.

When this happens, we now log a warning and not an error.