### PR TITLE
Fix utils packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 73.2.1
+
+* Fix utils packaging to allow access to subpackages again.
+
 ## 73.2.0
 
 * Adds a `include_notify_tag` parameter to `LetterPrintTemplate` so that bilingual letters can disable the NOTIFY tag on the English pages of a letter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ More minor changes may optionally be recorded here too.
 
 * Add compatibility with Python 3.11 and 3.12
 
+## 73.1.2
+
+* Change how utils is packaged to exclude tests.
+
+## 73.1.1
+
+* SKIPPED VERSION - NO RELEASE.
+
 ## 73.1.0
 
 * Adds request logging to flask apps.

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "73.2.0"  # c43120bd405427e3bfdf91421913ab3b
+__version__ = "73.2.1"  # 7b2f0f11d8c4ebd5c5d1f9102e3ca448

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author="Government Digital Service",
     description="Shared python code for GOV.UK Notify.",
     long_description=__doc__,
-    packages=find_packages(include=["notifications_utils"]),
+    packages=find_packages(exclude=("tests",)),
     include_package_data=True,
     install_requires=[
         "cachetools>=4.1.1",


### PR DESCRIPTION
In an attempt to exclude the `tests` package, we excluded a lot of
notifications_utils.

```
In [1]: from setuptools import find_packages

In [2]: find_packages()
Out[2]:
['tests',
 'notifications_utils',
 'notifications_utils.clients',
 'notifications_utils.testing',
 'notifications_utils.countries',
 'notifications_utils.clients.encryption',
 'notifications_utils.clients.redis',
 'notifications_utils.clients.antivirus',
 'notifications_utils.clients.statsd',
 'notifications_utils.clients.zendesk']
```

We should just exclude `tests`, rather than including the (top-level)
`notifications_utils`. The latter excludes all of the subpackages, which
then makes them inaccessible at their dot paths.

---

Was leading to errors like this when bumping utils on template-preview:

```
./scripts/run_with_docker.sh make test
Running custom command
ruff check .
black --check .
All done! ✨ 🍰 ✨
31 files would be left unchanged.
pytest -n auto --maxfail=10
ImportError while loading conftest '/home/vcap/app/tests/conftest.py'.
tests/conftest.py:8: in <module>
    from app import create_app
app/__init__.py:10: in <module>
    from notifications_utils.clients.encryption.encryption_client import Encryption
E   ModuleNotFoundError: No module named 'notifications_utils.clients'
```