### PR TITLE
Fix hyphen used as dash in phone validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 74.12.2
+
+* Fix use of hyphen in phone number validation error
+
 ## 74.12.1
 
 * email template: use the new crown and associated styling

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -559,7 +559,7 @@ def validate_uk_phone_number(number):
 
     if not number.startswith("7"):
         raise InvalidPhoneError(
-            "This does not look like a UK mobile number - double check the mobile number you entered"
+            "This does not look like a UK mobile number – double check the mobile number you entered"
         )
 
     if len(number) > 10:

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "74.12.1"  # 59ba4a5a8ca1bc15b0e4f3cc0d79d93c
+__version__ = "74.12.2"  # da6d7e5a9981d66147f4178351c4d51d

--- a/tests/test_recipient_validation.py
+++ b/tests/test_recipient_validation.py
@@ -71,7 +71,7 @@ invalid_uk_phone_numbers = sum(
                 ),
             ),
             (
-                "This does not look like a UK mobile number - double check the mobile number you entered",
+                "This does not look like a UK mobile number – double check the mobile number you entered",
                 (
                     "08081 570364",
                     "+44 8081 570364",


### PR DESCRIPTION
When a dash is used as to separate clauses our style is to use an en dash. Hyphens should only be used to join words.