### PR TITLE
HTML encode personalisation parentheses so they don't break links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 66.0.1
+
+* Use HTML-encoded parenthesis (`(` and `)`) when rendering template content with placeholders.
+* Bump `phonenumbers` to `>= 8.13.8`.
+
 ## 66.0.0
 
 * Switch from PyPDF2 to pypdf, and bump to version 3.9.0. This addresses an infinite loop vulnerability in PDF processing (https://nvd.nist.gov/vuln/detail/CVE-2023-36464).

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -66,8 +66,8 @@ class Field:
         r"([^()]+)"  # body of placeholder - potentially standard or conditional.
         r"\){2}"  # closing ))
     )
-    placeholder_tag = "<span class='placeholder'>(({}))</span>"
-    conditional_placeholder_tag = "<span class='placeholder-conditional'>(({}??</span>{}))"
+    placeholder_tag = "<span class='placeholder'>&#40;&#40;{}&#41;&#41;</span>"
+    conditional_placeholder_tag = "<span class='placeholder-conditional'>&#40;&#40;{}??</span>{}&#41;&#41;"
     placeholder_tag_no_brackets = "<span class='placeholder-no-brackets'>{}</span>"
     placeholder_tag_redacted = "<span class='placeholder-redacted'>hidden</span>"
 

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -105,11 +105,11 @@ class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
         return f"<li>{text.strip()}</li>\n"
 
     def link(self, link, title, content):
-
         if InsensitiveDict.make_key(content) == "qr":
             qr_data = replace_svg_dashes(qr_code_as_svg(link))
             if "span class='placeholder" in link:
-                return f"<div class='qrcode-placeholder'><{link}></div>"
+                return f"<div class='qrcode-placeholder'>{link}</div>"
+
             return f"<div class='qrcode'>{qr_data}</div>"
 
         return f"{content}: {self.autolink(link)}"

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -105,9 +105,12 @@ class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
         return f"<li>{text.strip()}</li>\n"
 
     def link(self, link, title, content):
+        if link.startswith("span class='placeholder") and link.endswith("</span"):
+            link = f"<{link}>"
+
         if InsensitiveDict.make_key(content) == "qr":
             qr_data = replace_svg_dashes(qr_code_as_svg(link))
-            if "span class='placeholder" in link:
+            if "<span class='placeholder" in link:
                 return f"<div class='qrcode-placeholder'>{link}</div>"
 
             return f"<div class='qrcode'>{qr_data}</div>"
@@ -199,6 +202,8 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
         )
 
     def link(self, link, title, content):
+        if link.startswith("span class='placeholder") and link.endswith("</span"):
+            link = f"<{link}>"
         if title:
             return f'<a style="{LINK_STYLE}" href="{link}" title="{title}">{content}</a>'
         return f'<a style="{LINK_STYLE}" href="{link}">{content}</a>'

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "66.0.0"  # cb23160ac8cbf60dc01dad4361bfc21b
+__version__ = "66.0.1"  # 8ffe8aee68eaea610de610312c3a0fb1

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -145,11 +145,11 @@ def test_optional_redacting_of_missing_values(template_content, data, expected):
 @pytest.mark.parametrize(
     "content,expected",
     [
-        ("((colour))", "<span class='placeholder'>((colour))</span>"),
-        ("the quick ((colour)) fox", "the quick <span class='placeholder'>((colour))</span> fox"),
+        ("((colour))", "<span class='placeholder'>&#40;&#40;colour&#41;&#41;</span>"),
+        ("the quick ((colour)) fox", "the quick <span class='placeholder'>&#40;&#40;colour&#41;&#41;</span> fox"),
         (
             "((article)) quick ((colour)) ((animal))",
-            "<span class='placeholder'>((article))</span> quick <span class='placeholder'>((colour))</span> <span class='placeholder'>((animal))</span>",  # noqa
+            "<span class='placeholder'>&#40;&#40;article&#41;&#41;</span> quick <span class='placeholder'>&#40;&#40;colour&#41;&#41;</span> <span class='placeholder'>&#40;&#40;animal&#41;&#41;</span>",  # noqa
         ),
         (
             """
@@ -158,24 +158,24 @@ def test_optional_redacting_of_missing_values(template_content, data, expected):
                 ((animal))
             """,
             """
-                <span class='placeholder'>((article))</span> quick
-                <span class='placeholder'>((colour))</span>
-                <span class='placeholder'>((animal))</span>
+                <span class='placeholder'>&#40;&#40;article&#41;&#41;</span> quick
+                <span class='placeholder'>&#40;&#40;colour&#41;&#41;</span>
+                <span class='placeholder'>&#40;&#40;animal&#41;&#41;</span>
             """,
         ),
-        ("the quick (((colour))) fox", "the quick (<span class='placeholder'>((colour))</span>) fox"),
-        ("((warning?))", "<span class='placeholder'>((warning?))</span>"),
+        ("the quick (((colour))) fox", "the quick (<span class='placeholder'>&#40;&#40;colour&#41;&#41;</span>) fox"),
+        ("((warning?))", "<span class='placeholder'>&#40;&#40;warning?&#41;&#41;</span>"),
         (
             "((warning? This is not a conditional))",
-            "<span class='placeholder'>((warning? This is not a conditional))</span>",
+            "<span class='placeholder'>&#40;&#40;warning? This is not a conditional&#41;&#41;</span>",
         ),
         (
             "((warning?? This is a warning))",
-            "<span class='placeholder-conditional'>((warning??</span> This is a warning))",
+            "<span class='placeholder-conditional'>&#40;&#40;warning??</span> This is a warning&#41;&#41;",
         ),
         (
             "((warning?? This is a warning\n text after linebreak))",
-            "<span class='placeholder-conditional'>((warning??</span> This is a warning\n text after linebreak))",
+            "<span class='placeholder-conditional'>&#40;&#40;warning??</span> This is a warning\n text after linebreak&#41;&#41;",  # noqa
         ),
     ],
 )
@@ -189,17 +189,17 @@ def test_formatting_of_placeholders(content, expected):
         (
             "((name)) ((colour))",
             {"name": "Jo"},
-            "Jo <span class='placeholder'>((colour))</span>",
+            "Jo <span class='placeholder'>&#40;&#40;colour&#41;&#41;</span>",
         ),
         (
             "((name)) ((colour))",
             {"name": "Jo", "colour": None},
-            "Jo <span class='placeholder'>((colour))</span>",
+            "Jo <span class='placeholder'>&#40;&#40;colour&#41;&#41;</span>",
         ),
         (
             "((show_thing??thing)) ((colour))",
             {"colour": "red"},
-            "<span class='placeholder-conditional'>((show_thing??</span>thing)) red",
+            "<span class='placeholder-conditional'>&#40;&#40;show_thing??</span>thing&#41;&#41; red",
         ),
     ],
 )

--- a/tests/test_field_html_handling.py
+++ b/tests/test_field_html_handling.py
@@ -15,8 +15,8 @@ from notifications_utils.field import Field
         (
             "string ((<em>with</em>)) html",
             {},
-            "string <span class='placeholder'>((&lt;em&gt;with&lt;/em&gt;))</span> html",
-            "string <span class='placeholder'>((<em>with</em>))</span> html",
+            "string <span class='placeholder'>&#40;&#40;&lt;em&gt;with&lt;/em&gt;&#41;&#41;</span> html",
+            "string <span class='placeholder'>&#40;&#40;<em>with</em>&#41;&#41;</span> html",
         ),
         (
             "string ((placeholder)) html",
@@ -30,15 +30,15 @@ from notifications_utils.field import Field
             (
                 "string "
                 "<span class='placeholder-conditional'>"
-                "((&lt;em&gt;conditional&lt;/em&gt;??</span>"
-                "&lt;em&gt;placeholder&lt;/em&gt;)) "
+                "&#40;&#40;&lt;em&gt;conditional&lt;/em&gt;??</span>"
+                "&lt;em&gt;placeholder&lt;/em&gt;&#41;&#41; "
                 "html"
             ),
             (
                 "string "
                 "<span class='placeholder-conditional'>"
-                "((<em>conditional</em>??</span>"
-                "<em>placeholder</em>)) "
+                "&#40;&#40;<em>conditional</em>??</span>"
+                "<em>placeholder</em>&#41;&#41; "
                 "html"
             ),
         ),

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -3134,6 +3134,29 @@ def test_letter_image_template_marks_first_page_of_attachment():
             ("<p>Example: <strong>pre<span class='placeholder'>&#40;&#40;var&#41;&#41;</span>post</strong></p>"),
         ),
         (
+            LetterPreviewTemplate,
+            {"template_type": "letter", "subject": "foo", "content": "[QR](((var)))"},
+            "<p><div class='qrcode‑placeholder'><span class='placeholder'>&#40;&#40;var&#41;&#41;</span></div></p>",
+        ),
+        (
+            LetterPreviewTemplate,
+            {"template_type": "letter", "subject": "foo", "content": "[QR](https://blah.blah/?query=((var)))"},
+            (
+                "<p><div class='qrcode‑placeholder'>"
+                "https://blah.blah/?query=<span class='placeholder'>&#40;&#40;var&#41;&#41;</span>"
+                "</div></p>"
+            ),
+        ),
+        (
+            LetterPreviewTemplate,
+            {"template_type": "letter", "subject": "foo", "content": "[QR](pre((var))post)"},
+            (
+                "<p><div class='qrcode‑placeholder'>"
+                "pre<span class='placeholder'>&#40;&#40;var&#41;&#41;</span>post"
+                "</div></p>"
+            ),
+        ),
+        (
             EmailPreviewTemplate,
             {"template_type": "email", "subject": "foo", "content": "[Example](((var)))"},
             (

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -3117,7 +3117,7 @@ def test_letter_image_template_marks_first_page_of_attachment():
         (
             LetterPreviewTemplate,
             {"template_type": "letter", "subject": "foo", "content": "[Example](((var)))"},
-            "<p>Example: <strong>span class=’placeholder’>&#40;&#40;var&#41;&#41;</span</strong></p>",
+            "<p>Example: <strong><span class='placeholder'>&#40;&#40;var&#41;&#41;</span></strong></p>",
         ),
         (
             LetterPreviewTemplate,
@@ -3129,13 +3129,18 @@ def test_letter_image_template_marks_first_page_of_attachment():
             ),
         ),
         (
+            LetterPreviewTemplate,
+            {"template_type": "letter", "subject": "foo", "content": "[Example](pre((var))post)"},
+            ("<p>Example: <strong>pre<span class='placeholder'>&#40;&#40;var&#41;&#41;</span>post</strong></p>"),
+        ),
+        (
             EmailPreviewTemplate,
             {"template_type": "email", "subject": "foo", "content": "[Example](((var)))"},
             (
                 '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; '
                 'color: #0B0C0C;">'
                 '<a style="word-wrap: break-word; color: #1D70B8;" '
-                "href=\"span class='placeholder'>&#40;&#40;var&#41;&#41;</span\">"
+                "href=\"<span class='placeholder'>&#40;&#40;var&#41;&#41;</span>\">"
                 "Example"
                 "</a>"
                 "</p>"
@@ -3149,6 +3154,19 @@ def test_letter_image_template_marks_first_page_of_attachment():
                 'color: #0B0C0C;">'
                 '<a style="word-wrap: break-word; color: #1D70B8;" '
                 "href=\"https://blah.blah/?query=<span class='placeholder'>&#40;&#40;var&#41;&#41;</span>\">"
+                "Example"
+                "</a>"
+                "</p>"
+            ),
+        ),
+        (
+            EmailPreviewTemplate,
+            {"template_type": "email", "subject": "foo", "content": "[Example](pre((var))post)"},
+            (
+                '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; '
+                'color: #0B0C0C;">'
+                '<a style="word-wrap: break-word; color: #1D70B8;" '
+                "href=\"pre<span class='placeholder'>&#40;&#40;var&#41;&#41;</span>post\">"
                 "Example"
                 "</a>"
                 "</p>"


### PR DESCRIPTION
There is still some wonky stuff after this patch (eg <strong> tags in weird places around link personalisation in letters, and link hrefs with personalisation spans in them is funky), but the situation is better.

---

# Normal links (email)
With the following markdown:
```markdown
[link](text)
[link](prefix ((personalised)))
[link](((personalised)) suffix)
[link](prefix ((personalised)) suffix)
```
## Before
### Displays as
<img width="759" alt="image" src="https://github.com/alphagov/notifications-utils/assets/2920760/9d254d68-897f-4857-8828-85e3f179c504">

### HTML
```html
<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;"><a
  style="word-wrap: break-word; color: #1D70B8;" href="text">link</a><br/><a
  style="word-wrap: break-word; color: #1D70B8;" href="prefix <span class='placeholder'>((personalised">link</a>)&lt;/span&gt;)<br/><a
  style="word-wrap: break-word; color: #1D70B8;" href="<span class='placeholder'>((personalised">link</a>)&lt;/span&gt;
  suffix)<br/><a style="word-wrap: break-word; color: #1D70B8;" href="prefix <span class='placeholder'>((personalised">link</a>)&lt;/span&gt;
  suffix)</p>
```

## After
### Displays as
<img width="747" alt="image" src="https://github.com/alphagov/notifications-utils/assets/2920760/a951a5ac-7ead-44f4-86a6-fb6cd1e100ea">

### HTML
```html
<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;"><a
  style="word-wrap: break-word; color: #1D70B8;" href="text">link</a><br/><a
  style="word-wrap: break-word; color: #1D70B8;"
  href="prefix <span class='placeholder'>&#40;&#40;personalised&#41;&#41;</span>">link</a><br/><a
  style="word-wrap: break-word; color: #1D70B8;"
  href="<span class='placeholder'>&#40;&#40;personalised&#41;&#41;</span> suffix">link</a><br/><a
  style="word-wrap: break-word; color: #1D70B8;"
  href="prefix <span class='placeholder'>&#40;&#40;personalised&#41;&#41;</span> suffix">link</a></p>
```

# QR codes (letters)

With the following markdown:
```markdown
[qr](((personalisation)))
[qr](prefix((personalisation)))
[qr](((personalisation))suffix)
[qr](prefix((personalisation))suffix)
```
## Before
### Displays as
<img width="859" alt="image" src="https://github.com/alphagov/notifications-utils/assets/2920760/1914a1ed-3db8-4232-85cc-55adf7860223">


### HTML
```html
<p>
<div class='qrcode‑placeholder'><span class='placeholder'>((personalisation))</span></div><br>
<div class='qrcode‑placeholder'>
  <prefix
  <span class='placeholder'>((personalisation></div>)&lt;/span&gt;)<br>
<div class='qrcode‑placeholder'><<span class='placeholder'>((personalisation></div>)&lt;/span&gt;suffix)<br>
<div class='qrcode‑placeholder'>
  <prefix
  <span class='placeholder'>((personalisation></div>)&lt;/span&gt;suffix)</p>
```

## After
### Displays as
<img width="803" alt="image" src="https://github.com/alphagov/notifications-utils/assets/2920760/4f64f412-1f1a-481f-8728-056f140550ca">


### HTML
```html
<p>
<div class='qrcode‑placeholder'><span class='placeholder'>&#40;&#40;personalisation&#41;&#41;</span></div></p><p>
<div class='qrcode‑placeholder'>prefix<span class='placeholder'>&#40;&#40;personalisation&#41;&#41;</span></div></p><p>
<div class='qrcode‑placeholder'><span class='placeholder'>&#40;&#40;personalisation&#41;&#41;</span>suffix</div></p><p>
<div class='qrcode‑placeholder'>prefix<span class='placeholder'>&#40;&#40;personalisation&#41;&#41;</span>suffix
</div></p>
```

# Links (letters)

## Before
<img width="835" alt="image" src="https://github.com/alphagov/notifications-utils/assets/2920760/20f6b5e0-f5e5-413a-b880-89e31b5b1239">

## After
<img width="811" alt="image" src="https://github.com/alphagov/notifications-utils/assets/2920760/ee74b5bd-c603-4d25-8d6f-df1763d3e967">
