### PR TITLE
Add `span_id` and `parent_span_id` annotation to logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 74.6.0
+
+* Include parent_span_id in request logs
+* Include span_id in all logs when available
+
 ## 74.5.0
 
 * Include remote_addr in request logs

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -149,6 +149,7 @@ def configure_handler(handler, app, formatter, *, extra_filters: Sequence[loggin
     handler.setFormatter(formatter)
     handler.addFilter(AppNameFilter(app.config["NOTIFY_APP_NAME"]))
     handler.addFilter(RequestIdFilter())
+    handler.addFilter(SpanIdFilter())
     handler.addFilter(ServiceIdFilter())
     handler.addFilter(UserIdFilter())
 
@@ -180,6 +181,22 @@ class RequestIdFilter(logging.Filter):
 
     def filter(self, record):
         record.request_id = self.request_id
+
+        return record
+
+
+class SpanIdFilter(logging.Filter):
+    @property
+    def span_id(self):
+        if has_request_context() and hasattr(request, "span_id"):
+            return request.span_id
+        elif has_app_context() and "span_id" in g:
+            return g.span_id
+        else:
+            return "no-span-id"
+
+    def filter(self, record):
+        record.span_id = self.span_id
 
         return record
 

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -25,6 +25,7 @@ def _common_request_extra_log_context():
         "url": request.url,
         "endpoint": request.endpoint,
         "remote_addr": request.remote_addr,
+        "parent_span_id": getattr(request, "parent_span_id", None),
         # pid and is available on LogRecord by default, as `process` but I don't see
         # a straightforward way of selectively including it only in certain log messages -
         # it is designed to be included when the formatter is being configured. This is

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "74.5.0"  # 5aaaf1d98eeebd2842dc230fa02a95b9
+__version__ = "74.6.0"  # 887b1d66478d65fd11054874e057e277

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -57,11 +57,11 @@ def test_get_handlers_sets_up_logging_appropriately_without_debug_when_not_on_ec
     assert len(handlers) == 2
     assert type(handlers[0]) == builtin_logging.StreamHandler
     assert type(handlers[0].formatter) == logging.JSONFormatter
-    assert len(handlers[0].filters) == 5
+    assert len(handlers[0].filters) == 6
 
     assert type(handlers[1]) == builtin_logging_handlers.WatchedFileHandler
     assert type(handlers[1].formatter) == logging.JSONFormatter
-    assert len(handlers[1].filters) == 5
+    assert len(handlers[1].filters) == 6
 
     dir_contents = tmpdir.listdir()
     assert len(dir_contents) == 1


### PR DESCRIPTION
https://trello.com/c/n4FmWuff/585-annotate-logs-with-cloudfront-http-request-ids

`parent_span_id` only needs to be present on one log of a span to be useful, but `span_id` needs to be present on all to identify which span each message comes from.