### PR TITLE
gunicorn_defaults: don't set `statsd_host` in defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 75.1.1
+
+* Don't set `statsd_host` in `set_gunicorn_defaults` - not all apps have statsd.
+
 ## 75.1.0
 
 * Split `logging.formatting` submodule out of `logging` module. All components should remain

--- a/notifications_utils/gunicorn_defaults.py
+++ b/notifications_utils/gunicorn_defaults.py
@@ -69,7 +69,6 @@ def set_gunicorn_defaults(globals_dict: dict):
         on_exit=on_exit,
         on_starting=on_starting,
         post_fork=post_fork,
-        statsd_host="{}:8125".format(os.getenv("STATSD_HOST", "127.0.0.1")),
         worker_abort=worker_abort,
         worker_int=worker_int,
     )

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "75.1.0"  # 573d3ee08c9f5b38fae9b8744b67edfc
+__version__ = "75.1.1"  # 305e3c3dbf326076dba72b7ce5d33968


### PR DESCRIPTION
Not all apps have `statsd`