### PR TITLE
Extend default request cache expiry from 7 to 28 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 64.1.0
+
+* `RequestCache` now stores items in Redis for 28 days by default (2419200 seconds instead
+  of 7 days or 604800 seconds)
+
 ## 64.0.0
 
 * Remove the `postage` argument from `LetterImageTemplate` in favour of getting `postage`

--- a/notifications_utils/clients/redis/request_cache.py
+++ b/notifications_utils/clients/redis/request_cache.py
@@ -7,7 +7,7 @@ from inspect import signature
 
 class RequestCache:
 
-    DEFAULT_TTL = int(timedelta(days=7).total_seconds())
+    DEFAULT_TTL = int(timedelta(days=28).total_seconds())
 
     def __init__(self, redis_client):
         self.redis_client = redis_client

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "64.0.0"  # 63abb2775c78fbdb9b70daac17d78d2e
+__version__ = "64.1.0"  # 4ed8a5cbd39c1551c55b1305df7420cc

--- a/tests/clients/redis/test_request_cache.py
+++ b/tests/clients/redis/test_request_cache.py
@@ -55,7 +55,7 @@ def test_set(
     mock_redis_set.assert_called_once_with(
         expected_cache_key,
         '"bar"',
-        ex=604_800,
+        ex=2_419_200,
     )
 
 


### PR DESCRIPTION
According to the Redis metrics from the PaaS the most we’ve used in the last 30 days is about 20% of the 568mb provided by our plan.

The longer we keep things in the cache, the more likely they are to be served from it, rather than having to go to the origin  (the API). Serving things from the cache is generally faster than serving them from the origin.

The worst case scenario is that by quadrupling the expiry time we quadruple the number of items in the cache. This would still only use 80% of the available memory, which still gives some headroom.

The worst case scenario is unlikely, because many of the things we cache at the moment will be accessed frequently. This means that they will get re-accessed and re-cached soon after they expire.

Most of the performance benefit here will come for items that are infrequently accessed. For example users who don’t log in very often or templates which aren’t sent very often. So while it may be a small improvement it’s worth doing – we are paying for the storage either way.