### PR TITLE
Remove `<strong>` tags from links in QR codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 68.0.1
+
+* Fix a bug with some HTML getting injected into QR codes
+
 ## 68.0.0
 
 * Update return value of `BaseLetterTemplate.has_qr_code_with_too_much_data` from `bool` to `Optional[QrCodeTooLong]`.

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -3,6 +3,7 @@ import re
 from itertools import count
 
 import mistune
+from bs4 import BeautifulSoup
 from orderedset import OrderedSet
 
 from notifications_utils import MAGIC_SEQUENCE, magic_sequence_regex
@@ -73,7 +74,16 @@ def qr_code_contents_from_paragraph(text):
 
 class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
     def _render_qr_data(self, data):
-        if "<span class='placeholder" in data:
+        if "<strong data-original-protocol=" in data:
+            parsed_data = BeautifulSoup(data, "html.parser")
+            strong_tag = parsed_data.select_one("strong[data-original-protocol]")
+            original_protocol = strong_tag["data-original-protocol"]
+            original_link = strong_tag.text
+            strong_tag.decompose()
+            rest_of_html = str(parsed_data).replace(">((", ">&#40;&#40;").replace("))<", "&#41;&#41;<")
+            data = f"{original_protocol}{original_link}{rest_of_html}"
+
+        if "<span class='placeholder" in data or '<span class="placeholder' in data:
             placeholder = qr_code_placeholder(data)
             return replace_svg_dashes(placeholder)
 

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -107,8 +107,9 @@ class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
         return ""
 
     def autolink(self, link, is_email=False):
-        link = link.replace("http://", "").replace("https://", "")
-        return f"<strong>{link}</strong>"
+        link_without_protocol = link.replace("http://", "").replace("https://", "")
+        protocol = link[: (len(link) - len(link_without_protocol))]
+        return f"<strong data-original-protocol='{protocol}'>{link_without_protocol}</strong>"
 
     def image(self, src, title, alt_text):
         return ""

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "68.0.0"  # bc9d46aa418be8b8e0e0e260bea1e717
+__version__ = "68.0.1"  # 59a58b3e00a6f603f03e7e30a1b85fed

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -636,6 +636,38 @@ def test_letter_qr_code_works_with_extra_whitespace():
 
 
 @pytest.mark.parametrize(
+    "content, mock, expected_data",
+    (
+        (
+            "qr: http://example.com",
+            "notifications_utils.markdown.qr_code_as_svg",
+            "http://example.com",
+        ),
+        (
+            "qr: http://example.com?foo=<span class='placeholder'>((bar))</span>",
+            "notifications_utils.markdown.qr_code_placeholder",
+            'http://example.com?foo=<span class="placeholder">&#40;&#40;bar&#41;&#41;</span>',
+        ),
+        (
+            "qr: arbitrary data not a URL",
+            "notifications_utils.markdown.qr_code_as_svg",
+            "arbitrary data not a URL",
+        ),
+    ),
+)
+def test_letter_qr_code_only_passes_through_url(
+    mocker,
+    content,
+    mock,
+    expected_data,
+):
+    mock_render = mocker.patch(mock)
+    notify_letter_preview_markdown(content)
+
+    mock_render.assert_called_once_with(expected_data)
+
+
+@pytest.mark.parametrize(
     "markdown_function, expected",
     (
         [notify_letter_preview_markdown, "<p>~~Strike~~</p>"],

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -426,7 +426,11 @@ def test_table(markdown_function):
 @pytest.mark.parametrize(
     "markdown_function, link, expected",
     (
-        [notify_letter_preview_markdown, "http://example.com", "<p><strong>example.com</strong></p>"],
+        [
+            notify_letter_preview_markdown,
+            "http://example.com",
+            "<p><strong data-original-protocol='http://'>example.com</strong></p>",
+        ],
         [
             notify_email_markdown,
             "http://example.com",
@@ -569,7 +573,10 @@ def test_image(markdown_function):
 @pytest.mark.parametrize(
     "markdown_function, expected",
     (
-        [notify_letter_preview_markdown, ("<p>Example: <strong>example.com</strong></p>")],
+        [
+            notify_letter_preview_markdown,
+            ("<p>Example: <strong data-original-protocol='http://'>example.com</strong></p>"),
+        ],
         [
             notify_email_markdown,
             (
@@ -592,7 +599,10 @@ def test_link(markdown_function, expected):
 @pytest.mark.parametrize(
     "markdown_function, expected",
     (
-        [notify_letter_preview_markdown, ("<p>Example: <strong>example.com</strong></p>")],
+        [
+            notify_letter_preview_markdown,
+            ("<p>Example: <strong data-original-protocol='http://'>example.com</strong></p>"),
+        ],
         [
             notify_email_markdown,
             (

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -644,7 +644,7 @@ def test_letter_qr_code_works_with_extra_whitespace():
             "http://example.com",
         ),
         (
-            "qr: http://example.com?foo=<span class='placeholder'>((bar))</span>",
+            'qr: http://example.com?foo=<span class="placeholder">&#40;&#40;bar&#41;&#41;</span>',
             "notifications_utils.markdown.qr_code_placeholder",
             'http://example.com?foo=<span class="placeholder">&#40;&#40;bar&#41;&#41;</span>',
         ),

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -3199,7 +3199,7 @@ def test_letter_image_template_marks_first_page_of_attachment():
                 "<div class='qrcode-placeholder'>\n"
                 "    <div class='qrcode-placeholder-border'></div>\n"
                 "    <div class='qrcode-placeholder-content'>\n"
-                "        <span class='qrcode-placeholder-content-background'><strong data-original-protocol='https://'>blah.blah/?query=</strong><span class='placeholder'>&#40;&#40;var&#41;&#41;</span></span>\n"  # noqa
+                "        <span class='qrcode-placeholder-content-background'>https://blah.blah/?query=<span class=\"placeholder\">&#40;&#40;var&#41;&#41;</span></span>\n"  # noqa
                 "    </div>\n"
                 "</div>\n"
                 "</p>"

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -3199,7 +3199,7 @@ def test_letter_image_template_marks_first_page_of_attachment():
                 "<div class='qrcode-placeholder'>\n"
                 "    <div class='qrcode-placeholder-border'></div>\n"
                 "    <div class='qrcode-placeholder-content'>\n"
-                "        <span class='qrcode-placeholder-content-background'>https://blah.blah/?query=<span class=\"placeholder\">&#40;&#40;var&#41;&#41;</span></span>\n"  # noqa
+                "        <span class='qrcode-placeholder-content-background'>https://blah.blah/?query=<span class='placeholder'>&#40;&#40;var&#41;&#41;</span></span>\n"  # noqa
                 "    </div>\n"
                 "</div>\n"
                 "</p>"

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -2789,8 +2789,16 @@ def test_plain_text_email_whitespace():
                 "</h2>"
             ),
         ),
-        (LetterPreviewTemplate, "letter", ("<h2>Heading link: <strong>example.com</strong></h2>")),
-        (LetterPrintTemplate, "letter", ("<h2>Heading link: <strong>example.com</strong></h2>")),
+        (
+            LetterPreviewTemplate,
+            "letter",
+            ("<h2>Heading link: <strong data‑original‑protocol='https://'>example.com</strong></h2>"),
+        ),
+        (
+            LetterPrintTemplate,
+            "letter",
+            ("<h2>Heading link: <strong data‑original‑protocol='https://'>example.com</strong></h2>"),
+        ),
     ),
 )
 def test_heading_only_template_renders(renderer, template_type, expected_content):
@@ -3117,21 +3125,29 @@ def test_letter_image_template_marks_first_page_of_attachment():
         (
             LetterPreviewTemplate,
             {"template_type": "letter", "subject": "foo", "content": "[Example](((var)))"},
-            "<p>Example: <strong><span class='placeholder'>&#40;&#40;var&#41;&#41;</span></strong></p>",
+            (
+                "<p>Example: "
+                "<strong data‑original‑protocol=''><span class='placeholder'>&#40;&#40;var&#41;&#41;</span></strong>"
+                "</p>"
+            ),
         ),
         (
             LetterPreviewTemplate,
             {"template_type": "letter", "subject": "foo", "content": "[Example](https://blah.blah/?query=((var)))"},
             (
                 "<p>Example: "
-                "<strong>blah.blah/?query=<span class='placeholder'>&#40;&#40;var&#41;&#41;</span></strong>"
+                "<strong data‑original‑protocol='https://'>blah.blah/?query=<span class='placeholder'>&#40;&#40;var&#41;&#41;</span></strong>"  # noqa
                 "</p>"
             ),
         ),
         (
             LetterPreviewTemplate,
             {"template_type": "letter", "subject": "foo", "content": "[Example](pre((var))post)"},
-            ("<p>Example: <strong>pre<span class='placeholder'>&#40;&#40;var&#41;&#41;</span>post</strong></p>"),
+            (
+                "<p>Example: "
+                "<strong data‑original‑protocol=''>pre<span class='placeholder'>&#40;&#40;var&#41;&#41;</span>post</strong>"  # noqa
+                "</p>"
+            ),
         ),
         (
             LetterPreviewTemplate,
@@ -3183,7 +3199,7 @@ def test_letter_image_template_marks_first_page_of_attachment():
                 "<div class='qrcode-placeholder'>\n"
                 "    <div class='qrcode-placeholder-border'></div>\n"
                 "    <div class='qrcode-placeholder-content'>\n"
-                "        <span class='qrcode-placeholder-content-background'><strong>blah.blah/?query=</strong><span class='placeholder'>&#40;&#40;var&#41;&#41;</span></span>\n"  # noqa
+                "        <span class='qrcode-placeholder-content-background'><strong data-original-protocol='https://'>blah.blah/?query=</strong><span class='placeholder'>&#40;&#40;var&#41;&#41;</span></span>\n"  # noqa
                 "    </div>\n"
                 "</div>\n"
                 "</p>"


### PR DESCRIPTION
We automatically make URLs in letters bold by adding a `<strong>` tag around them. We also remove the protocol (for example `https://`) from the URL.

If we want to reconstruct the full URL later down the line, we need to store the original protocol somewhere.

HTML allows for arbitrary attributes to be created as long as they are prefixed with `data-`. So this PR introduces a new attribute on the `<strong>` tag which stores the original protocol for later use.

***

Adding the `<strong>` tag happens before we look for our QR code syntax.

This means that URLs going into QR codes end up with a small bit of markup in them. This prevents them from going to the original URL when scanned.

This PR:
- removes the `<strong>` tag
- restores the protocol
- preserving any placeholders

Ideally we wouldn’t have to do and then undo this work, but I can’t see a way to either:
- selectively not add the `<strong>` tag if the URL is inside a QR code
- run the QR code detection before running the autolink code