### PR TITLE
Reject Gibraltar’s postcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 76.0.1
+
+* Reject Gibraltar’s postcode (`GX11 1AA) when validating postal addresses
+
 ## 76.0.0
 
 * Remove use of `NOTIFY_RUNTIME_PLATFORM` and `NOTIFY_LOG_PATH` flask config parameters, which no longer did anything. Technically this only affects users if the consumed the paramter themselves and relied on utils code setting default values for them.

--- a/notifications_utils/postal_address.py
+++ b/notifications_utils/postal_address.py
@@ -228,9 +228,12 @@ def normalise_postcode(postcode):
 
 
 def _is_a_real_uk_postcode(postcode):
+    normalised = normalise_postcode(postcode)
+    if normalised == "GX111AA":
+        return False
     # GIR0AA is Girobank
     pattern = re.compile(r"([A-Z]{1,2}[0-9][0-9A-Z]?[0-9][A-BD-HJLNP-UW-Z]{2})|(GIR0AA)")
-    return bool(pattern.fullmatch(normalise_postcode(postcode)))
+    return bool(pattern.fullmatch(normalised))
 
 
 def format_postcode_for_printing(postcode):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "76.0.0"  # a1ac3717196c8b4513bb05f388195ce7
+__version__ = "76.0.1"  # 20bd59ac4566d156c93e64befbcc3fd8

--- a/tests/test_postal_address.py
+++ b/tests/test_postal_address.py
@@ -651,6 +651,9 @@ def test_normalise_postcode(postcode, normalised_postcode):
         # Giro Bank valid postcode and invalid postcode
         ("GIR0AA", True),
         ("GIR0AB", False),
+        # Gibraltar’s one postcode is not valid because it’s in the
+        # Europe postal zone
+        ("GX111AA", False),
     ],
 )
 def test_if_postcode_is_a_real_uk_postcode(postcode, result):


### PR DESCRIPTION
> Gibraltar Post is currently developing a postcode system based on
> United Kingdom of Great Britain and Northern Ireland postcode system.
>
> For the time being, mailers are kindly requested to use GX11 1AA as
> generic postcode for Gibraltar

https://www.upu.int/UPU/media/upu/PostalEntitiesFiles/addressingUnit/gibEn.pdf

While Gibraltar is a British Overseas Territory it’s considered to be in ‘Europe Zone 3’ according to Royal Mail:
https://www.royalmail.com/sending/international/country-guides#accordion-item-11113

We’ve also confirmed with DVLA that they would:
- treat mail addressesed to Gibraltar as international
- reject mail addressed UK-style address (postcode only) to Gibraltar

Therefore we have 2 options:
1. normalise `GX11 1AA` to `Gibraltar`
2. reject addresses that end in `GX11 1AA`

(either way an address that uses both `GX11 1AA` and `Gibraltar` will be fine, same as any country’s postcode system)

This commit goes with option 2, because:
- if Gibraltar introduces a system with more than 1 postcode this will get messy
- option 1 would impact performance of validating large CSV files because of this optimisation https://github.com/alphagov/notifications-utils/blob/01d60fcf670caf4ce23b651106e6374a9df82a38/notifications_utils/countries/__init__.py#L34-L38