### PR TITLE
logging: remove `celery.*` structured logging for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+
+## 74.12.0
+
+* Remove celery.* structured logging for now. It can return when we have more certainty over what values it will log or can rule out that it is ever given sensitive values.
+
 ## 74.11.0
 
 * Add option to ignore list of web paths from request logging. Defaults to /_status and /metrics.

--- a/notifications_utils/logging.py
+++ b/notifications_utils/logging.py
@@ -108,17 +108,12 @@ def init_app(app, statsd_client=None, extra_filters: Sequence[logging.Filter] = 
     loggers = [
         app.logger,
         logging.getLogger("utils"),
-        logging.getLogger("celery.worker"),
-        logging.getLogger("celery.redirected"),  # stdout/stderr
     ]
     for logger_instance, handler in product(loggers, handlers):
         logger_instance.addHandler(handler)
         logger_instance.setLevel(loglevel)
     logging.getLogger("boto3").setLevel(logging.WARNING)
     logging.getLogger("s3transfer").setLevel(logging.WARNING)
-
-    # prevent (potentially sensitive) task args being logged
-    logging.getLogger("celery.worker.strategy").setLevel(logging.WARNING)
 
     request_loglevel = logging.getLevelName(app.config["NOTIFY_REQUEST_LOG_LEVEL"])
     app.logger.getChild("request").setLevel(request_loglevel)

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "74.11.0"  # 785aca5dbe214809ed615321c61be0c7
+__version__ = "74.12.0"  # c484a2f0896a0f24c0d8346a62e36ff8


### PR DESCRIPTION
It can return when we have more certainty over what values it will log or can rule out that it is ever given sensitive values.