### PR TITLE
Tweak how `LetterImageTemplate` is called with `page_count` and `postage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 64.0.0
+
+* Remove the `postage` argument from `LetterImageTemplate` in favour of getting `postage`
+  from the `template` `dict` (can still be overridden by setting `template_instance.postage`)
+* The `page_count` argument of `LetterImageTemplate` is now optional until the template is
+  rendered (calling `str(template)`)
+
 ## 63.4.0
 
 * Allow subheadings via markdown for emails using `##`.

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -805,20 +805,9 @@ class LetterImageTemplate(BaseLetterTemplate):
         postage=None,
     ):
         super().__init__(template, values, contact_block=contact_block)
-        if postage not in [None] + list(self.allowed_postage_types):
-            raise TypeError(
-                "postage must be None, {}".format(
-                    formatted_list(
-                        self.allowed_postage_types,
-                        conjunction="or",
-                        before_each="'",
-                        after_each="'",
-                    )
-                )
-            )
         self.image_url = image_url
         self._page_count = page_count
-        self._postage = postage
+        self.postage = postage
 
     @property
     def page_count(self):
@@ -829,6 +818,21 @@ class LetterImageTemplate(BaseLetterTemplate):
         if self.postal_address.international:
             return self.postal_address.postage
         return self._postage
+
+    @postage.setter
+    def postage(self, value):
+        if value not in [None] + list(self.allowed_postage_types):
+            raise TypeError(
+                "postage must be None, {}".format(
+                    formatted_list(
+                        self.allowed_postage_types,
+                        conjunction="or",
+                        before_each="'",
+                        after_each="'",
+                    )
+                )
+            )
+        self._postage = value
 
     @property
     def last_page_number(self):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -859,7 +859,7 @@ class LetterImageTemplate(BaseLetterTemplate):
     def __str__(self):
         for attr in ("page_count", "image_url"):
             if not getattr(self, attr):
-                raise TypeError(f"{attr} is required")
+                raise TypeError(f"{attr} is required to render {type(self).__name__}")
         return Markup(
             self.jinja_template.render(
                 {

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -805,8 +805,6 @@ class LetterImageTemplate(BaseLetterTemplate):
         postage=None,
     ):
         super().__init__(template, values, contact_block=contact_block)
-        if not page_count:
-            raise TypeError("page_count is required")
         if postage not in [None] + list(self.allowed_postage_types):
             raise TypeError(
                 "postage must be None, {}".format(
@@ -819,7 +817,7 @@ class LetterImageTemplate(BaseLetterTemplate):
                 )
             )
         self.image_url = image_url
-        self._page_count = int(page_count)
+        self._page_count = page_count
         self._postage = postage
 
     @property
@@ -859,6 +857,8 @@ class LetterImageTemplate(BaseLetterTemplate):
         }.get(self.postage)
 
     def __str__(self):
+        if not self.page_count:
+            raise TypeError("page_count is required")
         if not self.image_url:
             raise TypeError("image_url is required")
         return Markup(

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -802,12 +802,11 @@ class LetterImageTemplate(BaseLetterTemplate):
         image_url=None,
         page_count=None,
         contact_block=None,
-        postage=None,
     ):
         super().__init__(template, values, contact_block=contact_block)
         self.image_url = image_url
         self._page_count = page_count
-        self.postage = postage
+        self.postage = template.get("postage")
 
     @property
     def page_count(self):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -857,10 +857,9 @@ class LetterImageTemplate(BaseLetterTemplate):
         }.get(self.postage)
 
     def __str__(self):
-        if not self.page_count:
-            raise TypeError("page_count is required")
-        if not self.image_url:
-            raise TypeError("image_url is required")
+        for attr in ("page_count", "image_url"):
+            if not getattr(self, attr):
+                raise TypeError(f"{attr} is required")
         return Markup(
             self.jinja_template.render(
                 {

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "63.4.0"  # dfe8fc8a09a0f631c580d6ea6fccfc91
+__version__ = "64.0.0"  # 63abb2775c78fbdb9b70daac17d78d2e

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1167,7 +1167,7 @@ def test_letter_image_renderer_pagination(page_image_url):
         (
             {"image_url": "foo"},
             TypeError,
-            "page_count is required",
+            "page_count is required to render LetterImageTemplate",
         ),
         (
             {"image_url": "foo", "page_count": "foo"},
@@ -1200,7 +1200,7 @@ def test_letter_image_renderer_requires_image_url_to_render():
     )
     with pytest.raises(TypeError) as exception:
         str(template)
-    assert str(exception.value) == "image_url is required"
+    assert str(exception.value) == "image_url is required to render LetterImageTemplate"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Removes the `postage` argument from `LetterImageTemplate` in favour of getting `postage` from the template `dict` (can still be overridden by setting `template_instance.postage`). This will be nicer than how we currently override postage on a template: https://github.com/alphagov/notifications-admin/blob/867bd24d81e8003c2ca4b44d8c71ed497d86d1d4/app/main/views/uploads.py#L269-L272


The `page_count` argument of `LetterImageTemplate` is now optional until the template is rendered (calling `str(template)`). This means we can avoid dummy values like we’re using here: https://github.com/alphagov/notifications-admin/blob/867bd24d81e8003c2ca4b44d8c71ed497d86d1d4/app/utils/templates.py#L25