### PR TITLE
Switch from PyPDF2->pypdf>=3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 66.0.0
+
+* Switch from PyPDF2 to pypdf, and bump to version 3.9.0. This addresses an infinite loop vulnerability in PDF processing (https://nvd.nist.gov/vuln/detail/CVE-2023-36464).
+
 ## 65.2.0
 
 * Update international billing rates for text messages to latest values from MMG.

--- a/notifications_utils/pdf.py
+++ b/notifications_utils/pdf.py
@@ -1,8 +1,8 @@
 import io
 
-import PyPDF2
-from PyPDF2 import PdfWriter
-from PyPDF2.errors import PdfReadError
+import pypdf
+from pypdf import PdfWriter
+from pypdf.errors import PdfReadError
 
 from notifications_utils import LETTER_MAX_PAGE_COUNT
 
@@ -11,10 +11,10 @@ def pdf_page_count(src_pdf):
     """
     Returns number of pages in a pdf file
 
-    :param PyPDF2.PdfReader src_pdf: A File object or an object that supports the standard read and seek methods
+    :param pypdf.PdfReader src_pdf: A File object or an object that supports the standard read and seek methods
     """
     try:
-        pdf = PyPDF2.PdfReader(src_pdf)
+        pdf = pypdf.PdfReader(src_pdf)
     except AttributeError as e:
         raise PdfReadError("Could not open PDF file, stream is null", e) from e
 
@@ -38,7 +38,7 @@ def extract_page_from_pdf(src_pdf, page_number):
     :param src_pdf: File object or an object that supports the standard read and seek methods similar to a File object.
     :param page_number: The page number to retrieve (pages begin at zero)
     """
-    pdf = PyPDF2.PdfReader(src_pdf)
+    pdf = pypdf.PdfReader(src_pdf)
 
     if len(pdf.pages) < page_number:
         raise PdfReadError(f"Page number requested: {page_number} of {len(pdf.pages)} does not exist in document")

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,5 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-
-__version__ = "65.3.0"  # 4a51dc1f85d8dd733e46028ec0f4ec1c
+__version__ = "66.0.0"  # cb23160ac8cbf60dc01dad4361bfc21b

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
         "pyproj>=3.4.1",
         "pytz>=2020.4",
         "smartypants>=2.0.1",
-        "pypdf2>=2.0.0",
+        "pypdf>=3.9.0",
         "itsdangerous>=1.1.0",
         "govuk-bank-holidays>=0.10,<1.0",
         "geojson>=2.5.0",

--- a/tests/test_pdf.py
+++ b/tests/test_pdf.py
@@ -1,9 +1,9 @@
 import base64
 from io import BytesIO
 
-import PyPDF2
+import pypdf
 import pytest
-from PyPDF2.errors import PdfReadError
+from pypdf.errors import PdfReadError
 
 from notifications_utils.pdf import (
     extract_page_from_pdf,
@@ -45,9 +45,9 @@ def test_extract_page_from_pdf_one_page_pdf():
     file_data = base64.b64decode(one_page_pdf)
     pdf_page = extract_page_from_pdf(BytesIO(file_data), 0)
 
-    pdf_original = PyPDF2.PdfReader(BytesIO(file_data))
+    pdf_original = pypdf.PdfReader(BytesIO(file_data))
 
-    pdf_new = PyPDF2.PdfReader(BytesIO(pdf_page))
+    pdf_new = pypdf.PdfReader(BytesIO(pdf_page))
 
     assert pdf_original.pages[0].extract_text() == pdf_new.pages[0].extract_text()
 
@@ -56,9 +56,9 @@ def test_extract_page_from_pdf_multi_page_pdf():
     file_data = base64.b64decode(multi_page_pdf)
     pdf_page = extract_page_from_pdf(BytesIO(file_data), 4)
 
-    pdf_original = PyPDF2.PdfReader(BytesIO(file_data))
+    pdf_original = pypdf.PdfReader(BytesIO(file_data))
 
-    pdf_new = PyPDF2.PdfReader(BytesIO(pdf_page))
+    pdf_new = pypdf.PdfReader(BytesIO(pdf_page))
 
     assert pdf_original.pages[4].extract_text() == pdf_new.pages[0].extract_text()
     assert pdf_original.pages[3].extract_text() != pdf_new.pages[0].extract_text()


### PR DESCRIPTION
Addresses a vulnerability in PyPDF2
(https://github.com/alphagov/document-download-api/security/dependabot/16).

Also, PyPDF2 is now deprecated and development is continuing back on `pypdf`:

* https://pypi.org/project/PyPDF2/
* https://pypi.org/project/pypdf/

---

Although we are going up a major version, the breaking changes are minimal and none of them appear to affect us:

https://pypdf2.readthedocs.io/en/latest/meta/CHANGELOG.html
https://pypdf.readthedocs.io/en/latest/meta/CHANGELOG.html#version-3-1-0-2022-12-23