### PR TITLE
logging: also attach handlers etc. to `celery.worker` and `celery.redirected`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 74.9.0
+
+* logging: also attach handlers etc. to celery.worker and celery.redirected
+
 ## 74.8.1
 
 * Always hide barcodes when printing a letter - not only when adding a NOTIFY tag

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -89,7 +89,12 @@ def init_app(app, statsd_client=None, extra_filters: Sequence[logging.Filter] = 
 
     handlers = get_handlers(app, extra_filters=extra_filters)
     loglevel = logging.getLevelName(app.config["NOTIFY_LOG_LEVEL"])
-    loggers = [app.logger, logging.getLogger("utils")]
+    loggers = [
+        app.logger,
+        logging.getLogger("utils"),
+        logging.getLogger("celery.worker"),
+        logging.getLogger("celery.redirected"),  # stdout/stderr
+    ]
     for logger_instance, handler in product(loggers, handlers):
         logger_instance.addHandler(handler)
         logger_instance.setLevel(loglevel)

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "74.8.1"  # 3d3fd89ab6752815c17742c7bd4217d2
+__version__ = "74.9.0"  # 4efd03b662b068411cf7195989e178a1


### PR DESCRIPTION
https://trello.com/c/q5ehwcty/628-try-and-get-full-celery-logs-for-the-paas-into-logit

We're currently missing useful logs unless we keep all stderr from celery workers, but:

 - we don't on paas
 - it's horrible and unstructured, so it would be better if we didn't on ecs either

Adding `celery.redirected` should include messages that have been crudely structured from raw stdout/stderr messages, which we'll need because some important messages e.g. from kombu are sent through raw `print` calls.

I have tested this (minimally - it's hard to convince it to emit the right log messages from within celery) with the `notify-delivery-worker-sender`.