### PR TITLE
Remove the old syntax for QR codes in letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 69.0.0
+
+* Remove old syntax for QR codes in letters (only `QR: http://example.com` will work now)
+
 ## 68.0.1
 
 * Fix a bug with some HTML getting injected into QR codes

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -7,7 +7,6 @@ from orderedset import OrderedSet
 
 from notifications_utils import MAGIC_SEQUENCE, magic_sequence_regex
 from notifications_utils.formatters import create_sanitised_html_for_url, replace_svg_dashes
-from notifications_utils.insensitive_dict import InsensitiveDict
 from notifications_utils.qr_code import (
     QR_CODE_MAX_BYTES,
     QrCodeTooLong,
@@ -129,9 +128,6 @@ class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
     def link(self, link, title, content):
         if link.startswith("span class='placeholder") and link.endswith("</span"):
             link = f"<{link}>"
-
-        if InsensitiveDict.make_key(content) == "qr":
-            return self._render_qr_data(link)
 
         return f"{content}: {self.autolink(link)}"
 

--- a/notifications_utils/qr_code.py
+++ b/notifications_utils/qr_code.py
@@ -6,7 +6,7 @@ from textwrap import dedent
 import segno
 
 QR_CODE_MAX_BYTES = 504
-paragraph_is_qr_code_markup_regex = re.compile(r"^qr[\s]*:[\s]*(.+)", re.I)
+paragraph_is_qr_code_markup_regex = re.compile(r"^[\s]*qr[\s]*:[\s]*(.+)", re.I)
 
 
 class QrCodeTooLong(ValueError):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "68.0.1"  # 59a58b3e00a6f603f03e7e30a1b85fed
+__version__ = "69.0.0"  # 76e5ccea60146e45de4eb5d669466936

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -627,12 +627,12 @@ def test_link_with_title(markdown_function, expected):
 def test_letter_qr_code():
     expected_qr_code = '<p><div class=\'qrcode\'><svg viewBox="0 0 25 25"><path stroke="#000" d="M0 0.5h7m1 0h8m2 0h7m🛳️🐦🥴25 1h1m5 0h1m1 0h1m1 0h1m1 0h5m1 0h1m5 0h1m🛳️🐦🥴25 1h1m1 0h3m1 0h1m1 0h1m3 0h1m2 0h1m2 0h1m1 0h3m1 0h1m🛳️🐦🥴25 1h1m1 0h3m1 0h1m1 0h2m1 0h1m6 0h1m1 0h3m1 0h1m🛳️🐦🥴25 1h1m1 0h3m1 0h1m1 0h5m1 0h2m2 0h1m1 0h3m1 0h1m🛳️🐦🥴25 1h1m5 0h1m3 0h1m4 0h2m1 0h1m5 0h1m🛳️🐦🥴25 1h7m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h7m🛳️🐦🥴17 1h1m2 0h3m🛳️🐦🥴13 1h2m1 0h1m1 0h2m1 0h1m1 0h2m1 0h1m1 0h1m1 0h1m1 0h5m🛳️🐦🥴25 1h3m5 0h1m1 0h2m1 0h1m2 0h3m5 0h1m🛳️🐦🥴25 1h1m1 0h1m3 0h7m1 0h1m1 0h1m1 0h1m1 0h1m1 0h3m🛳️🐦🥴25 1h2m1 0h1m1 0h1m1 0h1m3 0h3m2 0h1m2 0h2m2 0h1m🛳️🐦🥴24 1h4m2 0h1m2 0h1m4 0h6m1 0h1m1 0h2m🛳️🐦🥴23 1h1m2 0h1m2 0h2m1 0h1m1 0h1m3 0h2m2 0h1m2 0h1m🛳️🐦🥴25 1h1m1 0h1m1 0h1m1 0h3m1 0h1m2 0h2m2 0h1m1 0h2m1 0h3m🛳️🐦🥴24 1h2m4 0h1m1 0h2m2 0h1m1 0h2m4 0h1m1 0h1m🛳️🐦🥴24 1h1m4 0h2m3 0h1m1 0h1m1 0h1m1 0h6m🛳️🐦🥴14 1h3m1 0h1m2 0h2m3 0h5m🛳️🐦🥴25 1h7m1 0h2m2 0h1m2 0h2m1 0h1m1 0h1m2 0h2m🛳️🐦🥴25 1h1m5 0h1m2 0h2m3 0h1m1 0h1m3 0h2m2 0h1m🛳️🐦🥴25 1h1m1 0h3m1 0h1m1 0h3m2 0h1m2 0h5m3 0h1m🛳️🐦🥴25 1h1m1 0h3m1 0h1m2 0h1m1 0h1m1 0h3m3 0h2m1 0h1m🛳️🐦🥴23 1h1m1 0h3m1 0h1m1 0h1m1 0h1m1 0h2m1 0h1m1 0h1m1 0h3m2 0h1m🛳️🐦🥴25 1h1m5 0h1m1 0h1m2 0h1m1 0h5m2 0h2m1 0h1m🛳️🐦🥴24 1h7m3 0h2m2 0h3m1 0h2m3 0h2"/></svg></div></p>'  # noqa
 
-    assert notify_letter_preview_markdown('[qr](http://example.com")') == expected_qr_code
+    assert notify_letter_preview_markdown('qr:http://example.com"') == expected_qr_code
 
 
 def test_letter_qr_code_works_with_extra_whitespace():
     expected_qr_code_start = "<p><div class='qrcode'><svg viewBox=\"0 0 25 25\">"
-    assert notify_letter_preview_markdown('[ qr ](http://example.com")').startswith(expected_qr_code_start)
+    assert notify_letter_preview_markdown(' qr : http://example.com"').startswith(expected_qr_code_start)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -907,7 +907,7 @@ def test_letter_preview_renders_QR_code_correctly(jinja_template):
     str(
         LetterPreviewTemplate(
             {
-                "content": "This is your link: [qr](https://www.example.com)",
+                "content": "This is your link:\n\nqr: https://www.example.com",
                 "subject": "Subject",
                 "template_type": "letter",
             },
@@ -918,7 +918,7 @@ def test_letter_preview_renders_QR_code_correctly(jinja_template):
 
     jinja_template_locals = jinja_template.call_args_list[0][0][0]
 
-    expected_qr_code_svg = '<p>This is your link: <div class=\'qrcode\'><svg viewBox="0 0 25 25"><path stroke="#000" d="M0 0.5h7m1 0h2m1 0h1m2 0h1m3 0h7m-25 1h1m5 0h1m1 0h6m4 0h1m5 0h1m-25 1h1m1 0h3m1 0h1m1 0h1m2 0h1m1 0h1m1 0h2m1 0h1m1 0h3m1 0h1m-25 1h1m1 0h3m1 0h1m2 0h2m2 0h1m4 0h1m1 0h3m1 0h1m-25 1h1m1 0h3m1 0h1m1 0h1m5 0h1m1 0h1m1 0h1m1 0h3m1 0h1m-25 1h1m5 0h1m3 0h2m2 0h1m3 0h1m5 0h1m-25 1h7m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h7m-16 1h1m2 0h2m2 0h1m-17 1h1m2 0h6m1 0h2m4 0h2m2 0h1m1 0h3m-24 1h3m3 0h2m2 0h5m1 0h1m1 0h5m-24 1h1m3 0h1m1 0h3m2 0h1m1 0h1m1 0h2m1 0h2m1 0h1m2 0h1m-25 1h1m2 0h1m5 0h2m1 0h1m3 0h1m2 0h1m1 0h4m-24 1h1m3 0h2m1 0h1m1 0h1m4 0h2m1 0h1m5 0h1m-25 1h2m1 0h2m2 0h1m4 0h6m2 0h1m2 0h1m-24 1h3m2 0h3m2 0h1m4 0h4m1 0h5m-25 1h1m1 0h2m3 0h2m3 0h1m3 0h2m1 0h1m1 0h2m1 0h1m-25 1h1m5 0h1m1 0h2m1 0h3m2 0h5m1 0h2m-16 1h1m1 0h2m1 0h1m1 0h2m3 0h1m1 0h2m-24 1h7m1 0h3m1 0h1m3 0h1m1 0h1m1 0h1m3 0h1m-25 1h1m5 0h1m1 0h4m1 0h1m1 0h2m3 0h1m2 0h1m-24 1h1m1 0h3m1 0h1m1 0h1m2 0h2m1 0h7m2 0h2m-25 1h1m1 0h3m1 0h1m1 0h2m2 0h5m1 0h1m4 0h2m-25 1h1m1 0h3m1 0h1m4 0h2m4 0h1m2 0h5m-25 1h1m5 0h1m2 0h1m1 0h2m1 0h1m4 0h2m1 0h3m-25 1h7m1 0h1m1 0h5m1 0h2m3 0h1m2 0h1"/></svg></div></p>'  # noqa
+    expected_qr_code_svg = '<p>This is your link:</p><p><div class=\'qrcode\'><svg viewBox="0 0 25 25"><path stroke="#000" d="M0 0.5h7m1 0h2m1 0h1m2 0h1m3 0h7m-25 1h1m5 0h1m1 0h6m4 0h1m5 0h1m-25 1h1m1 0h3m1 0h1m1 0h1m2 0h1m1 0h1m1 0h2m1 0h1m1 0h3m1 0h1m-25 1h1m1 0h3m1 0h1m2 0h2m2 0h1m4 0h1m1 0h3m1 0h1m-25 1h1m1 0h3m1 0h1m1 0h1m5 0h1m1 0h1m1 0h1m1 0h3m1 0h1m-25 1h1m5 0h1m3 0h2m2 0h1m3 0h1m5 0h1m-25 1h7m1 0h1m1 0h1m1 0h1m1 0h1m1 0h1m1 0h7m-16 1h1m2 0h2m2 0h1m-17 1h1m2 0h6m1 0h2m4 0h2m2 0h1m1 0h3m-24 1h3m3 0h2m2 0h5m1 0h1m1 0h5m-24 1h1m3 0h1m1 0h3m2 0h1m1 0h1m1 0h2m1 0h2m1 0h1m2 0h1m-25 1h1m2 0h1m5 0h2m1 0h1m3 0h1m2 0h1m1 0h4m-24 1h1m3 0h2m1 0h1m1 0h1m4 0h2m1 0h1m5 0h1m-25 1h2m1 0h2m2 0h1m4 0h6m2 0h1m2 0h1m-24 1h3m2 0h3m2 0h1m4 0h4m1 0h5m-25 1h1m1 0h2m3 0h2m3 0h1m3 0h2m1 0h1m1 0h2m1 0h1m-25 1h1m5 0h1m1 0h2m1 0h3m2 0h5m1 0h2m-16 1h1m1 0h2m1 0h1m1 0h2m3 0h1m1 0h2m-24 1h7m1 0h3m1 0h1m3 0h1m1 0h1m1 0h1m3 0h1m-25 1h1m5 0h1m1 0h4m1 0h1m1 0h2m3 0h1m2 0h1m-24 1h1m1 0h3m1 0h1m1 0h1m2 0h2m1 0h7m2 0h2m-25 1h1m1 0h3m1 0h1m1 0h2m2 0h5m1 0h1m4 0h2m-25 1h1m1 0h3m1 0h1m4 0h2m4 0h1m2 0h5m-25 1h1m5 0h1m2 0h1m1 0h2m1 0h1m4 0h2m1 0h3m-25 1h7m1 0h1m1 0h5m1 0h2m3 0h1m2 0h1"/></svg></div></p>'  # noqa
     assert jinja_template_locals["message"] == expected_qr_code_svg
 
 
@@ -3151,20 +3151,6 @@ def test_letter_image_template_marks_first_page_of_attachment():
         ),
         (
             LetterPreviewTemplate,
-            {"template_type": "letter", "subject": "foo", "content": "[QR](((var)))"},
-            (
-                "<p>\n"
-                "<div class='qrcode-placeholder'>\n"
-                "    <div class='qrcode-placeholder-border'></div>\n"
-                "    <div class='qrcode-placeholder-content'>\n"
-                "        <span class='qrcode-placeholder-content-background'><span class='placeholder'>&#40;&#40;var&#41;&#41;</span></span>\n"  # noqa
-                "    </div>\n"
-                "</div>\n"
-                "</p>"
-            ),
-        ),
-        (
-            LetterPreviewTemplate,
             {"template_type": "letter", "subject": "foo", "content": "QR: ((var))"},
             (
                 "<p>\n"
@@ -3179,20 +3165,6 @@ def test_letter_image_template_marks_first_page_of_attachment():
         ),
         (
             LetterPreviewTemplate,
-            {"template_type": "letter", "subject": "foo", "content": "[QR](https://blah.blah/?query=((var)))"},
-            (
-                "<p>\n"
-                "<div class='qrcode-placeholder'>\n"
-                "    <div class='qrcode-placeholder-border'></div>\n"
-                "    <div class='qrcode-placeholder-content'>\n"
-                "        <span class='qrcode-placeholder-content-background'>https://blah.blah/?query=<span class='placeholder'>&#40;&#40;var&#41;&#41;</span></span>\n"  # noqa
-                "    </div>\n"
-                "</div>\n"
-                "</p>"
-            ),
-        ),
-        (
-            LetterPreviewTemplate,
             {"template_type": "letter", "subject": "foo", "content": "QR:https://blah.blah/?query=((var))"},
             (
                 "<p>\n"
@@ -3200,19 +3172,6 @@ def test_letter_image_template_marks_first_page_of_attachment():
                 "    <div class='qrcode-placeholder-border'></div>\n"
                 "    <div class='qrcode-placeholder-content'>\n"
                 "        <span class='qrcode-placeholder-content-background'>https://blah.blah/?query=<span class='placeholder'>&#40;&#40;var&#41;&#41;</span></span>\n"  # noqa
-                "    </div>\n"
-                "</div>\n"
-                "</p>"
-            ),
-        ),
-        (
-            LetterPreviewTemplate,
-            {"template_type": "letter", "subject": "foo", "content": "[QR](pre((var))post)"},
-            (
-                "<p>\n<div class='qrcode-placeholder'>\n"
-                "    <div class='qrcode-placeholder-border'></div>\n"
-                "    <div class='qrcode-placeholder-content'>\n"
-                "        <span class='qrcode-placeholder-content-background'>pre<span class='placeholder'>&#40;&#40;var&#41;&#41;</span>post</span>\n"  # noqa
                 "    </div>\n"
                 "</div>\n"
                 "</p>"


### PR DESCRIPTION
We’ve introduced a new, friendlier syntax for QR codes in letters, which looks like
```
QR: https://www.example.com/
```

The old one looks like:
```
[QR](https://www.example.com/)
```

We should remove the old one so there’s only one way to do things.

We should remove it now (before we launch the feature) so that we don’t have to worry about it being a breaking change for teams using the old syntax.

This also includes making the regex for the new syntax a bit more flexible so it can handle leading whitespace.