### PR TITLE
Style the QR code placeholder so it looks better when the placeholder text is long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 66.0.2
+
+* Style the QR code placeholder so it looks better when the placeholder text is long
+
 ## 66.0.1
 
 * Use HTML-encoded parenthesis (`(` and `)`) when rendering template content with placeholders.

--- a/notifications_utils/jinja_templates/letter_pdf/_main_css.jinja2
+++ b/notifications_utils/jinja_templates/letter_pdf/_main_css.jinja2
@@ -195,23 +195,32 @@
     border-radius: 1.05em;
   }
   .qrcode,
-  .qrcode‑placeholder {
+  .qrcode-placeholder {
       display: block;
-      width: {{ line_height_raw * 5.25 }}pt;
       height: {{ line_height_raw * 5.25 }}pt;
       margin: {{ line_height_raw * 1.25 }}pt auto {{ line_height_raw * 1.5 }}pt auto;
+  }
+  .qrcode {
+      width: {{ line_height_raw * 5.25 }}pt;
   }
   .qrcode svg {
     display: block;
     width: 100%;
     height: 100%;
   }
-  .qrcode‑placeholder {
-      padding-top: {{ line_height_raw * 2 }}pt;
+  .qrcode-placeholder-border {
+      width: {{ line_height_raw * 5.25 }}pt;
+      height: {{ line_height_raw * 5.25 }}pt;
       border: 4pt dashed black;
-      vertical-align: middle;
-      text-align: center;
+      margin: 0 auto 0 auto;
       box-sizing: border-box;
   }
-
+  .qrcode-placeholder-content {
+      text-align: center;
+      margin-top: {{ line_height_raw * -3.125 }}pt;
+  }
+  .qrcode-placeholder-content-background {
+      padding: 4pt;
+      background: #fff;
+  }
 </style>

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -1,6 +1,7 @@
 import itertools
 import re
 from itertools import count
+from textwrap import dedent
 
 import mistune
 import segno
@@ -65,6 +66,19 @@ def qr_code_as_svg(data):
     return qr.svg_inline(border=0, svgclass=None, lineclass=None, omitsize=True)
 
 
+def qr_code_placeholder(link):
+    return dedent(
+        f"""
+            <div class='qrcode-placeholder'>
+                <div class='qrcode-placeholder-border'></div>
+                <div class='qrcode-placeholder-content'>
+                    <span class='qrcode-placeholder-content-background'>{link}</span>
+                </div>
+            </div>
+        """
+    )
+
+
 class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
     def block_code(self, code, language=None):
         return code
@@ -111,8 +125,7 @@ class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
         if InsensitiveDict.make_key(content) == "qr":
             qr_data = replace_svg_dashes(qr_code_as_svg(link))
             if "<span class='placeholder" in link:
-                return f"<div class='qrcode-placeholder'>{link}</div>"
-
+                return replace_svg_dashes(qr_code_placeholder(link))
             return f"<div class='qrcode'>{qr_data}</div>"
 
         return f"{content}: {self.autolink(link)}"

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "66.0.1"  # 8ffe8aee68eaea610de610312c3a0fb1
+__version__ = "66.0.2"  # a49c68d73aa2a4bc04dd173a8144e817

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -3136,24 +3136,42 @@ def test_letter_image_template_marks_first_page_of_attachment():
         (
             LetterPreviewTemplate,
             {"template_type": "letter", "subject": "foo", "content": "[QR](((var)))"},
-            "<p><div class='qrcode‑placeholder'><span class='placeholder'>&#40;&#40;var&#41;&#41;</span></div></p>",
+            (
+                "<p>\n"
+                "<div class='qrcode-placeholder'>\n"
+                "    <div class='qrcode-placeholder-border'></div>\n"
+                "    <div class='qrcode-placeholder-content'>\n"
+                "        <span class='qrcode-placeholder-content-background'><span class='placeholder'>&#40;&#40;var&#41;&#41;</span></span>\n"  # noqa
+                "    </div>\n"
+                "</div>\n"
+                "</p>"
+            ),
         ),
         (
             LetterPreviewTemplate,
             {"template_type": "letter", "subject": "foo", "content": "[QR](https://blah.blah/?query=((var)))"},
             (
-                "<p><div class='qrcode‑placeholder'>"
-                "https://blah.blah/?query=<span class='placeholder'>&#40;&#40;var&#41;&#41;</span>"
-                "</div></p>"
+                "<p>\n"
+                "<div class='qrcode-placeholder'>\n"
+                "    <div class='qrcode-placeholder-border'></div>\n"
+                "    <div class='qrcode-placeholder-content'>\n"
+                "        <span class='qrcode-placeholder-content-background'>https://blah.blah/?query=<span class='placeholder'>&#40;&#40;var&#41;&#41;</span></span>\n"  # noqa
+                "    </div>\n"
+                "</div>\n"
+                "</p>"
             ),
         ),
         (
             LetterPreviewTemplate,
             {"template_type": "letter", "subject": "foo", "content": "[QR](pre((var))post)"},
             (
-                "<p><div class='qrcode‑placeholder'>"
-                "pre<span class='placeholder'>&#40;&#40;var&#41;&#41;</span>post"
-                "</div></p>"
+                "<p>\n<div class='qrcode-placeholder'>\n"
+                "    <div class='qrcode-placeholder-border'></div>\n"
+                "    <div class='qrcode-placeholder-content'>\n"
+                "        <span class='qrcode-placeholder-content-background'>pre<span class='placeholder'>&#40;&#40;var&#41;&#41;</span>post</span>\n"  # noqa
+                "    </div>\n"
+                "</div>\n"
+                "</p>"
             ),
         ),
         (


### PR DESCRIPTION
When a QR code contains a placeholder we render a ‘placeholder’ box instead, which has a dashed border.

If the text of the placeholder or its prefix/suffix is long, then this causes the text to wrap inside the placeholder box. Because the placeholder box is a relatively narrow fixed width this:
- happens easily
- does not look very good
- makes the text harder to read

This commit adds some extra HTML elements which allow us to style the box and its contents separately.

This way the contents can overflow the box without looking messy. The width of the text is therefore limited to the width of the column, as it is for other URLs and placeholders.

# Before 

<img width="582" alt="image" src="https://github.com/alphagov/notifications-utils/assets/355079/4996ed50-9566-4605-94d3-c579a4ecff8f">

# After 

<img width="590" alt="image" src="https://github.com/alphagov/notifications-utils/assets/355079/f62b3ebd-d85f-4ecb-8c06-1e0c1695cc92">

***

By colour-coding the elements you can see how this is constructed:

<img width="570" alt="image" src="https://github.com/alphagov/notifications-utils/assets/355079/0a1c8b2c-421e-4460-bf83-e1583777a2df">

***

Ideally this would use `vertical-align: middle` to centre the text, even when it spans multiple lines. But Weasyprint doesn’t seem to support this, so using a negative margin to vertically centre one line of text will have to do. It looks like this:

<img width="565" alt="image" src="https://github.com/alphagov/notifications-utils/assets/355079/c47aacdd-5a54-49e6-8138-c89c20dff8e9">

<img width="535" alt="image" src="https://github.com/alphagov/notifications-utils/assets/355079/21b28499-d0d5-47c4-8d06-58a8eca3ae8e">
