### PR TITLE
Remove line and paragraph separators from text message content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 70.0.2
+
+* Update sanitising of SMS content to include more obscure whitespace
+
 ## 70.0.0
 
 * InvalidPhoneError messages have been updated. The new error messages are more user friendly.

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -17,6 +17,8 @@ OBSCURE_ZERO_WIDTH_WHITESPACE = (
     "\u200D"  # zero width joiner
     "\u2060"  # word joiner
     "\uFEFF"  # zero width non-breaking space
+    "\u2028"  # line separator
+    "\u2029"  # paragraph separator
 )
 
 OBSCURE_FULL_WIDTH_WHITESPACE = "\u00A0" "\u202F"  # non breaking space  # narrow no break space

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -18,6 +18,8 @@ class SanitiseText:
         "\u200D": "",  # zero width joiner
         "\u2060": "",  # word joiner
         "\uFEFF": "",  # zero width non-breaking space
+        "\u2028": "",  # line separator
+        "\u2029": "",  # paragraph separator
         "\u00A0": " ",  # NON BREAKING WHITE SPACE (U+200B)
         "\u202F": " ",  # narrow no break space
         "\t": " ",  # TAB

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "70.0.1"  # 84bff4567fb79767f925b40c8ca3be68
+__version__ = "70.0.2"  # b1d97710470e8d46db854f6dfeb83b82

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -395,7 +395,7 @@ def test_strip_unsupported_characters():
         # Narrow no break spaces replaced by single spaces
         "\u202FYour\u202Ftax\u202F is\u202F\u202Fdue\u202F",
         # zero width spaces are removed
-        "\u180EYour \u200Btax\u200C is \u200D\u2060due \uFEFF",
+        "\u180EYour \u200Btax\u200C is \u200D\u2060due \uFEFF\u2028\u2029",
         # tabs are replaced by single spaces
         "\tYour tax\tis due  ",
     ],

--- a/tests/test_sanitise_text.py
+++ b/tests/test_sanitise_text.py
@@ -90,7 +90,7 @@ def test_encode_string(content, expected):
         ("Ŵêlsh chârâctêrs ârê cômpâtîblê wîth SanitiseSMS", SanitiseSMS, set()),
         ("Lots of GSM chars that arent ascii compatible:\n\r€", SanitiseSMS, set()),
         ("Lots of GSM chars that arent ascii compatible:\n\r€", SanitiseASCII, {"\n", "\r", "€"}),
-        ("Obscure\u00A0whitespace\u202Fcharacters which we normalise o\u180Eut", SanitiseSMS, set()),
+        ("Obscure\u00A0whitespace\u202Fcharacters which \u2028we \u2029normalise o\u180Eut", SanitiseSMS, set()),
     ],
 )
 def test_sms_encoding_get_non_compatible_characters(content, cls, expected):


### PR DESCRIPTION
These are obscure unicode characters which are used to indicate that a new line should be treated as a line break or a new paragraph.

Because they are not in the GSM-7 character set we can’t send them without incurring double-charging. For this reason we validate them out at the time of template editing, and the user gets this unhelpful error message:

<img width="490" alt="image" src="https://github.com/alphagov/notifications-utils/assets/355079/3b3bc064-f928-486e-9701-6786f8aea025">

***

This PR adds these characters to the list of whitespace we remove and sanitise out.