### PR TITLE
logging: add microseconds to time format via mixin class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 74.2.0
+
+* Change logging's date formatting to include microseconds
+
 ## 74.1.0
 
 * remove the geojson dependency (another emergency alerts module)

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "74.1.0"  # 5802950d8c35cca2e31f37f269acba63
+__version__ = "74.2.0"  # 53106ddef0ee39363afb52666a4d5e4a


### PR DESCRIPTION
https://trello.com/c/pWDzU11r/567-fractional-timestamps-for-app-logs

Ideally we'd just include this in our `TIME_FORMAT`, but python's `strftime` has no ability to include even milliseconds. The python-default logging `datefmt` is augmented with milliseconds in the stdlib logging module via a hack, but this hack is disabled when a custom `datefmt` is supplied. So we have to add back our own hack to include precise time.

Use microsecond granularity as it should be enough to correctly order even log records that are generated immediately-consecutively in the same thread.