### PR TITLE
Add option to ignore list of web paths from request logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 74.11.0
+
+* Add option to ignore list of web paths from request logging. Defaults to /_status and /metrics.
+* Add new fields to web request log messages (user_agent, host, path)
+
 ## 74.9.1
 
 * logging: set celery.worker.strategy logging to WARNING to prevent sensitive information being logged

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "74.10.0"  # b03bb7df3ac49681d433cc25be72289c
+__version__ = "74.11.0"  # 785aca5dbe214809ed615321c61be0c7


### PR DESCRIPTION
What
----

- Add option to change set of web paths to debug request logging for successful calls. Defaults to /_status and /metrics.
- Add new fields to log messages:
  - user_agent
  - host
  - path

Why
----

- Our logs get too many successful status and metrics calls. This will remove them from our logs.
- Additional fields will help produce more useful logit dashboards.

