### PR TITLE
Always recommend updating CHANGELOG

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -59,23 +59,12 @@ print(
 )
 print("")
 
-if version_part == "minor":
-    print(f"{color.YELLOW}{color.BOLD}Consider updating CHANGELOG.md, for example:{color.END}")
-    print(
-        f"""
-    ## {new_major}.{new_minor}.{new_patch}
+print(f"{color.YELLOW}{color.BOLD}Make sure to update CHANGELOG.md, for example:{color.END}")
+print(
+    f"""
+## {new_major}.{new_minor}.{new_patch}
 
-    * Details of change 1
-    * Details of change 2
-    """
-    )
-
-if version_part == "major":
-    print(f"{color.YELLOW}{color.BOLD}Make sure to update CHANGELOG.md, for example:{color.END}")
-    print(
-        f"""
-    ## {new_major}.{new_minor}.{new_patch}
-
-    * Details of breaking change
-    """
-    )
+* Details of change 1
+* Details of change 2
+"""
+)


### PR DESCRIPTION
This makes the output of `make version-minor` and `make version-patch` consistent with the change to the README in 66248cede37e112344647f01aa3d684b62da617f which now says

https://github.com/alphagov/notifications-utils/blob/20ec6ceb960ae5b93a618ef87002459f390b46ff/README.md#L35