### PR TITLE
logging: set `celery.worker.strategy` logging to `WARNING`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 74.9.1
+
+* logging: set celery.worker.strategy logging to WARNING to prevent sensitive information being logged
+
 ## 74.9.0
 
 * logging: also attach handlers etc. to celery.worker and celery.redirected

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -101,6 +101,9 @@ def init_app(app, statsd_client=None, extra_filters: Sequence[logging.Filter] = 
     logging.getLogger("boto3").setLevel(logging.WARNING)
     logging.getLogger("s3transfer").setLevel(logging.WARNING)
 
+    # prevent (potentially sensitive) task args being logged
+    logging.getLogger("celery.worker.strategy").setLevel(logging.WARNING)
+
     request_loglevel = logging.getLevelName(app.config["NOTIFY_REQUEST_LOG_LEVEL"])
     app.logger.getChild("request").setLevel(request_loglevel)
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "74.9.0"  # 4efd03b662b068411cf7195989e178a1
+__version__ = "74.9.1"  # 6add133ca110b397ab3f1ae0e43d1029


### PR DESCRIPTION
Quick fix to prevent us logging some potentially sensitive information.