### PR TITLE
Make sure QR code <strong> tags are removed

### DIFF
--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -72,9 +72,6 @@ def qr_code_contents_from_paragraph(text):
 
 class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
     def _render_qr_data(self, data):
-        # Restore http:// or https:// and strip out the <strong> tag that gets injected by the `link`/`autolink` methods
-        data = re.sub(r"<strong data-original-protocol='(https?://)'>(.*?)</strong>", r"\1\2", data)
-
         if "<span class='placeholder" in data or '<span class="placeholder' in data:
             placeholder = qr_code_placeholder(data)
             return replace_svg_dashes(placeholder)
@@ -101,7 +98,11 @@ class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
             return ""
 
         if qr_code_contents := qr_code_contents_from_paragraph(text):
-            text = self._render_qr_data(qr_code_contents)
+            # Restore http:// or https:// and strip out the <strong> tag that gets injected by
+            # the `link`/`autolink` methods
+            text = self._render_qr_data(
+                re.sub(r"<strong data-original-protocol='(https?://)'>(.*?)</strong>", r"\1\2", qr_code_contents)
+            )
 
         return f"<p>{text}</p>"
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "70.0.0"  # 6cc2adee179cb4d78903f8d3003497e0
+__version__ = "70.0.1"  # 84bff4567fb79767f925b40c8ca3be68

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,10 +1,13 @@
 import pytest
 
+from notifications_utils.field import Field
 from notifications_utils.markdown import (
     notify_email_markdown,
     notify_letter_preview_markdown,
+    notify_letter_qrcode_validator,
     notify_plain_text_email_markdown,
 )
+from notifications_utils.take import Take
 from notifications_utils.template import HTMLEmailTemplate
 
 
@@ -665,6 +668,14 @@ def test_letter_qr_code_only_passes_through_url(
     notify_letter_preview_markdown(content)
 
     mock_render.assert_called_once_with(expected_data)
+
+
+def test_qr_code_validator_gets_expected_data(mocker):
+    mock_render = mocker.patch("notifications_utils.markdown.NotifyLetterMarkdownValidatingRenderer._render_qr_data")
+
+    Take(Field("qr: ((data))", {"data": "https://www.example.com"}, html="escape")).then(notify_letter_qrcode_validator)
+
+    assert mock_render.call_args_list == [mocker.call("https://www.example.com")]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
We removed the <strong> tags when rendering the QR code for preview/print, but because we override `_render_qr_data` for the validation renderer we had missed it there.

Let's move the <strong> stripping to before we pass the data into the renderer so it takes effect everywhere.