### PR TITLE
remove from_address from EmailPreviewTemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 72.0.0
+
+* Remove the deprecated `from_address` param from EmailPreviewTemplate (it's been unused for six years)
+
 ## 71.0.0
 
 * Remove support for Markdown-style links in letters `[label](https://example.url)`

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -614,14 +614,12 @@ class EmailPreviewTemplate(BaseEmailTemplate):
         template,
         values=None,
         from_name=None,
-        from_address=None,
         reply_to=None,
         show_recipient=True,
         redact_missing_personalisation=False,
     ):
         super().__init__(template, values, redact_missing_personalisation=redact_missing_personalisation)
         self.from_name = from_name
-        self.from_address = from_address
         self.reply_to = reply_to
         self.show_recipient = show_recipient
 
@@ -632,7 +630,6 @@ class EmailPreviewTemplate(BaseEmailTemplate):
                     "body": self.html_body,
                     "subject": self.subject,
                     "from_name": escape_html(self.from_name),
-                    "from_address": self.from_address,
                     "reply_to": self.reply_to,
                     "recipient": Field("((email address))", self.values, with_brackets=False),
                     "show_recipient": self.show_recipient,

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "71.0.0"  # 7bf8dc0f5c44896b7426e390e7fac1f9
+__version__ = "72.0.0"  # baebdc057db65cd9532a23adbcf78e74

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -2223,10 +2223,6 @@ def test_html_template_can_inject_personalisation_with_special_characters():
     "extra_args",
     [
         {"from_name": "Example service"},
-        {
-            "from_name": "Example service",
-            "from_address": "test@example.com",
-        },
         pytest.param({}, marks=pytest.mark.xfail),
     ],
 )
@@ -2236,14 +2232,11 @@ def test_email_preview_shows_from_name(extra_args):
     )
     assert '<th scope="row">From</th>' in str(template)
     assert "Example service" in str(template)
-    assert "test@example.com" not in str(template)
 
 
 def test_email_preview_escapes_html_in_from_name():
     template = EmailPreviewTemplate(
-        {"content": "content", "subject": "subject", "template_type": "email"},
-        from_name='<script>alert("")</script>',
-        from_address="test@example.com",
+        {"content": "content", "subject": "subject", "template_type": "email"}, from_name='<script>alert("")</script>'
     )
     assert "<script>" not in str(template)
     assert '&lt;script&gt;alert("")&lt;/script&gt;' in str(template)


### PR DESCRIPTION
it's been unused since 2017[^1]

[^1]: https://github.com/alphagov/notifications-utils/pull/227