### PR TITLE
Charge order of invalid address line characters

### DIFF
--- a/notifications_utils/postal_address.py
+++ b/notifications_utils/postal_address.py
@@ -27,7 +27,7 @@ country_UK = Country(UK)
 class PostalAddress:
     MIN_LINES = 3
     MAX_LINES = 7
-    INVALID_CHARACTERS_AT_START_OF_ADDRESS_LINE = r'[\/()@]<>",=~'
+    INVALID_CHARACTERS_AT_START_OF_ADDRESS_LINE = r'@()=[]"\/,<>~'
 
     def __init__(self, raw_address, allow_international_letters=False):
         self.raw_address = raw_address

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "72.1.0"  # c356ee7adae6b034f525ae19404c6a75
+__version__ = "70.0.7"  # 3951650faacc092d58042571d8fc4024


### PR DESCRIPTION
So they match the order we display them in the error message. Doing this means we can reference this constant when writing the error message, rather than hard-coding the set of characters.