### PR TITLE
Allow hiding notify tag on letter print template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 73.2.0
+
+* Adds a `include_notify_tag` parameter to `LetterPrintTemplate` so that bilingual letters can disable the NOTIFY tag on the English pages of a letter.
+
 This is only used for recording changes for major version bumps.
 More minor changes may optionally be recorded here too.
 

--- a/notifications_utils/jinja_templates/letter_pdf/print.jinja2
+++ b/notifications_utils/jinja_templates/letter_pdf/print.jinja2
@@ -1,4 +1,6 @@
 {% include 'letter_pdf/_head.jinja2' %}
 {% include 'letter_pdf/_main_css.jinja2' %}
+{% if include_notify_tag %}
 {% include 'letter_pdf/_print_only_css.jinja2' %}
+{% endif %}
 {% include 'letter_pdf/_body.jinja2' %}

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "73.1.3"  # f64909325253a40dfdf35789224d49d1
+__version__ = "73.2.0"  # c43120bd405427e3bfdf91421913ab3b

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -2801,3 +2801,18 @@ def test_letter_qr_codes_with_too_much_data(content, values, should_error):
         assert error.num_bytes == 700
     else:
         assert error is None
+
+
+@pytest.mark.parametrize(
+    "extra_template_kwargs, should_have_notify_tag",
+    (
+        ({}, True),
+        ({"include_notify_tag": True}, True),
+        ({"include_notify_tag": False}, False),
+    ),
+)
+def test_rendered_letter_template_for_print_can_toggle_notify_tag(extra_template_kwargs, should_have_notify_tag):
+    template = LetterPrintTemplate(
+        {"template_type": "letter", "subject": "subject", "content": "content"}, {}, **extra_template_kwargs
+    )
+    assert ("content: 'NOTIFY';" in str(template)) == should_have_notify_tag


### PR DESCRIPTION
This tag should only be present on the first page of a PDF we generate to send to DVLA.

In supporting bilingual letters, we generate two PDFs: a Welsh variant followed by an English variant.

We need to stop inserting the 'NOTIFY' tag on the English variant, and so need to be able to toggle the tag off, otherwise DVLA's printers get confused.