### PR TITLE
Ensure no stale data in redis if redis errors when deleting cache key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 77.2.1
+
+* Change redis delete behaviour to error, rather than end up with stale data, if Redis is unavailable.
+
 ## 77.2.0
 
 * `NotifyTask`: include pid and other structured fields in completion log messages

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "77.2.0"  # dbe1d856722af4ad0303161298e2aba3
+__version__ = "77.2.1"  # 096378d793de4f0d83045dda5032c767

--- a/tests/clients/redis/test_request_cache.py
+++ b/tests/clients/redis/test_request_cache.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
@@ -182,7 +182,8 @@ def test_delete(mocker, mocked_redis_client, cache, args, expected_cache_key):
 
     assert foo(*args) == "bar"
 
-    mock_redis_delete.assert_called_once_with(expected_cache_key, raise_exception=True)
+    expected_call = call(expected_cache_key, raise_exception=True)
+    mock_redis_delete.assert_has_calls([expected_call, expected_call])
 
 
 def test_doesnt_update_api_if_redis_delete_fails(mocker, mocked_redis_client, cache):
@@ -211,7 +212,8 @@ def test_delete_by_pattern(mocker, mocked_redis_client, cache):
 
     assert foo(1, 2, 3) == "bar"
 
-    mock_redis_delete.assert_called_once_with("1-2-3-???", raise_exception=True)
+    expected_call = call("1-2-3-???", raise_exception=True)
+    mock_redis_delete.assert_has_calls([expected_call, expected_call])
 
 
 def test_doesnt_update_api_if_redis_delete_by_pattern_fails(mocker, mocked_redis_client, cache):

--- a/tests/clients/redis/test_request_cache.py
+++ b/tests/clients/redis/test_request_cache.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from notifications_utils.clients.redis import RequestCache
@@ -180,23 +182,21 @@ def test_delete(mocker, mocked_redis_client, cache, args, expected_cache_key):
 
     assert foo(*args) == "bar"
 
-    mock_redis_delete.assert_called_once_with(expected_cache_key)
+    mock_redis_delete.assert_called_once_with(expected_cache_key, raise_exception=True)
 
 
-def test_delete_even_if_call_raises(mocker, mocked_redis_client, cache):
-    mock_redis_delete = mocker.patch.object(
-        mocked_redis_client,
-        "delete",
-    )
+def test_doesnt_update_api_if_redis_delete_fails(mocker, mocked_redis_client, cache):
+    mocker.patch.object(mocked_redis_client, "delete", side_effect=RuntimeError("API update failed"))
+    fake_api_call = MagicMock()
 
     @cache.delete("bar")
     def foo():
-        raise RuntimeError
+        return fake_api_call()
 
     with pytest.raises(RuntimeError):
         foo()
 
-    mock_redis_delete.assert_called_once_with("bar")
+    fake_api_call.assert_not_called()
 
 
 def test_delete_by_pattern(mocker, mocked_redis_client, cache):
@@ -211,20 +211,18 @@ def test_delete_by_pattern(mocker, mocked_redis_client, cache):
 
     assert foo(1, 2, 3) == "bar"
 
-    mock_redis_delete.assert_called_once_with("1-2-3-???")
+    mock_redis_delete.assert_called_once_with("1-2-3-???", raise_exception=True)
 
 
-def test_delete_by_pattern_even_if_call_raises(mocker, mocked_redis_client, cache):
-    mock_redis_delete = mocker.patch.object(
-        mocked_redis_client,
-        "delete_by_pattern",
-    )
+def test_doesnt_update_api_if_redis_delete_by_pattern_fails(mocker, mocked_redis_client, cache):
+    mocker.patch.object(mocked_redis_client, "delete_by_pattern", side_effect=RuntimeError("API update failed"))
+    fake_api_call = MagicMock()
 
     @cache.delete_by_pattern("bar-???")
     def foo():
-        raise RuntimeError
+        return fake_api_call()
 
     with pytest.raises(RuntimeError):
         foo()
 
-    mock_redis_delete.assert_called_once_with("bar-???")
+    fake_api_call.assert_not_called()


### PR DESCRIPTION
For context, when the admin app wants to get data from our API
it will first try and get the data from redis and if the data
doesn't exist in redis, it will get the data from the API and then
finish by setting that data in redis. When the admin app wants to
update data for our API, it currently calls out to the API to
update the data and then deletes any existing/relevant data cached
in redis. The subsequent time it tries to get this data that it just
updated, it will use the usual approach for getting data that will
set the redis key too.

There is a problem with when the admin app wants to update something
in the database. At the moment, it will start by calling the API
to update the database and if that is successful it will then attempt
to delete the relevant cache keys in redis. But redis may not always
be available and in that case, it will
- fail to delete the cache key
- catch and ignore the exception raised when trying to delete the
  redis cache key
This leads to the change the user requested being made in the
database, but the cache still has the old data in it! This is bad
because our apps check the cache first and this can result in us
sending out incorrect emails using old templates, for example. We
have a runbook to manually recover from this position if redis
has downtime and delete queries fail during this time:
https://github.com/alphagov/notifications-manuals/wiki/Support-Runbook#deal-with-redis-outages

Note, there is no issue with `cache.set` calls. If the call to redis
fails as part of this, no stale data is produced. The database hasn't
been changed and either redis hasn't been changed or hasn't had
the current data added to it.

This commit changes our caching logic so that we can't end up with
stale data in redis if a delete to redis fails. If a delete to redis
fails, then we error early and don't attempt to update the database.
The trade off we make here is that now a user will see an error
page if their request failed to delete from redis, whereas before
they would have gotten a 200 (but ended up with stale data). We
think it is worse to have stale data, then it is to fail a
users request.

## Replicating locally
If you want to see the behaviour before and after you can replicate redis having an error deleting a key by inserting `raise Exception` above this line:
https://github.com/alphagov/notifications-utils/blob/main/notifications_utils/clients/redis/redis_client.py#L177. If running notify using notifications-local, you can install your local utils by 

```
docker exec -it notify-admin bash
pip install -e ../utils
```

And then inspect your Redis using:
```
docker exec -it redis bash
redis-cli
```

And inspect your Postgres using
```
psql postgresql://notify:notify@localhost:5433/notification_api
```