### PR TITLE
Use a simpler syntax for QR codes in letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 66.1.0
+
+* Add a simpler syntax for QR codes in letters (QR: http://example.com)
+
 ## 66.0.2
 
 * Style the QR code placeholder so it looks better when the placeholder text is long

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "66.0.2"  # a49c68d73aa2a4bc04dd173a8144e817
+__version__ = "66.1.0"  # 916e161957dfcb3f0bada19618f0efe3

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -3149,6 +3149,20 @@ def test_letter_image_template_marks_first_page_of_attachment():
         ),
         (
             LetterPreviewTemplate,
+            {"template_type": "letter", "subject": "foo", "content": "QR: ((var))"},
+            (
+                "<p>\n"
+                "<div class='qrcode-placeholder'>\n"
+                "    <div class='qrcode-placeholder-border'></div>\n"
+                "    <div class='qrcode-placeholder-content'>\n"
+                "        <span class='qrcode-placeholder-content-background'><span class='placeholder'>&#40;&#40;var&#41;&#41;</span></span>\n"  # noqa
+                "    </div>\n"
+                "</div>\n"
+                "</p>"
+            ),
+        ),
+        (
+            LetterPreviewTemplate,
             {"template_type": "letter", "subject": "foo", "content": "[QR](https://blah.blah/?query=((var)))"},
             (
                 "<p>\n"
@@ -3163,7 +3177,34 @@ def test_letter_image_template_marks_first_page_of_attachment():
         ),
         (
             LetterPreviewTemplate,
+            {"template_type": "letter", "subject": "foo", "content": "QR:https://blah.blah/?query=((var))"},
+            (
+                "<p>\n"
+                "<div class='qrcode-placeholder'>\n"
+                "    <div class='qrcode-placeholder-border'></div>\n"
+                "    <div class='qrcode-placeholder-content'>\n"
+                "        <span class='qrcode-placeholder-content-background'><strong>blah.blah/?query=</strong><span class='placeholder'>&#40;&#40;var&#41;&#41;</span></span>\n"  # noqa
+                "    </div>\n"
+                "</div>\n"
+                "</p>"
+            ),
+        ),
+        (
+            LetterPreviewTemplate,
             {"template_type": "letter", "subject": "foo", "content": "[QR](pre((var))post)"},
+            (
+                "<p>\n<div class='qrcode-placeholder'>\n"
+                "    <div class='qrcode-placeholder-border'></div>\n"
+                "    <div class='qrcode-placeholder-content'>\n"
+                "        <span class='qrcode-placeholder-content-background'>pre<span class='placeholder'>&#40;&#40;var&#41;&#41;</span>post</span>\n"  # noqa
+                "    </div>\n"
+                "</div>\n"
+                "</p>"
+            ),
+        ),
+        (
+            LetterPreviewTemplate,
+            {"template_type": "letter", "subject": "foo", "content": "qr:pre((var))post"},
             (
                 "<p>\n<div class='qrcode-placeholder'>\n"
                 "    <div class='qrcode-placeholder-border'></div>\n"


### PR DESCRIPTION
Our current syntax for QR codes is pretty gnarly, especially when it comes to using placeholders as all or part of the URL, for example
```
[qr](https://www.example.com?reference=((placeholder)))
```

If I saw triple closing brackets like that in some code I was writing I would consider if there was a better way to factor the code to make it easier to read. And this example isn’t full-blown code, it’s our templating.

We initially went with this syntax because it’s consistent with how Markdown links work. However it also differs from Markdown links in that the label part (the `[qr]`) is fixed and can’t be changed. So the reusable knowledge is more hypothesis than fact.

Markdown links do have the advantage of being inline, in other words they can be inserted in the middle of a paragraph. But this isn’t something we’d ever want to do because we always display the QR codes much larger than a single line, with padding around them.

Re-using Markdown links also has the disadvantage that our Markdown parser will be expecting URLs between the parentheses. In the future we users might want to include arbitrary data in their QR codes (for example some kind of encrypted blob). If this data included spaces or parentheses then the parser which is looking for a URL might struggle.

What I’m proposing here is an alternative syntax which has no brackets:
```
QR: https://www.example.com?reference=((placeholder))
```

I think this is:
- easier to read
- easier to explain in guidance
- more future proof in terms of what data can go in it (basically anything except newlines)

This PR doesn’t remove the old way of doing things yet – we can do that separately if we decide for sure that this is the way we want to go.

*** 

Example of what the guidance would look like if we made this change: https://docs.google.com/document/d/1EpiH8s-Ff_VAQwYafgrIo64mDUY0_BVIrHlarlZGB-M/edit