### PR TITLE
Lift and shift LetterImageTemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 
+## 73.0.0
+
+* Removes `LetterImageTemplate`. This has been moved to admin, as that is the only app using it.
+
 ## 72.2.0
 
 * Render Welsh language templated letter, with page numbers footer and name of the month in Welsh

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "72.2.0"  # feaf21c390e135c7108fa8b3cfc203d9
+__version__ = "73.0.0"  # 744510921d4fdbace3fdea30dcad1bc3

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -19,7 +19,7 @@ from notifications_utils.recipients import (
 )
 from notifications_utils.template import (
     EmailPreviewTemplate,
-    LetterImageTemplate,
+    LetterPreviewTemplate,
     SMSMessageTemplate,
 )
 
@@ -28,10 +28,8 @@ def _sample_template(template_type, content="foo"):
     return {
         "email": EmailPreviewTemplate({"content": content, "subject": "bar", "template_type": "email"}),
         "sms": SMSMessageTemplate({"content": content, "template_type": "sms"}),
-        "letter": LetterImageTemplate(
+        "letter": LetterPreviewTemplate(
             {"content": content, "subject": "bar", "template_type": "letter"},
-            image_url="https://example.com",
-            page_count=1,
         ),
     }.get(template_type)
 


### PR DESCRIPTION
Moves this class and its related template file to the admin app, which is the only thing using it.

This allow us to inject overlay (UI) elements into the correct place, as we want to have an 'edit' button appear on the first page of English content. This may be any arbitrary depth into the letter.