### PR TITLE
Remove empty cell for state of branding

### DIFF
--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -197,15 +197,14 @@
                     <td>
                       <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse">
                         <tr>
-                          <td style="padding: 0 5px 0{% if brand_colour %} 7px; border-left: solid 2px {{ brand_colour }}{% else %} 0{% endif %}">
-                            <img src="{{ brand_logo }}" style="display: block; border: 0" height="{% if brand_text -%} 27 {%- else -%} 54 {%- endif %}"
-                                 alt="{% if brand_text %}{% else -%}{{ brand_alt_text }}{%- endif %}" />
+                          <td style="padding: 0 5px 0{% if brand_colour %} 7px; border-left: solid 2px {{ brand_colour }}{% else %} 0{% endif %}{% if not brand_text -%}; max-height: 54px{%- endif %}">
+                            <img src="{{ brand_logo }}" style="display: block; border: 0{% if not brand_text -%}; max-height: 54px{%- endif %}" height="{% if brand_text -%}27{%- else -%}54{%- endif %}" alt="{% if brand_text %}{% else -%}{{ brand_alt_text }}{%- endif %}" />
                           </td>
+                          {% if brand_text %}
                           <td width="100%" style="font-family: Helvetica, Arial, sans-serif; font-size: 18px; line-height: 23px;" valign="center">
-                            {% if brand_text %}
                             {{ brand_text }}
-                            {% endif %}
                           </td>
+                          {% endif %}
                         </tr>
                       </table>
                     </td>


### PR DESCRIPTION
For some reason the cell used to hold the branding text causes an error with the JAWS screen reader
when empty (which it is when the 'only branding'
brand has no text).

In this state, and when the content of the email
has a certain form, JAWS announces all links in
the email the same.

This therefore removes that cell when it is empty.

It includes the addition of a max-width to stop
the Outlook app on Android from stretching the
logo to twice the size. It seems strange to keep
the height attribute on the <img> tag but that is
needed to keep the image working on Outlook on
Windows.

Also note that we only apply the max-width when
there is no text. Setting it on the cell with the
logo image makes it overlap the text in several
email clients.