### PR TITLE
Fix barcodes bilingual letters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 74.8.1
+
+* Always hide barcodes when printing a letter - not only when adding a NOTIFY tag
+
 ## 74.8.0
 
 * NotifyRequest: generate own span_id if none provided in headers

--- a/notifications_utils/jinja_templates/letter_pdf/_print_only_add_tag_css.jinja2
+++ b/notifications_utils/jinja_templates/letter_pdf/_print_only_add_tag_css.jinja2
@@ -1,11 +1,5 @@
 <style media="print">
 
-  #mdi,
-  #barcode,
-  #qrcode {
-    display: none;
-  }
-
   @page :first {
     @top-left-corner {
         content: 'NOTIFY';

--- a/notifications_utils/jinja_templates/letter_pdf/_print_only_hide_barcodes_css.jinja2
+++ b/notifications_utils/jinja_templates/letter_pdf/_print_only_hide_barcodes_css.jinja2
@@ -1,0 +1,9 @@
+<style media="print">
+
+  #mdi,
+  #barcode,
+  #qrcode {
+    display: none;
+  }
+
+</style>

--- a/notifications_utils/jinja_templates/letter_pdf/print.jinja2
+++ b/notifications_utils/jinja_templates/letter_pdf/print.jinja2
@@ -1,6 +1,7 @@
 {% include 'letter_pdf/_head.jinja2' %}
 {% include 'letter_pdf/_main_css.jinja2' %}
 {% if include_notify_tag %}
-{% include 'letter_pdf/_print_only_css.jinja2' %}
+{% include 'letter_pdf/_print_only_add_tag_css.jinja2' %}
 {% endif %}
+{% include 'letter_pdf/_print_only_hide_barcodes_css.jinja2' %}
 {% include 'letter_pdf/_body.jinja2' %}

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "74.8.0"  # 7b295c8ffe578c7d2b6641def446d227
+__version__ = "74.8.1"  # 3d3fd89ab6752815c17742c7bd4217d2

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -2433,8 +2433,11 @@ def test_letter_qr_codes_with_too_much_data(content, values, should_error):
         ({"include_notify_tag": False}, False),
     ),
 )
-def test_rendered_letter_template_for_print_can_toggle_notify_tag(extra_template_kwargs, should_have_notify_tag):
+def test_rendered_letter_template_for_print_can_toggle_notify_tag_and_always_hides_barcodes(
+    extra_template_kwargs, should_have_notify_tag
+):
     template = LetterPrintTemplate(
         {"template_type": "letter", "subject": "subject", "content": "content"}, {}, **extra_template_kwargs
     )
     assert ("content: 'NOTIFY';" in str(template)) == should_have_notify_tag
+    assert "#mdi,\n  #barcode,\n  #qrcode {\n    display: none;\n  }" in str(template).strip()


### PR DESCRIPTION
Always hide barcodes when printing a letter

We used to only hide them on a page with Notify tag, but that
lead to a problem with bilingual letters when on first page of
English version of the letter barcodes were visible and were causing
problems for DVLA.