### PR TITLE
allow redis_client to take in optional kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 72.3.0
+
+* allow optional `redis_client_kwargs` dict to be passed through `RedisClient.init_app`
+
 ## 72.2.0
 
 * Render Welsh language templated letter, with page numbers footer and name of the month in Welsh

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -45,10 +45,10 @@ class RedisClient:
     active = False
     scripts = {}
 
-    def init_app(self, app):
+    def init_app(self, app, redis_client_kwargs: Optional[dict] = None):
         self.active = app.config.get("REDIS_ENABLED")
         if self.active:
-            self.redis_store.init_app(app)
+            self.redis_store.init_app(app, **redis_client_kwargs or {})
 
             self.register_scripts()
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "72.2.0"  # feaf21c390e135c7108fa8b3cfc203d9
+__version__ = "72.3.0"  # 91494d6cc54149611e443e428422483d

--- a/tests/clients/redis/test_redis_client.py
+++ b/tests/clients/redis/test_redis_client.py
@@ -58,6 +58,16 @@ def failing_redis_client(mocked_redis_client, delete_mock):
     return mocked_redis_client
 
 
+def test_redis_client_accepts_optional_kwargs(app, mocker):
+    app.config["REDIS_ENABLED"] = True
+    app.config["REDIS_URL"] = "rediss://foo.localhost:6379"
+
+    redis_client = RedisClient()
+    redis_client.init_app(app, redis_client_kwargs={"db": 1})
+
+    assert redis_client.redis_store.connection_pool.connection_kwargs["db"] == 1
+
+
 def test_should_not_raise_exception_if_raise_set_to_false(app, caplog, failing_redis_client):
     with caplog.at_level(logging.ERROR):
         assert failing_redis_client.get("get_key") is None


### PR DESCRIPTION
these get passed through to the redis constructor - potentially useful for fields like `db` to define the db to connect to separate from the url