### PR TITLE
Bump linters

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
 # bulk change for black formatting changes
 0f3f4b3e6aa5a199a1b5e79742aa776ce8d8bf7e
+ce619c18021e1a219cac2da4e3b0470ddfc08508

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,12 @@ repos:
   - id: check-yaml
   - id: debug-statements
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.0.272'
+  rev: 'v0.3.7'
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
 - repo: https://github.com/psf/black
-  rev: 23.10.1
+  rev: 24.4.0
   hooks:
     - id: black
       name: black (python)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 76.0.2
+
+* linting changes
+
 ## 76.0.1
 
 * Reject Gibraltar’s postcode (`GX11 1AA) when validating postal addresses

--- a/notifications_utils/clients/antivirus/antivirus_client.py
+++ b/notifications_utils/clients/antivirus/antivirus_client.py
@@ -47,7 +47,7 @@ class AntivirusClient:
             error = AntivirusError.from_exception(e)
             current_app.logger.warning("Notify Antivirus API request failed with error: %s", error.message)
 
-            raise error
+            raise error from e
         finally:
             document_stream.seek(0)
 

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -48,7 +48,6 @@ class Placeholder:
 
 
 class Field:
-
     """
     An instance of Field represents a string of text which may contain
     placeholders.

--- a/notifications_utils/insensitive_dict.py
+++ b/notifications_utils/insensitive_dict.py
@@ -4,7 +4,6 @@ from ordered_set import OrderedSet
 
 
 class InsensitiveDict(dict):
-
     """
     `InsensitiveDict` behaves like an ordered dictionary, except it normalises
     case, whitespace, hypens and underscores in keys.

--- a/notifications_utils/serialised_model.py
+++ b/notifications_utils/serialised_model.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 
 
 class SerialisedModel(ABC):
-
     """
     A SerialisedModel takes a dictionary, typically created by
     serialising a database object. It then takes the value of specified
@@ -32,7 +31,6 @@ class SerialisedModel(ABC):
 
 
 class SerialisedModelCollection(ABC):
-
     """
     A SerialisedModelCollection takes a list of dictionaries, typically
     created by serialising database objects. When iterated over it

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "76.0.1"  # 20bd59ac4566d156c93e64befbcc3fd8
+__version__ = "76.0.2"  # 11145636cc878dc6d4c648ef30488612

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ line-length = 120
 
 target-version = "py39"
 
-select = [
+lint.select = [
     "E",  # pycodestyle
     "W",  # pycodestyle
     "F",  # pyflakes
@@ -15,7 +15,7 @@ select = [
     "C90",  # mccabe cyclomatic complexity
     "G",  # flake8-logging-format
 ]
-ignore = []
+lint.ignore = []
 exclude = [
     "migrations/versions/",
     "venv*",

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -15,5 +15,5 @@ pytest-testmon==2.1.0
 pytest-watch==4.2.0
 redis>=4.3.4  # Earlier versions of redis miss features the tests need
 snakeviz==2.1.1
-black==23.10.1  # Also update `.pre-commit-config.yaml` if this changes
-ruff==0.0.272  # Also update `.pre-commit-config.yaml` if this changes
+black==24.4.0  # Also update `.pre-commit-config.yaml` if this changes
+ruff==0.3.7  # Also update `.pre-commit-config.yaml` if this changes

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 """
 Python API client for GOV.UK Notify
 """
+
 import ast
 import re
 


### PR DESCRIPTION
our versions of black and ruff are a bit out of date and it was causing havoc with my editor - lets bump them. there's also an outsanding CVE in black `>= 0, < 24.3.0` - https://github.com/advisories/GHSA-fj7x-q9j7-g6q6

if people are happy with this i'll upgrade them all in the rest of our repos