### PR TITLE
Remove translation of markdown links in letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 71.0.0
+
+* Remove support for Markdown-style links in letters `[label](https://example.url)`
+
 ## 70.0.6
 
 * Fix QR code rendering for old-style syntax `[QR]()`

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -135,7 +135,10 @@ class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
         if link.startswith("span class='placeholder") and link.endswith("</span"):
             link = f"<{link}>"
 
-        return f"{content}: {self.autolink(link)}"
+        if title:
+            return f'[{content}]({link} "{title}")'
+
+        return f"[{content}]({link})"
 
     def footnote_ref(self, key, index):
         return ""

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "70.0.6"  # 9c090531e4de4412ac3de9030de13c86
+__version__ = "71.0.0"  # 7bf8dc0f5c44896b7426e390e7fac1f9

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -2792,12 +2792,12 @@ def test_plain_text_email_whitespace():
         (
             LetterPreviewTemplate,
             "letter",
-            ("<h2>Heading link: <strong data‑original‑protocol='https://'>example.com</strong></h2>"),
+            ("<h2>Heading [link](https://example.com)</h2>"),
         ),
         (
             LetterPrintTemplate,
             "letter",
-            ("<h2>Heading link: <strong data‑original‑protocol='https://'>example.com</strong></h2>"),
+            ("<h2>Heading [link](https://example.com)</h2>"),
         ),
     ),
 )
@@ -3125,29 +3125,21 @@ def test_letter_image_template_marks_first_page_of_attachment():
         (
             LetterPreviewTemplate,
             {"template_type": "letter", "subject": "foo", "content": "[Example](((var)))"},
-            (
-                "<p>Example: "
-                "<strong data‑original‑protocol=''><span class='placeholder'>&#40;&#40;var&#41;&#41;</span></strong>"
-                "</p>"
-            ),
+            ("<p>[Example](<span class='placeholder'>&#40;&#40;var&#41;&#41;</span>)</p>"),
         ),
         (
             LetterPreviewTemplate,
             {"template_type": "letter", "subject": "foo", "content": "[Example](https://blah.blah/?query=((var)))"},
             (
-                "<p>Example: "
-                "<strong data‑original‑protocol='https://'>blah.blah/?query=<span class='placeholder'>&#40;&#40;var&#41;&#41;</span></strong>"  # noqa
+                "<p>[Example]"
+                "(https://blah.blah/?query=<span class='placeholder'>&#40;&#40;var&#41;&#41;</span>)"
                 "</p>"
             ),
         ),
         (
             LetterPreviewTemplate,
             {"template_type": "letter", "subject": "foo", "content": "[Example](pre((var))post)"},
-            (
-                "<p>Example: "
-                "<strong data‑original‑protocol=''>pre<span class='placeholder'>&#40;&#40;var&#41;&#41;</span>post</strong>"  # noqa
-                "</p>"
-            ),
+            ("<p>[Example](pre<span class='placeholder'>&#40;&#40;var&#41;&#41;</span>post)</p>"),
         ),
         (
             LetterPreviewTemplate,


### PR DESCRIPTION
When we first added markdown-style formatting to emails – before letters were even a thing – we decided to translate links into a text-only-friendly representation, so `[link](url)` became `link: url`:
https://github.com/alphagov/notifications-utils/blob/13abc3f200603c46c35c76b0dc40718c7efe3ac2/notifications_utils/formatters.py#L149-L150

This is because we did not – officially or unofficially – support link text in emails.

When we added letter templates we shared the same method for rendering links, so letter templates also got this same plain-text representation of Markdown-style links.

The idea was that if you pasted a Markdown-style link into a template and didn’t realise it wasn’t supported the recipient wouldn’t get something which looked broken.

We later chose to make the URLs bold, the same as other URLs in letters:
https://github.com/alphagov/notifications-utils/blob/713c765a916218f0b826915876e0bbddf66e1b52/notifications_utils/formatters.py#L108-L109

In January 2018 we enabled link text in emails, but didn’t officially support it: https://github.com/alphagov/notifications-utils/pull/293

In May 2023 we officially documented support for link text in emails: https://github.com/alphagov/notifications-admin/pull/4686

We never documented how Markdown-style links worked in letters. So the fact that they do anything at all is a bit of a historic oddity. Doing some analysis shows that only a couple of real templates are using this behaviour, and probably by accident.

Removing support for this will make our code easier to maintain, because it means we have:
- one less undocumented feature that we need to maintain support for
- one less bit of weirdness that people need to spelunk through the code for (see above) in order to understand

We were bitten by both of the above when working on QR codes in letters.

Before we deploy this change we will need to manually edit the couple of templates which are relying on it.