### PR TITLE
logging: remove use of `NOTIFY_RUNTIME_PLATFORM` & `NOTIFY_LOG_PATH` config parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 76.0.0
+
+* Remove use of `NOTIFY_RUNTIME_PLATFORM` and `NOTIFY_LOG_PATH` flask config parameters, which no longer did anything. Technically this only affects users if the consumed the paramter themselves and relied on utils code setting default values for them.
+
 ## 75.2.0
 
 * Add `InsensitiveSet` class (behaves like a normal set, but with uniqueness determined by normalised values)

--- a/notifications_utils/logging/__init__.py
+++ b/notifications_utils/logging/__init__.py
@@ -43,7 +43,6 @@ def _common_request_extra_log_context():
 def init_app(app, statsd_client=None, extra_filters: Sequence[logging.Filter] = tuple()):
     app.config.setdefault("NOTIFY_LOG_LEVEL", "INFO")
     app.config.setdefault("NOTIFY_APP_NAME", "none")
-    app.config.setdefault("NOTIFY_LOG_PATH", "./log/application.log")
     app.config.setdefault("NOTIFY_LOG_DEBUG_PATH_LIST", {"/_status", "/metrics"})
     app.config.setdefault("NOTIFY_REQUEST_LOG_LEVEL", "CRITICAL")
 

--- a/notifications_utils/logging/__init__.py
+++ b/notifications_utils/logging/__init__.py
@@ -44,12 +44,8 @@ def init_app(app, statsd_client=None, extra_filters: Sequence[logging.Filter] = 
     app.config.setdefault("NOTIFY_LOG_LEVEL", "INFO")
     app.config.setdefault("NOTIFY_APP_NAME", "none")
     app.config.setdefault("NOTIFY_LOG_PATH", "./log/application.log")
-    app.config.setdefault("NOTIFY_RUNTIME_PLATFORM", None)
     app.config.setdefault("NOTIFY_LOG_DEBUG_PATH_LIST", {"/_status", "/metrics"})
-    app.config.setdefault(
-        "NOTIFY_REQUEST_LOG_LEVEL",
-        "CRITICAL" if app.config["NOTIFY_RUNTIME_PLATFORM"] == "paas" else "NOTSET",
-    )
+    app.config.setdefault("NOTIFY_REQUEST_LOG_LEVEL", "CRITICAL")
 
     @app.before_request
     def before_request():
@@ -102,10 +98,6 @@ def init_app(app, statsd_client=None, extra_filters: Sequence[logging.Filter] = 
     # avoid lastResort handler coming into play
     logging.getLogger().addHandler(logging.NullHandler())
 
-    if app.config["NOTIFY_RUNTIME_PLATFORM"] != "ecs":
-        # TODO: ecs-migration: check if we still need this function after we migrate to ecs
-        ensure_log_path_exists(app.config["NOTIFY_LOG_PATH"])
-
     handlers = get_handlers(app, extra_filters=extra_filters)
     loglevel = logging.getLevelName(app.config["NOTIFY_LOG_LEVEL"])
     loggers = [
@@ -156,13 +148,6 @@ def get_handlers(app, extra_filters: Sequence[logging.Filter]):
 
     # stream json to stdout in all cases
     handlers.append(configure_handler(stream_handler, app, json_formatter, extra_filters=extra_filters))
-
-    # TODO: ecs-migration: delete this when we migrate to ecs
-    # only write json to file if we're not running on ECS
-    if app.config["NOTIFY_RUNTIME_PLATFORM"] != "ecs":
-        # machine readable json to both file and stdout
-        file_handler = logging.handlers.WatchedFileHandler(filename=f"{app.config['NOTIFY_LOG_PATH']}.json")
-        handlers.append(configure_handler(file_handler, app, json_formatter, extra_filters=extra_filters))
 
     return handlers
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "75.2.0"  # dcb211bcd897f265625247221b449913
+__version__ = "76.0.0"  # a1ac3717196c8b4513bb05f388195ce7

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,11 +49,7 @@ def app_with_mocked_logger(mocker, tmpdir):
         "flask.sansio.app.create_logger",
         return_value=mocker.Mock(spec=logging.Logger("flask.app"), handlers=[]),
     )
-    yield from _create_app(
-        extra_config={
-            "NOTIFY_LOG_PATH": str(tmpdir / "foo"),
-        }
-    )
+    yield from _create_app()
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -10,9 +10,9 @@ from notifications_utils import logging, request_helper
 from notifications_utils.testing.comparisons import AnyStringMatching, RestrictedAny
 
 
-def test_get_handlers_sets_up_logging_appropriately_with_debug(tmpdir):
+def test_get_handlers_sets_up_logging_appropriately_with_debug():
     class App:
-        config = {"NOTIFY_LOG_PATH": str(tmpdir / "foo"), "NOTIFY_APP_NAME": "bar", "NOTIFY_LOG_LEVEL": "ERROR"}
+        config = {"NOTIFY_APP_NAME": "bar", "NOTIFY_LOG_LEVEL": "ERROR"}
         debug = True
 
     app = App()
@@ -22,14 +22,11 @@ def test_get_handlers_sets_up_logging_appropriately_with_debug(tmpdir):
     assert len(handlers) == 1
     assert type(handlers[0]) == builtin_logging.StreamHandler
     assert type(handlers[0].formatter) == logging.Formatter
-    assert not (tmpdir / "foo").exists()
 
 
-def test_get_handlers_sets_up_logging_appropriately_without_debug(tmpdir):
+def test_get_handlers_sets_up_logging_appropriately_without_debug():
     class App:
         config = {
-            # make a tempfile called foo
-            "NOTIFY_LOG_PATH": str(tmpdir / "foo"),
             "NOTIFY_APP_NAME": "bar",
             "NOTIFY_LOG_LEVEL": "ERROR",
         }
@@ -42,8 +39,6 @@ def test_get_handlers_sets_up_logging_appropriately_without_debug(tmpdir):
     assert len(handlers) == 1
     assert type(handlers[0]) == builtin_logging.StreamHandler
     assert type(handlers[0].formatter) == logging.JSONFormatter
-
-    assert not (tmpdir / "foo.json").exists()
 
 
 @pytest.mark.parametrize(
@@ -59,8 +54,6 @@ def test_log_timeformat_fractional_seconds(frozen_time, logged_time, tmpdir):
 
         class App:
             config = {
-                # make a tempfile called foo
-                "NOTIFY_LOG_PATH": str(tmpdir / "foo"),
                 "NOTIFY_APP_NAME": "bar",
                 "NOTIFY_LOG_LEVEL": "INFO",
             }

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,6 +1,5 @@
 import json
 import logging as builtin_logging
-import logging.handlers as builtin_logging_handlers
 import time
 from unittest import mock
 
@@ -26,56 +25,13 @@ def test_get_handlers_sets_up_logging_appropriately_with_debug(tmpdir):
     assert not (tmpdir / "foo").exists()
 
 
-@pytest.mark.parametrize(
-    "platform",
-    [
-        "local",
-        "paas",
-        "something-else",
-    ],
-)
-def test_get_handlers_sets_up_logging_appropriately_without_debug_when_not_on_ecs(tmpdir, platform):
-    class TestFilter(builtin_logging.Filter):
-        def filter(self, record):
-            record.arbitrary_info = "some-extra-info"
-            return record
-
+def test_get_handlers_sets_up_logging_appropriately_without_debug(tmpdir):
     class App:
         config = {
             # make a tempfile called foo
             "NOTIFY_LOG_PATH": str(tmpdir / "foo"),
             "NOTIFY_APP_NAME": "bar",
             "NOTIFY_LOG_LEVEL": "ERROR",
-            "NOTIFY_RUNTIME_PLATFORM": platform,
-        }
-        debug = False
-
-    app = App()
-
-    handlers = logging.get_handlers(app, extra_filters=[TestFilter()])
-
-    assert len(handlers) == 2
-    assert type(handlers[0]) == builtin_logging.StreamHandler
-    assert type(handlers[0].formatter) == logging.JSONFormatter
-    assert len(handlers[0].filters) == 6
-
-    assert type(handlers[1]) == builtin_logging_handlers.WatchedFileHandler
-    assert type(handlers[1].formatter) == logging.JSONFormatter
-    assert len(handlers[1].filters) == 6
-
-    dir_contents = tmpdir.listdir()
-    assert len(dir_contents) == 1
-    assert dir_contents[0].basename == "foo.json"
-
-
-def test_get_handlers_sets_up_logging_appropriately_without_debug_on_ecs(tmpdir):
-    class App:
-        config = {
-            # make a tempfile called foo
-            "NOTIFY_LOG_PATH": str(tmpdir / "foo"),
-            "NOTIFY_APP_NAME": "bar",
-            "NOTIFY_LOG_LEVEL": "ERROR",
-            "NOTIFY_RUNTIME_PLATFORM": "ecs",
         }
         debug = False
 
@@ -107,7 +63,6 @@ def test_log_timeformat_fractional_seconds(frozen_time, logged_time, tmpdir):
                 "NOTIFY_LOG_PATH": str(tmpdir / "foo"),
                 "NOTIFY_APP_NAME": "bar",
                 "NOTIFY_LOG_LEVEL": "INFO",
-                "NOTIFY_RUNTIME_PLATFORM": "ecs",
             }
             debug = False
 
@@ -542,28 +497,6 @@ def test_app_request_logger_level_set(app_with_mocked_logger, level_name, expect
     app.logger.getChild.side_effect = lambda name: mock_req_logger if name == "request" else mock.DEFAULT
 
     app.config["NOTIFY_REQUEST_LOG_LEVEL"] = level_name
-    logging.init_app(app)
-
-    assert mock_req_logger.setLevel.call_args_list[-1] == mock.call(expected_level)
-
-
-@pytest.mark.parametrize(
-    "rtplatform,expected_level",
-    (
-        ("ecs", builtin_logging.NOTSET),
-        ("local", builtin_logging.NOTSET),
-        ("paas", builtin_logging.CRITICAL),
-    ),
-)
-def test_app_request_logger_level_defaults(app_with_mocked_logger, rtplatform, expected_level):
-    app = app_with_mocked_logger
-    mock_req_logger = mock.Mock(
-        spec=builtin_logging.Logger("flask.app.request"),
-        handlers=[],
-    )
-    app.logger.getChild.side_effect = lambda name: mock_req_logger if name == "request" else mock.DEFAULT
-
-    app.config["NOTIFY_RUNTIME_PLATFORM"] = rtplatform
     logging.init_app(app)
 
     assert mock_req_logger.setLevel.call_args_list[-1] == mock.call(expected_level)


### PR DESCRIPTION
This sits on top of #1108 so the diff will be confusing till that is merged.

https://trello.com/c/kuPbusFR/724-check-if-we-should-and-then-remove-notifyruntimeplatform-functionality

`NOTIFY_RUNTIME_PLATFORM` was only used in one remaining place, and now it's effectively always set to "ecs". If we ever did want to reintroduce something similar, I think we're agreed we'd want to use a set of more explicit configuration parameters instead.

This also means there are no more cases where `NOTIFY_LOG_PATH` needs to do anything - we no longer use the aws logs agent - so references to it have also been removed.