### PR TITLE
Update InvalidPhoneError messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 70.0.0
+
+* InvalidPhoneError messages have been updated. The new error messages are more user friendly.
+
 ## 66.1.0
 
 * Add a simpler syntax for QR codes in letters (QR: http://example.com)

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -553,7 +553,9 @@ def validate_uk_phone_number(number):
     number = normalise_phone_number(number).lstrip(uk_prefix).lstrip("0")
 
     if not number.startswith("7"):
-        raise InvalidPhoneError("This does not look like a UK mobile number - double check the number you entered")
+        raise InvalidPhoneError(
+            "This does not look like a UK mobile number - double check the mobile number you entered"
+        )
 
     if len(number) > 10:
         raise InvalidPhoneError("Mobile number is too long")
@@ -578,7 +580,7 @@ def validate_phone_number(number, international=False):
         raise InvalidPhoneError("Mobile number is too long")
 
     if get_international_prefix(number) is None:
-        raise InvalidPhoneError("Country code not found - double check this mobile number")
+        raise InvalidPhoneError("Country code not found - double check the number you entered")
 
     return number
 

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -580,7 +580,7 @@ def validate_phone_number(number, international=False):
         raise InvalidPhoneError("Mobile number is too long")
 
     if get_international_prefix(number) is None:
-        raise InvalidPhoneError("Country code not found - double check the number you entered")
+        raise InvalidPhoneError("Country code not found - double check the mobile number you entered")
 
     return number
 

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -482,7 +482,7 @@ def normalise_phone_number(number):
     try:
         list(map(int, number))
     except ValueError as e:
-        raise InvalidPhoneError("Must not contain letters or symbols") from e
+        raise InvalidPhoneError("Mobile numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -") from e
 
     return number.lstrip("0")
 
@@ -553,13 +553,13 @@ def validate_uk_phone_number(number):
     number = normalise_phone_number(number).lstrip(uk_prefix).lstrip("0")
 
     if not number.startswith("7"):
-        raise InvalidPhoneError("Not a UK mobile number")
+        raise InvalidPhoneError("This does not look like a UK mobile number - double check the number you entered")
 
     if len(number) > 10:
-        raise InvalidPhoneError("Too many digits")
+        raise InvalidPhoneError("Mobile number is too long")
 
     if len(number) < 10:
-        raise InvalidPhoneError("Not enough digits")
+        raise InvalidPhoneError("Mobile number is too short")
 
     return f"{uk_prefix}{number}"
 
@@ -572,13 +572,13 @@ def validate_phone_number(number, international=False):
     number = normalise_phone_number(number)
 
     if len(number) < 8:
-        raise InvalidPhoneError("Not enough digits")
+        raise InvalidPhoneError("Mobile number is too short")
 
     if len(number) > 15:
-        raise InvalidPhoneError("Too many digits")
+        raise InvalidPhoneError("Mobile number is too long")
 
     if get_international_prefix(number) is None:
-        raise InvalidPhoneError("Not a valid country prefix")
+        raise InvalidPhoneError("Country code not found - double check this mobile number")
 
     return number
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "66.1.0"  # 916e161957dfcb3f0bada19618f0efe3
+__version__ = "70.0.0"  # 6cc2adee179cb4d78903f8d3003497e0

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -108,7 +108,7 @@ invalid_phone_numbers = list(
         invalid_uk_phone_numbers,
     )
 ) + [
-    ("800000000000", "Country code not found - double check the number you entered"),
+    ("800000000000", "Country code not found - double check the mobile number you entered"),
     ("1234567", "Mobile number is too short"),
     ("+682 1234", "Mobile number is too short"),  # Cook Islands phone numbers can be 5 digits
     ("+12345 12345 12345 6", "Mobile number is too long"),

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -52,7 +52,7 @@ invalid_uk_phone_numbers = sum(
         [(phone_number, error) for phone_number in group]
         for error, group in [
             (
-                "Too many digits",
+                "Mobile number is too long",
                 (
                     "712345678910",
                     "0712345678910",
@@ -62,7 +62,7 @@ invalid_uk_phone_numbers = sum(
                 ),
             ),
             (
-                "Not enough digits",
+                "Mobile number is too short",
                 (
                     "0712345678",
                     "004471234567",
@@ -71,7 +71,7 @@ invalid_uk_phone_numbers = sum(
                 ),
             ),
             (
-                "Not a UK mobile number",
+                "This does not look like a UK mobile number - double check the number you entered",
                 (
                     "08081 570364",
                     "+44 8081 570364",
@@ -82,7 +82,7 @@ invalid_uk_phone_numbers = sum(
                 ),
             ),
             (
-                "Must not contain letters or symbols",
+                "Mobile numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -",
                 (
                     "07890x32109",
                     "07123 456789...",
@@ -108,10 +108,10 @@ invalid_phone_numbers = list(
         invalid_uk_phone_numbers,
     )
 ) + [
-    ("800000000000", "Not a valid country prefix"),
-    ("1234567", "Not enough digits"),
-    ("+682 1234", "Not enough digits"),  # Cook Islands phone numbers can be 5 digits
-    ("+12345 12345 12345 6", "Too many digits"),
+    ("800000000000", "Country code not found - double check this mobile number"),
+    ("1234567", "Mobile number is too short"),
+    ("+682 1234", "Mobile number is too short"),  # Cook Islands phone numbers can be 5 digits
+    ("+12345 12345 12345 6", "Mobile number is too long"),
 ]
 
 
@@ -298,7 +298,7 @@ def test_normalise_phone_number_raises_if_unparseable_characters(phone_number):
 def test_get_international_info_raises(phone_number):
     with pytest.raises(InvalidPhoneError) as error:
         get_international_phone_info(phone_number)
-    assert str(error.value) == "Not a valid country prefix"
+    assert str(error.value) == "Country code not found - double check this mobile number"
 
 
 @pytest.mark.parametrize("phone_number", valid_uk_phone_numbers)

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -71,7 +71,7 @@ invalid_uk_phone_numbers = sum(
                 ),
             ),
             (
-                "This does not look like a UK mobile number - double check the number you entered",
+                "This does not look like a UK mobile number - double check the mobile number you entered",
                 (
                     "08081 570364",
                     "+44 8081 570364",
@@ -108,7 +108,7 @@ invalid_phone_numbers = list(
         invalid_uk_phone_numbers,
     )
 ) + [
-    ("800000000000", "Country code not found - double check this mobile number"),
+    ("800000000000", "Country code not found - double check the number you entered"),
     ("1234567", "Mobile number is too short"),
     ("+682 1234", "Mobile number is too short"),  # Cook Islands phone numbers can be 5 digits
     ("+12345 12345 12345 6", "Mobile number is too long"),
@@ -298,7 +298,7 @@ def test_normalise_phone_number_raises_if_unparseable_characters(phone_number):
 def test_get_international_info_raises(phone_number):
     with pytest.raises(InvalidPhoneError) as error:
         get_international_phone_info(phone_number)
-    assert str(error.value) == "Country code not found - double check this mobile number"
+    assert str(error.value) == "Country code not found - double check the number you entered"
 
 
 @pytest.mark.parametrize("phone_number", valid_uk_phone_numbers)

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -298,7 +298,7 @@ def test_normalise_phone_number_raises_if_unparseable_characters(phone_number):
 def test_get_international_info_raises(phone_number):
     with pytest.raises(InvalidPhoneError) as error:
         get_international_phone_info(phone_number)
-    assert str(error.value) == "Country code not found - double check the number you entered"
+    assert str(error.value) == "Country code not found - double check the mobile number you entered"
 
 
 @pytest.mark.parametrize("phone_number", valid_uk_phone_numbers)


### PR DESCRIPTION
 As part of the work being done on [this](https://trello.com/c/IgLu00uK/449-add-error-summaries-to-profile-page-forms) error summaries ticket, the current InvalidPhoneError messages are being updated.

There are different validation scenarios ie uk numbers vs international numbers. The previous errors were quite generic while the new error messages are more specific and are tied to the validation parameters. For example the error message "not enough digits" is being replaced by either "Mobile phone number must be at least 8 digits long" for International numbers or "Mobile phone number must be at least 10 digits long" for UK numbers.

I have attached before and after screen shots of the various error messages. There may have to be a rethink of the new error message for invalid error messages as it may be too long even though it is appropriately descriptive. 


**Minimum digits for local numbers before and after:**

<img width="666" alt="minimum-digits-local-b4" src="https://github.com/alphagov/notifications-utils/assets/32799090/7b4ba3f2-24d2-475a-96a3-d2d72d13d250">

<img width="797" alt="minimum-digits-local-after" src="https://github.com/alphagov/notifications-utils/assets/32799090/45ca3838-973d-4897-81ad-f3cd0edd8048">


**Minimum digits for international numbers before and after:**
<img width="582" alt="minimum-digits-international-b4" src="https://github.com/alphagov/notifications-utils/assets/32799090/e6cd9cec-7a14-44c3-8d6c-855d10a54e5f">

<img width="682" alt="minimum-digits-international-after" src="https://github.com/alphagov/notifications-utils/assets/32799090/68f9b7e5-aa41-43f2-8897-593365921fe5">


**Maximum digits for local numbers before and after:**

<img width="664" alt="maximum-digits-local-b4" src="https://github.com/alphagov/notifications-utils/assets/32799090/2979c430-4110-4d26-b9ab-d01e4d762c59">

<img width="741" alt="maximum-digits-local-after" src="https://github.com/alphagov/notifications-utils/assets/32799090/bb16fd75-f912-4407-883e-ecb68044b0d2">


**Maximum digits for international numbers before and after:**

<img width="797" alt="maximum-digits-international b4" src="https://github.com/alphagov/notifications-utils/assets/32799090/c701a4a5-4482-4943-a0b3-d2f202223af8">

<img width="772" alt="maximum-digits-international-after" src="https://github.com/alphagov/notifications-utils/assets/32799090/b9d389cc-299e-4814-801e-cc37000b0c9d">


**Invalid UK numbers before and after**

<img width="578" alt="invalid-uk-number-b4" src="https://github.com/alphagov/notifications-utils/assets/32799090/49059a3e-f849-48d5-8ff0-fdb21e4fec0b">

<img width="689" alt="invalid-uk-number-after" src="https://github.com/alphagov/notifications-utils/assets/32799090/3796aa36-6a22-492e-9e41-f7d8b6e17b09">


**Invalid country prefixes before and after**

<img width="607" alt="invalid-country-prefix-b4" src="https://github.com/alphagov/notifications-utils/assets/32799090/e535fef4-8672-4eef-bb02-3affe76be0e1">

<img width="1029" alt="invalid-country-prefix-after" src="https://github.com/alphagov/notifications-utils/assets/32799090/8d18a49a-0540-4c37-8299-2d2ed3edd840">

