### PR TITLE
Invalid phone error refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## 81.0.0
+
+* BREAKING CHANGE: The constructor for `notification_utils.recipient_validation.errors.InvalidPhoneError`
+  - When raising InvalidPhoneError, instead of supplying a custom message, you must create an error by supplying a code from the `InvalidPhoneError.Codes` enum
+* `InvalidPhoneError.code` will contain this machine-readable code for an exception if you need to examine it later
+* `InvalidPhoneError.get_legacy_v2_api_error_message` returns a historical error message for use on the public v2 api
+
 ## 80.0.1
 
 * Reduces minimum required Gunicorn version for compatibility

--- a/notifications_utils/recipient_validation/errors.py
+++ b/notifications_utils/recipient_validation/errors.py
@@ -33,6 +33,14 @@ class InvalidPhoneError(InvalidRecipientError):
         Codes.UNSUPPORTED_COUNTRY_CODE: "Country code not found - double check the mobile number you entered",
     }
 
+    LEGACY_V2_API_ERROR_MESSAGES = ERROR_MESSAGES | {
+        Codes.TOO_LONG: "Too many digits",
+        Codes.TOO_SHORT: "Not enough digits",
+        Codes.NOT_A_UK_MOBILE: "Not a UK mobile number",
+        Codes.UNKNOWN_CHARACTER: "Must not contain letters or symbols",
+        Codes.UNSUPPORTED_COUNTRY_CODE: "Not a valid country prefix",
+    }
+
     def __init__(self, *, code: Codes = Codes.INVALID_NUMBER):
         """
         Create an InvalidPhoneError. The code must be present in InvalidPhoneError.ERROR_MESSAGES or this will raise a
@@ -40,6 +48,9 @@ class InvalidPhoneError(InvalidRecipientError):
         """
         self.code = code
         super().__init__(message=self.ERROR_MESSAGES[code])
+
+    def get_legacy_v2_api_error_message(self):
+        return self.LEGACY_V2_API_ERROR_MESSAGES[self.code]
 
 
 class InvalidAddressError(InvalidRecipientError):

--- a/notifications_utils/recipient_validation/errors.py
+++ b/notifications_utils/recipient_validation/errors.py
@@ -1,7 +1,10 @@
+from enum import StrEnum, auto
+
+
 class InvalidRecipientError(Exception):
     message = "Not a valid recipient address"
 
-    def __init__(self, message=None):
+    def __init__(self, message: str = None):
         super().__init__(message or self.message)
 
 
@@ -10,7 +13,33 @@ class InvalidEmailError(InvalidRecipientError):
 
 
 class InvalidPhoneError(InvalidRecipientError):
-    message = "Not a valid phone number"
+    class Codes(StrEnum):
+        INVALID_NUMBER = auto()
+        TOO_LONG = auto()
+        TOO_SHORT = auto()
+        NOT_A_UK_MOBILE = auto()
+        UNKNOWN_CHARACTER = auto()
+        UNSUPPORTED_COUNTRY_CODE = auto()
+
+    # TODO: Move this somewhere else maybe? Maybe not?
+    ERROR_MESSAGES = {
+        Codes.INVALID_NUMBER: "Not a valid phone number",
+        Codes.TOO_LONG: "Mobile number is too long",
+        Codes.TOO_SHORT: "Mobile number is too short",
+        Codes.NOT_A_UK_MOBILE: (
+            "This does not look like a UK mobile number – double check the mobile number you entered"
+        ),
+        Codes.UNKNOWN_CHARACTER: "Mobile numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -",
+        Codes.UNSUPPORTED_COUNTRY_CODE: "Country code not found - double check the mobile number you entered",
+    }
+
+    def __init__(self, *, code: Codes = Codes.INVALID_NUMBER):
+        """
+        Create an InvalidPhoneError. The code must be present in InvalidPhoneError.ERROR_MESSAGES or this will raise a
+        KeyError which you may not expect!
+        """
+        self.code = code
+        super().__init__(message=self.ERROR_MESSAGES[code])
 
 
 class InvalidAddressError(InvalidRecipientError):

--- a/notifications_utils/recipient_validation/phone_number.py
+++ b/notifications_utils/recipient_validation/phone_number.py
@@ -33,7 +33,7 @@ def normalise_phone_number(number):
     try:
         list(map(int, number))
     except ValueError as e:
-        raise InvalidPhoneError("Mobile numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -") from e
+        raise InvalidPhoneError(code=InvalidPhoneError.Codes.UNKNOWN_CHARACTER) from e
 
     return number.lstrip("0")
 
@@ -90,15 +90,13 @@ def validate_uk_phone_number(number):
     number = normalise_phone_number(number).lstrip(UK_PREFIX).lstrip("0")
 
     if not number.startswith("7"):
-        raise InvalidPhoneError(
-            "This does not look like a UK mobile number – double check the mobile number you entered"
-        )
+        raise InvalidPhoneError(code=InvalidPhoneError.Codes.NOT_A_UK_MOBILE)
 
     if len(number) > 10:
-        raise InvalidPhoneError("Mobile number is too long")
+        raise InvalidPhoneError(code=InvalidPhoneError.Codes.TOO_LONG)
 
     if len(number) < 10:
-        raise InvalidPhoneError("Mobile number is too short")
+        raise InvalidPhoneError(code=InvalidPhoneError.Codes.TOO_SHORT)
 
     return f"{UK_PREFIX}{number}"
 
@@ -110,13 +108,13 @@ def validate_phone_number(number, international=False):
     number = normalise_phone_number(number)
 
     if len(number) < 8:
-        raise InvalidPhoneError("Mobile number is too short")
+        raise InvalidPhoneError(code=InvalidPhoneError.Codes.TOO_SHORT)
 
     if len(number) > 15:
-        raise InvalidPhoneError("Mobile number is too long")
+        raise InvalidPhoneError(code=InvalidPhoneError.Codes.TOO_LONG)
 
     if get_international_prefix(number) is None:
-        raise InvalidPhoneError("Country code not found - double check the mobile number you entered")
+        raise InvalidPhoneError(code=InvalidPhoneError.Codes.UNSUPPORTED_COUNTRY_CODE)
 
     return number
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "80.0.1"  # 5d80aecac00f9145ca76d05c62848a87
+__version__ = "81.0.0"  # 151ab871231fba7feb2eb8c23c908da9

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -75,7 +75,7 @@ invalid_uk_mobile_phone_numbers = sum(
         [(phone_number, error) for phone_number in group]
         for error, group in [
             (
-                "Mobile number is too long",
+                InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.TOO_LONG],
                 (
                     "712345678910",
                     "0712345678910",
@@ -85,7 +85,7 @@ invalid_uk_mobile_phone_numbers = sum(
                 ),
             ),
             (
-                "Mobile number is too short",
+                InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.TOO_SHORT],
                 (
                     "0712345678",
                     "004471234567",
@@ -94,11 +94,11 @@ invalid_uk_mobile_phone_numbers = sum(
                 ),
             ),
             (
-                "This does not look like a UK mobile number – double check the mobile number you entered",
+                InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.NOT_A_UK_MOBILE],
                 valid_uk_landlines + invalid_uk_landlines,
             ),
             (
-                "Mobile numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -",
+                InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.UNKNOWN_CHARACTER],
                 (
                     "07890x32109",
                     "07123 456789...",
@@ -124,10 +124,13 @@ invalid_mobile_phone_numbers = list(
         invalid_uk_mobile_phone_numbers,
     )
 ) + [
-    ("80000000000", "Country code not found - double check the mobile number you entered"),
-    ("1234567", "Mobile number is too short"),
-    ("+682 1234", "Mobile number is too short"),  # Cook Islands phone numbers can be 5 digits
-    ("+12345 12345 12345 6", "Mobile number is too long"),
+    ("80000000000", InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.UNSUPPORTED_COUNTRY_CODE]),
+    ("1234567", InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.TOO_SHORT]),
+    (
+        "+682 1234",
+        InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.TOO_SHORT],
+    ),  # Cook Islands phone numbers can be 5 digits
+    ("+12345 12345 12345 6", InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.TOO_LONG]),
 ]
 
 
@@ -261,7 +264,7 @@ def test_normalise_phone_number_raises_if_unparseable_characters(phone_number):
 def test_get_international_info_raises(phone_number):
     with pytest.raises(InvalidPhoneError) as error:
         get_international_phone_info(phone_number)
-    assert str(error.value) == "Country code not found - double check the mobile number you entered"
+    assert str(error.value) == InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.UNSUPPORTED_COUNTRY_CODE]
 
 
 @pytest.mark.parametrize("phone_number", valid_uk_mobile_phone_numbers)

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -16,7 +16,7 @@ from notifications_utils.recipients import (
     format_recipient,
 )
 
-valid_uk_phone_numbers = [
+valid_uk_mobile_phone_numbers = [
     "7123456789",
     "07123456789",
     "07123 456789",
@@ -44,10 +44,33 @@ valid_international_phone_numbers = [
 ]
 
 
-valid_phone_numbers = valid_uk_phone_numbers + valid_international_phone_numbers
+valid_mobile_phone_numbers = valid_uk_mobile_phone_numbers + valid_international_phone_numbers
 
+valid_uk_landlines = [
+    "0117 496 0860",  # regular uk landline
+    "0044 117 496 0860",
+    "44 117 496 0860",
+    "+44 117 496 0860",
+    "016064 1234",  # brampton (one digit shorter than normal)
+    "020 7946 0991",  # london
+    "030 1234 5678",  # non-geographic
+    "0500 123 4567",  # corporate numbering and voip services
+    "0800 123 4567",  # freephone
+    "0800 123 456",  # shorter freephone
+    "0800 11 11",  # shortest freephone
+    "0845 46 46",  # short premium
+    "0900 123 4567",  # premium
+]
 
-invalid_uk_phone_numbers = sum(
+invalid_uk_landlines = [
+    "0400 123 4567",  # not in use
+    "0600 123 4567",  # not in use
+    "0300 46 46",  # short but not 01x or 08x
+    "0800 11 12",  # short but not 01x or 08x
+    "0845 46 31",  # short but not 01x or 08x
+]
+
+invalid_uk_mobile_phone_numbers = sum(
     [
         [(phone_number, error) for phone_number in group]
         for error, group in [
@@ -72,14 +95,7 @@ invalid_uk_phone_numbers = sum(
             ),
             (
                 "This does not look like a UK mobile number – double check the mobile number you entered",
-                (
-                    "08081 570364",
-                    "+44 8081 570364",
-                    "0117 496 0860",
-                    "+44 117 496 0860",
-                    "020 7946 0991",
-                    "+44 20 7946 0991",
-                ),
+                valid_uk_landlines + invalid_uk_landlines,
             ),
             (
                 "Mobile numbers can only include: 0 1 2 3 4 5 6 7 8 9 ( ) + -",
@@ -99,16 +115,16 @@ invalid_uk_phone_numbers = sum(
 )
 
 
-invalid_phone_numbers = list(
+invalid_mobile_phone_numbers = list(
     filter(
         lambda number: number[0]
         not in {
             "712345678910",  # Could be Russia
         },
-        invalid_uk_phone_numbers,
+        invalid_uk_mobile_phone_numbers,
     )
 ) + [
-    ("800000000000", "Country code not found - double check the mobile number you entered"),
+    ("80000000000", "Country code not found - double check the mobile number you entered"),
     ("1234567", "Mobile number is too short"),
     ("+682 1234", "Mobile number is too short"),  # Cook Islands phone numbers can be 5 digits
     ("+12345 12345 12345 6", "Mobile number is too long"),
@@ -120,7 +136,7 @@ def test_detect_international_phone_numbers(phone_number):
     assert is_uk_phone_number(phone_number) is False
 
 
-@pytest.mark.parametrize("phone_number", valid_uk_phone_numbers)
+@pytest.mark.parametrize("phone_number", valid_uk_mobile_phone_numbers)
 def test_detect_uk_phone_numbers(phone_number):
     assert is_uk_phone_number(phone_number) is True
 
@@ -248,7 +264,7 @@ def test_get_international_info_raises(phone_number):
     assert str(error.value) == "Country code not found - double check the mobile number you entered"
 
 
-@pytest.mark.parametrize("phone_number", valid_uk_phone_numbers)
+@pytest.mark.parametrize("phone_number", valid_uk_mobile_phone_numbers)
 @pytest.mark.parametrize(
     "extra_args",
     [
@@ -263,7 +279,7 @@ def test_phone_number_accepts_valid_values(extra_args, phone_number):
         pytest.fail("Unexpected InvalidPhoneError")
 
 
-@pytest.mark.parametrize("phone_number", valid_phone_numbers)
+@pytest.mark.parametrize("phone_number", valid_mobile_phone_numbers)
 def test_phone_number_accepts_valid_international_values(phone_number):
     try:
         validate_phone_number(phone_number, international=True)
@@ -271,7 +287,7 @@ def test_phone_number_accepts_valid_international_values(phone_number):
         pytest.fail("Unexpected InvalidPhoneError")
 
 
-@pytest.mark.parametrize("phone_number", valid_uk_phone_numbers)
+@pytest.mark.parametrize("phone_number", valid_uk_mobile_phone_numbers)
 def test_valid_uk_phone_number_can_be_formatted_consistently(phone_number):
     assert validate_and_format_phone_number(phone_number) == "447123456789"
 
@@ -291,7 +307,7 @@ def test_valid_international_phone_number_can_be_formatted_consistently(phone_nu
     assert validate_and_format_phone_number(phone_number, international=True) == expected_formatted
 
 
-@pytest.mark.parametrize("phone_number, error_message", invalid_uk_phone_numbers)
+@pytest.mark.parametrize("phone_number, error_message", invalid_uk_mobile_phone_numbers)
 @pytest.mark.parametrize(
     "extra_args",
     [
@@ -305,14 +321,14 @@ def test_phone_number_rejects_invalid_values(extra_args, phone_number, error_mes
     assert error_message == str(e.value)
 
 
-@pytest.mark.parametrize("phone_number, error_message", invalid_phone_numbers)
+@pytest.mark.parametrize("phone_number, error_message", invalid_mobile_phone_numbers)
 def test_phone_number_rejects_invalid_international_values(phone_number, error_message):
     with pytest.raises(InvalidPhoneError) as e:
         validate_phone_number(phone_number, international=True)
     assert error_message == str(e.value)
 
 
-@pytest.mark.parametrize("phone_number", valid_uk_phone_numbers)
+@pytest.mark.parametrize("phone_number", valid_uk_mobile_phone_numbers)
 def test_validates_against_guestlist_of_phone_numbers(phone_number):
     assert allowed_to_send_to(phone_number, ["07123456789", "07700900460", "test@example.com"])
     assert not allowed_to_send_to(phone_number, ["07700900460", "07700900461", "test@example.com"])


### PR DESCRIPTION
https://trello.com/c/I67noSbf/10-update-phone-number-validation-to-optionally-allow-uk-landlines

More refactoring of `InvalidPhoneError` ahead of adding UK landlines.

This one's quite a big one - I'm taking an opinionated stance that rather than writing code like `raise InvalidPhoneError('some error message')`, it's nicer to write `raise InvalidPhoneError(code=InvalidPhoneError.Codes.SOME_ERROR)`. Then, the exception class itself has a list of all the error codes, and a list of all the human-readable messages for surfacing on the front-end etc.

This means we can define these messages once, and only need to surface them at exit points (API error json serialisation, form rendering) and can just use the codes if we need to branch.

We're not doing work on the API v2 error slugs just yet but it's useful to have a starting point for that work I think.

Best viewed commit by commit.

Open to discussion about class names, file locations, if the error codes should be nested or not, if there's better ways to represent than an enum of codes and a map of said enums to strings, etc.