### PR TITLE
Change emails to HTML5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 72.1.0
+
+* Change the email template to use a HTML5 doctype and add a 'hidden' attribute to the preheader
+
 ## 72.0.0
 
 * Remove the deprecated `from_address` param from EmailPreviewTemplate (it's been unused for six years)

--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -3,12 +3,12 @@
 <html lang="en">
 
 <head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-  <meta content="telephone=no" name="format-detection" /> <!-- need to add formatting for real phone numbers -->
-  <meta name="viewport" content="width=device-width" />
+  <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+  <meta content="telephone=no" name="format-detection"> <!-- need to add formatting for real phone numbers -->
+  <meta name="viewport" content="width=device-width">
   <title>{{ subject }}</title>
 
-  <style type="text/css">
+  <style>
     @media only screen and (min-device-width: 581px) {
       .content {
         width: 580px !important;
@@ -19,7 +19,7 @@
   </style>
 
   <!--[if gte mso 9]>
-    <style type="text/css">
+    <style>
       li {
         margin-left: 4px !important;
       }
@@ -57,7 +57,7 @@
                         height="32"
                         border="0"
                         style="Margin-top: 4px;"
-                      />
+                      >
                     </td>
                     <td style="font-size: 28px; line-height: 1.315789474; Margin-top: 4px; padding-left: 10px;">
                       <span style="
@@ -142,7 +142,7 @@
                     style="display: block; border: 0;"
                     height="{% if brand_text -%} 27 {%- else -%} 54 {%- endif %}"
                     alt="{% if brand_text %}{% else -%}{{ brand_alt_text }}{%- endif %}"
-                  />
+                  >
                 </td>
               {% endif %}
               {% if brand_text %}
@@ -191,14 +191,14 @@
         <![endif]-->
                 <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse">
                   <tr>
-                    <td height="24" width="100%" colspan="2"><br /></td>
+                    <td height="24" width="100%" colspan="2"><br></td>
                   </tr>
                   <tr>
                     <td>
                       <table role="presentation" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse">
                         <tr>
                           <td style="padding: 0 5px 0{% if brand_colour %} 7px; border-left: solid 2px {{ brand_colour }}{% else %} 0{% endif %}{% if not brand_text -%}; max-height: 54px{%- endif %}">
-                            <img src="{{ brand_logo }}" style="display: block; border: 0{% if not brand_text -%}; max-height: 54px{%- endif %}" height="{% if brand_text -%}27{%- else -%}54{%- endif %}" alt="{% if brand_text %}{% else -%}{{ brand_alt_text }}{%- endif %}" />
+                            <img src="{{ brand_logo }}" style="display: block; border: 0{% if not brand_text -%}; max-height: 54px{%- endif %}" height="{% if brand_text -%}27{%- else -%}54{%- endif %}" alt="{% if brand_text %}{% else -%}{{ brand_alt_text }}{%- endif %}">
                           </td>
                           {% if brand_text %}
                           <td width="100%" style="font-family: Helvetica, Arial, sans-serif; font-size: 18px; line-height: 23px;" valign="center">
@@ -231,10 +231,10 @@
       width="100%"
   >
     <tr>
-      <td height="30"><br /></td>
+      <td height="30"><br></td>
     </tr>
     <tr>
-      <td width="10" valign="middle"><br /></td>
+      <td width="10" valign="middle"><br></td>
       <td style="font-family: Helvetica, Arial, sans-serif; font-size: 19px; line-height: 1.315789474; max-width: 560px;">
         <!--[if (gte mso 9)|(IE)]>
           <table role="presentation" width="560" align="center" cellpadding="0" cellspacing="0" border="0" style="border-collapse: collapse;width: 560px;">
@@ -248,10 +248,10 @@
           </table>
         <![endif]-->
       </td>
-      <td width="10" valign="middle"><br /></td>
+      <td width="10" valign="middle"><br></td>
     </tr>
     <tr>
-      <td height="30"><br /></td>
+      <td height="30"><br></td>
     </tr>
   </table>
 {% if complete_html %}

--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -34,7 +34,7 @@
 
 <body style="font-family: Helvetica, Arial, sans-serif;font-size: 16px;margin: 0;color:#0b0c0c;">
 {% endif %}
-<span style="display: none;font-size: 1px;color: #fff; max-height: 0;">{{ preheader }}…</span>
+<span style="display: none;font-size: 1px;color: #fff; max-height: 0;" hidden>{{ preheader }}…</span>
 {% if govuk_banner %}
   <table role="presentation" width="100%" style="border-collapse: collapse;min-width: 100%;width: 100% !important;" cellpadding="0" cellspacing="0" border="0">
     <tr>

--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -1,6 +1,6 @@
 {% if complete_html %}
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<!DOCTYPE html>
+<html lang="en">
 
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -182,7 +182,7 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
         return '<hr style="border: 0; height: 1px; background: #B1B4B6; Margin: 30px 0 30px 0;">'
 
     def linebreak(self):
-        return "<br />"
+        return "<br>"
 
     def list(self, body, ordered=True):
         return (

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "72.0.1"  # dec720ef49bdf098b3d67163647d4c1b
+__version__ = "72.1.0"  # c356ee7adae6b034f525ae19404c6a75

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -383,7 +383,7 @@ def test_pluses_dont_render_as_lists(markdown_function, expected):
         [
             notify_email_markdown,
             (
-                '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">line one<br />'
+                '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">line one<br>'
                 "line two</p>"
                 '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">new paragraph</p>'
             ),

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -282,7 +282,7 @@ def test_preheader_is_at_start_of_html_emails():
     assert (
         '<body style="font-family: Helvetica, Arial, sans-serif;font-size: 16px;margin: 0;color:#0b0c0c;">\n'
         "\n"
-        '<span style="display: none;font-size: 1px;color: #fff; max-height: 0;">content…</span>'
+        '<span style="display: none;font-size: 1px;color: #fff; max-height: 0;" hidden>content…</span>'
     ) in str(HTMLEmailTemplate({"content": "content", "subject": "subject", "template_type": "email"}))
 
 


### PR DESCRIPTION
Changes the doctype of our email template from XHTML1.0 strict to HTML5, to let us use the `hidden` attribute to hide our preheader.

https://trello.com/c/SeG6l0zU/375-change-email-doctype-to-html5

Note: the new template still has validation errors but they are due to our use of deprecated HTML4 features to stop email client programs stripping out our styles.

## Testing done

I tested [all the possible branding variants](https://github.com/alphagov/notifications-manuals/wiki/Email-template-documentation#possible-branding-variations-for-testing) of this template with [all the email clients we support](https://github.com/alphagov/notifications-manuals/wiki/Support-for-browsers,-email-clients-and-assistive-technologies#support-for-email-clients) and [all the asssitive technologies we support](https://github.com/alphagov/notifications-manuals/wiki/Support-for-browsers,-email-clients-and-assistive-technologies#support-for-assistive-technologies). No new issues detected from the changes.

## Notes for reviewers

I've tested all the clients that consume the different outputs of this template downstream so, other than sending yourself an email maybe, this would be best reviewed for the logic of the changes.