### PR TITLE
Invisibly mark the first page of a letter attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 64.2.0
+
+* `LetterImageTemplate` now adds a hidden element marking the first page of any attachment
+
 ## 64.1.0
 
 * `RequestCache` now stores items in Redis for 28 days by default (2419200 seconds instead

--- a/notifications_utils/jinja_templates/letter_image_template.jinja2
+++ b/notifications_utils/jinja_templates/letter_image_template.jinja2
@@ -8,7 +8,7 @@
     {% if page_number == first_page_of_attachment %}
     <div id="first-page-of-attachment"></div>
     {% endif %}
-    <img src="{{ image_url }}?page={{ page_number }}" alt="" loading="{{ 'eager' if loop.first else 'lazy' }}">
+    <img src="{{ image_url }}?page={{ page_number }}" alt="" loading="{{ 'eager' if page_number in (1, first_page_of_attachment) else 'lazy' }}">
   </div>
 {% endfor %}
 

--- a/notifications_utils/jinja_templates/letter_image_template.jinja2
+++ b/notifications_utils/jinja_templates/letter_image_template.jinja2
@@ -5,6 +5,9 @@
         Postage: {{ postage_description }}
       </p>
     {% endif %}
+    {% if page_number == first_page_of_attachment %}
+    <div id="first-page-of-attachment"></div>
+    {% endif %}
     <img src="{{ image_url }}?page={{ page_number }}" alt="" loading="{{ 'eager' if loop.first else 'lazy' }}">
   </div>
 {% endfor %}

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -859,6 +859,11 @@ class LetterImageTemplate(BaseLetterTemplate):
             Postage.REST_OF_WORLD: "letter-postage-international",
         }.get(self.postage)
 
+    @property
+    def first_page_of_attachment(self):
+        if getattr(self, "attachment", None):
+            return self.page_count - self.attachment.page_count + 1
+
     def __str__(self):
         for attr in ("page_count", "image_url"):
             if not getattr(self, attr):
@@ -868,6 +873,7 @@ class LetterImageTemplate(BaseLetterTemplate):
                 {
                     "image_url": self.image_url,
                     "page_numbers": self.page_numbers,
+                    "first_page_of_attachment": self.first_page_of_attachment,
                     "address": self._address_block,
                     "contact_block": self._contact_block,
                     "date": self._date,

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "64.1.0"  # 4ed8a5cbd39c1551c55b1305df7420cc
+__version__ = "64.2.0"  # 0da4092243d5486e5b2a1d3ec7ef844d

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -3084,7 +3084,7 @@ def test_letter_image_template_marks_first_page_of_attachment():
         '<img alt="" loading="lazy" src="http://example.com/endpoint.png?page=4"/>',
         '<img alt="" loading="lazy" src="http://example.com/endpoint.png?page=5"/>',
         '<div id="first-page-of-attachment"></div>',
-        '<img alt="" loading="lazy" src="http://example.com/endpoint.png?page=6"/>',
+        '<img alt="" loading="eager" src="http://example.com/endpoint.png?page=6"/>',
         '<img alt="" loading="lazy" src="http://example.com/endpoint.png?page=7"/>',
         '<img alt="" loading="lazy" src="http://example.com/endpoint.png?page=8"/>',
     ]

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -973,6 +973,7 @@ def test_letter_image_renderer(
         {
             "image_url": "http://example.com/endpoint.png",
             "page_numbers": expected_page_numbers,
+            "first_page_of_attachment": None,
             "address": [
                 "<span class='placeholder-no-brackets'>address line 1</span>",
                 "<span class='placeholder-no-brackets'>address line 2</span>",
@@ -3056,3 +3057,34 @@ def test_broadcast_message_single_counts_diacritics_in_gsm(
     )
     assert template.encoded_content_count == 1
     assert template.max_content_count == 1_395
+
+
+def test_letter_image_template_marks_first_page_of_attachment():
+    class Attachment:
+        page_count = 3
+
+    class LetterImageTemplateWithAttachment(LetterImageTemplate):
+        attachment = Attachment()
+        page_count = 8
+
+    template = BeautifulSoup(
+        str(
+            LetterImageTemplateWithAttachment(
+                {"content": "Content", "subject": "Subject", "template_type": "letter"},
+                image_url="http://example.com/endpoint.png",
+            )
+        ),
+        features="html.parser",
+    )
+
+    assert [str(element) for element in template.select(".letter *")] == [
+        '<img alt="" loading="eager" src="http://example.com/endpoint.png?page=1"/>',
+        '<img alt="" loading="lazy" src="http://example.com/endpoint.png?page=2"/>',
+        '<img alt="" loading="lazy" src="http://example.com/endpoint.png?page=3"/>',
+        '<img alt="" loading="lazy" src="http://example.com/endpoint.png?page=4"/>',
+        '<img alt="" loading="lazy" src="http://example.com/endpoint.png?page=5"/>',
+        '<div id="first-page-of-attachment"></div>',
+        '<img alt="" loading="lazy" src="http://example.com/endpoint.png?page=6"/>',
+        '<img alt="" loading="lazy" src="http://example.com/endpoint.png?page=7"/>',
+        '<img alt="" loading="lazy" src="http://example.com/endpoint.png?page=8"/>',
+    ]


### PR DESCRIPTION
So that we can jump directly to it using an anchor link.

Separate element instead of adding an `id` to the image so that we can control the exact positioning without changing the position of the visible element (i.e. the preview of the page itself).

Also adds `loading=eager` to the first page of the attachment as a hint to browsers. If the user is jumped straight to the first page of the attachment then we should try to load that as quickly as possible, rather than loading all the intermediary templated pages first.