### PR TITLE
Add mappings for international phone countries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 65.1.0
+
+* Add a few more mappings to the list of countries for postage
+
 # 65.0.0
 
 * Remove automatic formatting from JSONFormatter. Any log messages using `{}` to inject strings should be converted

--- a/notifications_utils/countries/_data/synonyms.json
+++ b/notifications_utils/countries/_data/synonyms.json
@@ -62,5 +62,15 @@
   "West Germany": "Germany",
   "Saint Kitts and Nevis": "St Kitts and Nevis",
   "Saint Kitts": "St Kitts and Nevis",
-  "St Kitts": "St Kitts and Nevis"
+  "St Kitts": "St Kitts and Nevis",
+  "Virgin Islands, British": "British Virgin Islands",
+  "Congo, Democratic Republic of": "Congo",
+  "Curacao (former Netherlands Antilles)": "Curaçao",
+  "Djibouti, Republic of": "Djibouti",
+  "Dominica, Commonwealth of": "Dominica",
+  "Korea, Republic of": "South Korea",
+  "Micronesia, Federated States of": "Micronesia",
+  "Palestinian Territory": "Occupied Palestinian Territories",
+  "Rwanda, Republic of": "Rwanda",
+  "San Marino, Republic of": "San Marino"
 }

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "65.0.0"  # 18221bbd0d9219911715b9288cdaec44
+__version__ = "65.1.0"  # 1d73aba265e6015f4268dea22f856d71

--- a/tests/test_countries.py
+++ b/tests/test_countries.py
@@ -117,6 +117,16 @@ def test_crowdsourced_test_data():
         ("Illes Balears", "Balearic Islands"),
         ("Corsica", "Corsica"),
         ("Corse", "Corsica"),
+        ("Congo, Democratic Republic of", "Congo"),
+        ("Curacao (former Netherlands Antilles)", "Curaçao"),
+        ("Djibouti, Republic of", "Djibouti"),
+        ("Dominica, Commonwealth of", "Dominica"),
+        ("Korea, Republic of", "South Korea"),
+        ("Micronesia, Federated States of", "Micronesia"),
+        ("Palestinian Territory", "Occupied Palestinian Territories"),
+        ("Rwanda, Republic of", "Rwanda"),
+        ("San Marino, Republic of", "San Marino"),
+        ("Virgin Islands, British", "British Virgin Islands"),
     ),
 )
 def test_hand_crafted_synonyms(search, expected):


### PR DESCRIPTION
If we want to display the correct names for countries we need to be able to map from the source data to what we consider the canonical names.

This commit adds data to our countries list so that we can do that.

Whether or not this is used for international SMS, it’s always good to make these mappings more robust and comprehensive for international letters.