### PR TITLE
Return QR code validation error from check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 68.0.0
+
+* Update return value of `BaseLetterTemplate.has_qr_code_with_too_much_data` from `bool` to `Optional[QrCodeTooLong]`.
+
 ## 67.0.0
 
 * Add `has_qr_code_with_too_much_data` property to letter templates.

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -6,7 +6,7 @@ from contextlib import suppress
 from functools import lru_cache
 from io import StringIO
 from itertools import islice
-from typing import cast
+from typing import Optional, cast
 
 import phonenumbers
 from flask import current_app
@@ -30,6 +30,7 @@ from notifications_utils.postal_address import (
 from notifications_utils.template import BaseLetterTemplate, Template
 
 from . import EMAIL_REGEX_PATTERN, hostname_part, tld_part
+from .qr_code import QrCodeTooLong
 
 uk_prefix = "44"
 
@@ -117,7 +118,7 @@ class RecipientCSV:
         ]
 
     @property
-    def has_errors(self):
+    def has_errors(self) -> bool:
         return bool(
             self.missing_column_headers
             or self.duplicate_recipient_column_headers
@@ -293,7 +294,7 @@ class RecipientCSV:
         return 3 if self.template_type == "letter" else 1
 
     @property
-    def has_recipient_columns(self):
+    def has_recipient_columns(self) -> bool:
 
         if self.template_type == "letter":
             sets_to_check = [
@@ -386,7 +387,7 @@ class Row(InsensitiveDict):
             else:
                 self.message_too_long = template.is_message_too_long()
             self.message_empty = template.is_message_empty()
-            self.qr_code_too_long = self._has_qr_code_with_too_much_data()
+            self.qr_code_too_long: Optional[QrCodeTooLong] = self._has_qr_code_with_too_much_data()
 
         super().__init__({key: Cell(key, value, error_fn, self.placeholders) for key, value in row_dict.items()})
 
@@ -399,11 +400,11 @@ class Row(InsensitiveDict):
         return self[key]
 
     @property
-    def has_error(self):
+    def has_error(self) -> bool:
         return self.has_error_spanning_multiple_cells or any(cell.error for cell in self.values())
 
     @property
-    def has_bad_recipient(self):
+    def has_bad_recipient(self) -> bool:
         if self.template_type == "letter":
             return self.has_bad_postal_address
         return self.get(self.recipient_column_headers[0]).recipient_error
@@ -412,22 +413,22 @@ class Row(InsensitiveDict):
     def has_bad_postal_address(self):
         return self.template_type == "letter" and not self.as_postal_address.valid
 
-    def _has_qr_code_with_too_much_data(self):
+    def _has_qr_code_with_too_much_data(self) -> Optional[QrCodeTooLong]:
         if not self._template:
-            return False
+            return None
 
         if self._template.template_type != "letter":
-            return False
+            return None
 
         self._template = cast(BaseLetterTemplate, self._template)
         return self._template.has_qr_code_with_too_much_data()
 
     @property
-    def has_error_spanning_multiple_cells(self):
-        return self.message_too_long or self.message_empty or self.has_bad_postal_address or self.qr_code_too_long
+    def has_error_spanning_multiple_cells(self) -> bool:
+        return self.message_too_long or self.message_empty or self.has_bad_postal_address or bool(self.qr_code_too_long)
 
     @property
-    def has_missing_data(self):
+    def has_missing_data(self) -> bool:
         return any(cell.error == Cell.missing_field_error for cell in self.values())
 
     @property

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from functools import lru_cache
 from html import unescape
 from os import path
+from typing import Optional
 
 from jinja2 import Environment, FileSystemLoader
 from markupsafe import Markup
@@ -706,14 +707,14 @@ class BaseLetterTemplate(SubjectMixin, Template):
     def postal_address(self):
         return PostalAddress.from_personalisation(InsensitiveDict(self.values))
 
-    def has_qr_code_with_too_much_data(self):
+    def has_qr_code_with_too_much_data(self) -> Optional[QrCodeTooLong]:
         content = self._personalised_content if self.values else self.content
         try:
             Take(content).then(notify_letter_qrcode_validator)
-        except QrCodeTooLong:
-            return True
+        except QrCodeTooLong as e:
+            return e
 
-        return False
+        return None
 
     @property
     def _address_block(self):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "67.0.0"  # d5a67ded868fab436761689a7f12dc25
+__version__ = "68.0.0"  # bc9d46aa418be8b8e0e0e260bea1e717

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -10,6 +10,7 @@ from orderedset import OrderedSet
 
 from notifications_utils import SMS_CHAR_COUNT_LIMIT
 from notifications_utils.countries import Country
+from notifications_utils.qr_code import QrCodeTooLong
 from notifications_utils.recipients import (
     Cell,
     RecipientCSV,
@@ -1252,6 +1253,6 @@ def test_errors_on_qr_codes_with_too_much_data():
     assert recipients.has_errors is True
     assert len(list(recipients.rows_with_errors)) == 1
     assert recipients.rows_as_list[0].has_error is False
-    assert recipients.rows_as_list[0].qr_code_too_long is False
+    assert recipients.rows_as_list[0].qr_code_too_long is None
     assert recipients.rows_as_list[1].has_error is True
-    assert recipients.rows_as_list[1].qr_code_too_long is True
+    assert isinstance(recipients.rows_as_list[1].qr_code_too_long, QrCodeTooLong)

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -3272,4 +3272,11 @@ def test_links_with_personalisation(template_class, template_data, expect_conten
 def test_letter_qr_codes_with_too_much_data(content, values, should_error):
     template = LetterPreviewTemplate({"template_type": "letter", "subject": "foo", "content": content}, values)
 
-    assert template.has_qr_code_with_too_much_data() is should_error
+    error = template.has_qr_code_with_too_much_data()
+
+    if should_error:
+        assert error.data == "content" * 100
+        assert error.max_bytes == 504
+        assert error.num_bytes == 700
+    else:
+        assert error is None


### PR DESCRIPTION
The exception raised by the contains useful information about the problem at hand, such as the data passed into the QR code, and the actual & max length of QR codes.

Let's pass this back instead of lose the information by only returning True/False. Then we can potentially display the bad QR code data to the user if it's helpful.