### PR TITLE
NotifyRequest: generate own `span_id` if none provided in headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 74.8.0
+
+* NotifyRequest: generate own span_id if none provided in headers
+
 ## 74.7.0
 
 * Include onwards request headers in AntivirusClient requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 74.7.0
+
+* Include onwards request headers in AntivirusClient requests
+
 ## 74.6.0
 
 * Include parent_span_id in request logs

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "74.7.0"  # 68f28b36b4e3f4ee4093e01c1988f09b
+__version__ = "74.8.0"  # 7b295c8ffe578c7d2b6641def446d227


### PR DESCRIPTION
https://trello.com/c/n4FmWuff/585-annotate-logs-with-cloudfront-http-request-ids

This is me correcting some of my own logic from a few years ago.

The worry about such a `span_id` being propagated indefinitely is partially valid, but on balance it's probably worse not having *any* span id for the initial span as it makes it harder to find logs and failing to pass on a parent span id to the next server is indistinguishable from the mechanism being broken. And on a platform that isn't using a span id-aware router between apps, we should just handle the advancing of span ids ourselves.

When generating own `span_id`, prefix it with `self-` in attempt to avoid people going looking for whatever caller assigned it this span id. This is technically not a zipkin-compliant value, but we're already breaking those rules by passing around cloudfront and ALB request ids under the `x-b3-traceid` header. This should only ever get passed in requests under the `x-b3-parentspanid` header.