### PR TITLE
Look at `requirements.txt` to determine installed version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 77.1.1
+
+* Fix how `version_tools.copy_pyproject_toml` discovers the current version of notifications-utils
+
 ## 77.1.0
 
 * Add `version_tools.copy_pyproject_toml` to share linter config between apps

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "77.1.0"  # 0547464f2c9c5dde9cb473dfc2b166a7
+__version__ = "77.1.1"  # 07e8998aff89b28962f71a42867067ce

--- a/notifications_utils/version_tools.py
+++ b/notifications_utils/version_tools.py
@@ -3,6 +3,7 @@ import pathlib
 import requests
 
 requirements_file = pathlib.Path("requirements.in")
+frozen_requirements_file = pathlib.Path("requirements.txt")
 pyproject_file = pathlib.Path("pyproject.toml")
 repo_name = "alphagov/notifications-utils"
 
@@ -44,7 +45,7 @@ def get_remote_version():
 
 
 def get_app_version():
-    return next(line.split("@")[-1] for line in requirements_file.read_text().split("\n") if repo_name in line)
+    return next(line.split("@")[-1] for line in frozen_requirements_file.read_text().split("\n") if repo_name in line)
 
 
 def write_version_to_requirements_file(version):


### PR DESCRIPTION
This is better than looking at `requirements.in` because:
- `requirements.in` isn’t always present (for example when running apps in Docker)
- `requirements.txt` is more likely to reflect what’s actually installed (since that’s what we tell `pip` to look at)