### PR TITLE
Add a command to copy `pyproject.toml` into apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 77.1.0
+
+* Add `version_tools.copy_pyproject_toml` to share linter config between apps
+
 ## 77.0.0
 
 * Breaking change to the Zendesk Client. The `ticket_categories` argument has been replaced with a `notify_task_type` argument, and it now populates

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -164,7 +164,7 @@ class RecipientCSV:
 
             output_dict = {}
 
-            for column_name, column_value in zip(column_headers, row):
+            for column_name, column_value in zip(column_headers, row, strict=False):
                 column_value = strip_and_remove_obscure_whitespace(column_value)
 
                 if InsensitiveDict.make_key(column_name) in self.recipient_column_headers_as_column_keys:

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "77.0.0"  # 72d8310e6b5e4ead204ca33678e9f84b
+__version__ = "77.1.0"  # 0547464f2c9c5dde9cb473dfc2b166a7

--- a/notifications_utils/version_tools.py
+++ b/notifications_utils/version_tools.py
@@ -3,6 +3,7 @@ import pathlib
 import requests
 
 requirements_file = pathlib.Path("requirements.in")
+pyproject_file = pathlib.Path("pyproject.toml")
 repo_name = "alphagov/notifications-utils"
 
 
@@ -76,3 +77,9 @@ def get_relevant_changelog_lines(current_version, newest_version):
 
 def get_file_contents_from_github(branch_or_tag, path):
     return requests.get(f"https://raw.githubusercontent.com/{repo_name}/{branch_or_tag}/{path}").text
+
+
+def copy_pyproject_toml():
+    local_utils_version = get_app_version()
+    remote_contents = get_file_contents_from_github(local_utils_version, "pyproject.toml")
+    pyproject_file.write_text(remote_contents)

--- a/notifications_utils/version_tools.py
+++ b/notifications_utils/version_tools.py
@@ -82,4 +82,6 @@ def get_file_contents_from_github(branch_or_tag, path):
 def copy_pyproject_toml():
     local_utils_version = get_app_version()
     remote_contents = get_file_contents_from_github(local_utils_version, "pyproject.toml")
-    pyproject_file.write_text(remote_contents)
+    pyproject_file.write_text(
+        f"# This file is automatically copied from notifications-utils@{local_utils_version}\n\n{remote_contents}"
+    )

--- a/notifications_utils/version_tools.py
+++ b/notifications_utils/version_tools.py
@@ -26,7 +26,7 @@ def upgrade_version():
 
     write_version_to_requirements_file(newest_version)
 
-    print(
+    print(  # noqa: T201
         f"{color.GREEN}✅ {color.BOLD}notifications-utils bumped to {newest_version}{color.END}\n\n"
         f"{color.YELLOW}{color.UNDERLINE}Now run:{color.END}\n\n"
         f"  make freeze-requirements\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ lint.select = [
     "B",  # flake8-bugbear
     "C90",  # mccabe cyclomatic complexity
     "G",  # flake8-logging-format
+    "T20", # flake8-print
 ]
 lint.ignore = []
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ line-length = 120
 [tool.ruff]
 line-length = 120
 
-target-version = "py39"
+target-version = "py311"
 
 lint.select = [
     "E",  # pycodestyle

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# ruff: noqa: T201
 
 import argparse
 import hashlib
@@ -20,7 +21,6 @@ version_parts = ("major", "minor", "patch")
 parser = argparse.ArgumentParser()
 parser.add_argument("version_part", choices=version_parts)
 version_part = parser.parse_args().version_part
-
 current_major, current_minor, current_patch = map(int, old_version.split("."))
 
 print(f"current version {old_version=}")

--- a/tests/clients/redis/test_redis_client.py
+++ b/tests/clients/redis/test_redis_client.py
@@ -237,7 +237,6 @@ def test_get_redis_lock_returns_stub_if_redis_not_enabled(mocked_redis_client):
 
 
 def test_redis_stub_lock_function_signatures_match():
-    print(f"Testing StubLock agains redis=={redis.__version__}")
     lock_methods = dict(inspect.getmembers(redis.lock.Lock, inspect.isfunction))
     stub_methods = dict(inspect.getmembers(StubLock, inspect.isfunction))
 
@@ -252,12 +251,12 @@ def test_redis_stub_lock_function_signatures_match():
     }
 
     missing_methods = lock_methods_to_test - stub_methods.keys()
-    assert not missing_methods, "stub has missing methods"
+    assert not missing_methods, f"StubLock has missing methods (testing against redis=={redis.__version__})"
 
     for fn_name in lock_methods_to_test:
         lock_sig = inspect.signature(lock_methods[fn_name])
         stub_sig = inspect.signature(stub_methods[fn_name])
-        assert lock_sig.parameters == stub_sig.parameters
+        assert lock_sig.parameters == stub_sig.parameters, f"(testing StubLock against redis=={redis.__version__})"
 
 
 def test_decrby(mocked_redis_client):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -287,8 +287,6 @@ def test_app_request_logs_response_on_status_200(app_with_mocked_logger):
 
     app.test_client().get("/_status")
 
-    print(mock_req_logger.log.call_args_list)
-
     assert (
         mock.call(
             builtin_logging.DEBUG,

--- a/tests/test_sanitise_text.py
+++ b/tests/test_sanitise_text.py
@@ -21,6 +21,7 @@ params, ids = zip(
     # this unicode char is not decomposable
     (("😬", "?"), "undecomposable unicode char (grimace emoji)"),
     (("↉", "?"), "vulgar fraction (↉) that we do not try decomposing"),
+    strict=True,
 )
 
 
@@ -43,6 +44,7 @@ params, ids = zip(
     (("ë", "ë", "e"), "non-gsm Welsh char (e with dots)"),
     (("Ò", "Ò", "O"), "non-gsm Welsh char (capital O with grave accent)"),
     (("í", "í", "i"), "non-gsm Welsh char (i with accent)"),
+    strict=True,
 )
 
 


### PR DESCRIPTION
This will let us share linter config between the apps. In the future it might even let us share common dependencies between the apps, since `pyproject.toml` can do dependency management.

This will require adding a `make` command to each app like:
```bash
python -c "from notifications_utils.version_tools import copy_pyproject_toml; copy_pyproject_toml()"
```

It also updates a couple of bits of config in `pyproject.toml` so that we’ll have parity when we drop this into the admin app.