### PR TITLE
Add `decrby` method to RedisClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 74.3.0
+
+* Add `decrby` method to the RedisClient
+
 ## 74.2.0
 
 * Change logging's date formatting to include microseconds

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -153,6 +153,13 @@ class RedisClient:
             except Exception as e:
                 self.__handle_exception(e, raise_exception, "incr", key)
 
+    def decrby(self, key, amount, raise_exception=False):
+        if self.active:
+            try:
+                return self.redis_store.decrby(key, amount)
+            except Exception as e:
+                self.__handle_exception(e, raise_exception, "decrby", key)
+
     def get(self, key, raise_exception=False):
         key = prepare_value(key)
         if self.active:

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "74.2.0"  # 53106ddef0ee39363afb52666a4d5e4a
+__version__ = "74.3.0"  # 1e51dab2bf3c73469dbb5731c3fb3e8d


### PR DESCRIPTION
This adds a `decrby` method to the RedisClient so that we can change the cache keys for total daily notifications and total letters sent if letters are cancelled.

The new method is consistent with the others by keeping the `raise_exception` flag even though this may not be used.