### PR TITLE
Update Zendesk client for new form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 77.0.0
+
+* Breaking change to the Zendesk Client. The `ticket_categories` argument has been replaced with a `notify_task_type` argument, and it now populates
+  a different Zendesk form.
+
 ## 76.1.0
 
 * Remove `check_proxy_header_before_request` from request_helper.py since this was only used when apps

--- a/notifications_utils/clients/zendesk/zendesk_client.py
+++ b/notifications_utils/clients/zendesk/zendesk_client.py
@@ -171,7 +171,7 @@ class NotifySupportTicket:
     NOTIFY_GROUP_ID = 360000036529
     # Organization: GDS
     NOTIFY_ORG_ID = 21891972
-    NOTIFY_TICKET_FORM_ID = 1900000284794
+    NOTIFY_TICKET_FORM_ID = 14226867890588
 
     def __init__(
         self,
@@ -183,7 +183,7 @@ class NotifySupportTicket:
         user_email=None,
         requester_sees_message_content=True,
         notify_ticket_type: Optional[NotifyTicketType] = None,
-        ticket_categories=None,
+        notify_task_type=None,
         org_id=None,
         org_type=None,
         service_id=None,
@@ -198,7 +198,7 @@ class NotifySupportTicket:
         self.user_email = user_email
         self.requester_sees_message_content = requester_sees_message_content
         self.notify_ticket_type = notify_ticket_type
-        self.ticket_categories = ticket_categories or []
+        self.notify_task_type = notify_task_type
         self.org_id = org_id
         self.org_type = org_type
         self.service_id = service_id
@@ -236,14 +236,14 @@ class NotifySupportTicket:
     def _get_custom_fields(self):
         org_type_tag = f"notify_org_type_{self.org_type}" if self.org_type else None
         custom_fields = [
-            {"id": "360022836500", "value": self.ticket_categories},  # Notify Ticket category field
+            {"id": "14229641690396", "value": self.notify_task_type},  # Notify Task type field
             {"id": "360022943959", "value": self.org_id},  # Notify Organisation ID field
             {"id": "360022943979", "value": org_type_tag},  # Notify Organisation type field
             {"id": "1900000745014", "value": self.service_id},  # Notify Service ID field
         ]
 
         if self.notify_ticket_type:
-            # Notify Ticket type field
+            # Notify Responder field
             custom_fields.append({"id": "1900000744994", "value": self.notify_ticket_type.value})
 
         return custom_fields

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "76.1.0"  # 7ffeff9d42cce4ecf84336d77dbb92b6
+__version__ = "77.0.0"  # 72d8310e6b5e4ead204ca33678e9f84b

--- a/tests/clients/zendesk/test_zendesk_client.py
+++ b/tests/clients/zendesk/test_zendesk_client.py
@@ -123,7 +123,7 @@ def test_notify_support_ticket_request_data(p1_arg, expected_tags, expected_prio
             "tags": expected_tags,
             "type": "question",
             "custom_fields": [
-                {"id": "360022836500", "value": []},
+                {"id": "14229641690396", "value": None},
                 {"id": "360022943959", "value": None},
                 {"id": "360022943979", "value": None},
                 {"id": "1900000745014", "value": None},
@@ -149,21 +149,21 @@ def test_notify_support_ticket_request_data_with_user_name_and_email(name, zende
 
 
 @pytest.mark.parametrize(
-    "custom_fields, tech_ticket_tag, categories, org_id, org_type, service_id",
+    "custom_fields, tech_ticket_tag, notify_task_type, org_id, org_type, service_id",
     [
-        ({"notify_ticket_type": NotifyTicketType.TECHNICAL}, "notify_ticket_type_technical", [], None, None, None),
+        ({"notify_ticket_type": NotifyTicketType.TECHNICAL}, "notify_ticket_type_technical", None, None, None, None),
         (
             {"notify_ticket_type": NotifyTicketType.NON_TECHNICAL},
             "notify_ticket_type_non_technical",
-            [],
+            None,
             None,
             None,
             None,
         ),
         (
-            {"ticket_categories": ["notify_billing", "notify_bug"]},
+            {"notify_task_type": "notify_task_email_branding"},
             None,
-            ["notify_billing", "notify_bug"],
+            "notify_task_email_branding",
             None,
             None,
             None,
@@ -171,7 +171,7 @@ def test_notify_support_ticket_request_data_with_user_name_and_email(name, zende
         (
             {"org_id": "1234", "org_type": "local"},
             None,
-            [],
+            None,
             "1234",
             "notify_org_type_local",
             None,
@@ -179,7 +179,7 @@ def test_notify_support_ticket_request_data_with_user_name_and_email(name, zende
         (
             {"service_id": "abcd", "org_type": "nhs"},
             None,
-            [],
+            None,
             None,
             "notify_org_type_nhs",
             "abcd",
@@ -189,7 +189,7 @@ def test_notify_support_ticket_request_data_with_user_name_and_email(name, zende
 def test_notify_support_ticket_request_data_custom_fields(
     custom_fields,
     tech_ticket_tag,
-    categories,
+    notify_task_type,
     org_id,
     org_type,
     service_id,
@@ -200,7 +200,9 @@ def test_notify_support_ticket_request_data_custom_fields(
         assert {"id": "1900000744994", "value": tech_ticket_tag} in notify_ticket_form.request_data["ticket"][
             "custom_fields"
         ]
-    assert {"id": "360022836500", "value": categories} in notify_ticket_form.request_data["ticket"]["custom_fields"]
+    assert {"id": "14229641690396", "value": notify_task_type} in notify_ticket_form.request_data["ticket"][
+        "custom_fields"
+    ]
     assert {"id": "360022943959", "value": org_id} in notify_ticket_form.request_data["ticket"]["custom_fields"]
     assert {"id": "360022943979", "value": org_type} in notify_ticket_form.request_data["ticket"]["custom_fields"]
     assert {"id": "1900000745014", "value": service_id} in notify_ticket_form.request_data["ticket"]["custom_fields"]
@@ -231,7 +233,7 @@ def test_notify_support_ticket_with_html_body():
             "tags": ["govuk_notify_support"],
             "type": "task",
             "custom_fields": [
-                {"id": "360022836500", "value": []},
+                {"id": "14229641690396", "value": None},
                 {"id": "360022943959", "value": None},
                 {"id": "360022943979", "value": None},
                 {"id": "1900000745014", "value": None},


### PR DESCRIPTION
We are switching to use a new Zendesk form, so this changes the Zendesk
client. We now need to pass in the ID of the new form, and instead of
populating the "Ticket category" dropdown we want to populate a dropdown
called "Task type". This will only ever have one thing selected, so
doesn't need to be able to take a list of values.