### PR TITLE
Patch version bump to 72.1.1

### DIFF
--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "70.0.7"  # 3951650faacc092d58042571d8fc4024
+__version__ = "72.1.1"  # 3951650faacc092d58042571d8fc4024


### PR DESCRIPTION
Somehow the script got this wrong previously and went from
https://github.com/alphagov/notifications-utils/blob/e7882987f0b0e4aa00d3aec9df3d53e9cae85440/notifications_utils/version.py#L8

to
https://github.com/alphagov/notifications-utils/blob/cfc571ca02e3f0a225859721a203e01302bbe4d2/notifications_utils/version.py#L8


This PR manually corrects that to increment the patch version by `1`, to `72.1.1`