### PR TITLE
Update crown for email template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 74.12.1
+
+* email template: use the new crown and associated styling
 
 ## 74.12.0
 

--- a/notifications_utils/jinja_templates/email_template.jinja2
+++ b/notifications_utils/jinja_templates/email_template.jinja2
@@ -52,20 +52,20 @@
                   <tr>
                     <td style="padding-left: 10px">
                       <img
-                        src="https://static.notifications.service.gov.uk/images/gov.uk_logotype_crown.png"
+                        src="https://static.notifications.service.gov.uk/images/govuk-logotype-tudor-crown.png"
                         alt=""
                         height="32"
                         border="0"
-                        style="Margin-top: 4px;"
+                        style="Margin-top: 2px;"
                       >
                     </td>
-                    <td style="font-size: 28px; line-height: 1.315789474; Margin-top: 4px; padding-left: 10px;">
+                    <td style="font-size: 28px; line-height: 1.315789474; Margin-top: 4px; padding-left: 8px;">
                       <span style="
                         font-family: Helvetica, Arial, sans-serif;
                         font-weight: 700;
                         color: #ffffff;
                         text-decoration: none;
-                        vertical-align:top;
+                        vertical-align:middle;
                         display: inline-block;
                           ">GOV.UK</span>
                     </td>


### PR DESCRIPTION
Do not merge until monday the 19th.

This also has three styling changes to align the GOVUK with the crown better.

Before

<img width="570" alt="Screenshot 2024-02-15 at 11 02 07" src="https://github.com/alphagov/notifications-utils/assets/10772338/e3b2420e-bd24-4cbb-b35d-fde86eab40e2">

After

<img width="564" alt="Screenshot 2024-02-15 at 11 03 36" src="https://github.com/alphagov/notifications-utils/assets/10772338/10df3418-1ea2-46dc-80c0-dbfbb64ed81e">
