### PR TITLE
AntivirusClient: include onwards request headers in outgoing requests

### DIFF
--- a/notifications_utils/clients/antivirus/antivirus_client.py
+++ b/notifications_utils/clients/antivirus/antivirus_client.py
@@ -1,5 +1,6 @@
 import requests
-from flask import current_app
+from flask import current_app, request
+from flask.ctx import has_request_context
 
 
 class AntivirusError(Exception):
@@ -29,12 +30,14 @@ class AntivirusClient:
         self.auth_token = app.config["ANTIVIRUS_API_KEY"]
 
     def scan(self, document_stream):
+        headers = {"Authorization": f"Bearer {self.auth_token}"}
+        if has_request_context() and hasattr(request, "get_onwards_request_headers"):
+            headers.update(request.get_onwards_request_headers())
+
         try:
             response = requests.post(
                 f"{self.api_host}/scan",
-                headers={
-                    "Authorization": f"Bearer {self.auth_token}",
-                },
+                headers=headers,
                 files={"document": document_stream},
             )
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "74.6.0"  # 887b1d66478d65fd11054874e057e277
+__version__ = "74.7.0"  # 68f28b36b4e3f4ee4093e01c1988f09b


### PR DESCRIPTION
https://trello.com/c/n4FmWuff/585-annotate-logs-with-cloudfront-http-request-ids

Who knew that beyond https://github.com/alphagov/document-download-api/blob/main/app/utils/antivirus.py we also have an `AntivirusClient` in here.