### PR TITLE
Fix QR code rendering with old [QR]() syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 70.0.6
+
+* Fix QR code rendering for old-style syntax `[QR]()`
+
 ## 70.0.5
 
 * Ensure UUIDs in Redis cache keys are always lowercase

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -101,7 +101,7 @@ class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
             # Restore http:// or https:// and strip out the <strong> tag that gets injected by
             # the `link`/`autolink` methods
             text = self._render_qr_data(
-                re.sub(r"<strong data-original-protocol='(https?://)'>(.*?)</strong>", r"\1\2", qr_code_contents)
+                re.sub(r"<strong data-original-protocol='(https?://|)'>(.*?)</strong>", r"\1\2", qr_code_contents)
             )
 
         return f"<p>{text}</p>"
@@ -110,9 +110,14 @@ class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
         return ""
 
     def autolink(self, link, is_email=False):
-        link_without_protocol = link.replace("http://", "").replace("https://", "")
-        protocol = link[: (len(link) - len(link_without_protocol))]
-        return f"<strong data-original-protocol='{protocol}'>{link_without_protocol}</strong>"
+        proto_matcher = re.compile(r"^(https?://)")
+
+        protocol = ""
+        if match := proto_matcher.match(link):
+            protocol = match.group(1)
+            link = proto_matcher.sub("", link, 1)
+
+        return f"<strong data-original-protocol='{protocol}'>{link}</strong>"
 
     def image(self, src, title, alt_text):
         return ""

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "70.0.5"  # e28797b5b30b439130610c53a694f2a1
+__version__ = "70.0.6"  # 9c090531e4de4412ac3de9030de13c86


### PR DESCRIPTION
We have switched to using the syntax `QR: link/data` in letter template content for rendering QR codes. However, we use mistune to parse the letter content into HTML, and that just so happens to take our "old" QR code syntax of `[QR](link/data)` and turn it into `QR: link/data`, which then can get picked up as the new-style syntax.

I had a quick look to see if we could force the old-style syntax to only render as links, not QR codes, but the solution felt slightly convoluted (need to feed some indicator/argument between `link`/`autolink` and `paragraph` methods) and I don't think it's really worth doing. We can technically support both syntaxes, but only advertise the simpler one. Note also that the "old-style" `[QR]()` syntax only resolves to an actual QR code if it's the only thing in the paragraph block. If it's mid-paragraph, it will remain as a normal link.

**Note**: I've edited the QR code renderer to show the QR code data as a string below the code for example purposes only.

# Before

| Letter content | Before | After |
|--------|--------|--------|
| `qr: http://www.google.com`<br><br>`[qr](http://www.google.com)` | <img width="517" alt="image" src="https://github.com/alphagov/notifications-utils/assets/2920760/6ddb6aef-d0ca-4314-8969-2937ac308f6b"> | <img width="466" alt="image" src="https://github.com/alphagov/notifications-utils/assets/2920760/e2be85c5-b873-4917-be3b-3398a922a9e2"> |
| `qr: just some text`<br><br>`[qr](just some text)` | <img width="530" alt="image" src="https://github.com/alphagov/notifications-utils/assets/2920760/71df1cb7-d9ef-4213-90f3-fec12c916905"> | <img width="470" alt="image" src="https://github.com/alphagov/notifications-utils/assets/2920760/e5df0735-35f9-4f16-9232-323f46ebbaaf"> |
| `qr: some text and then a link https://www.google.com`<br><br>`[qr](some text and then a link https://www.google.com)` | <img width="609" alt="image" src="https://github.com/alphagov/notifications-utils/assets/2920760/9d1c5492-cf42-4ffb-97c7-3c9e0b7643f5"> | <img width="522" alt="image" src="https://github.com/alphagov/notifications-utils/assets/2920760/8ced8ac6-82df-41a1-9691-3bf83ef9f80e"> | 


