### PR TITLE
Phone number validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 81.1.0
+* introduce new validation class - `PhoneNumber`, that we will use for services that want to send sms
+to landline (and in the future this new code can be extended for all phone number validation)
+* in this new class, we use `phonenumbers` library for validating phone numbers, instead of our custom valdiation code
+
+
 ## 81.0.0
 
 * BREAKING CHANGE: The constructor for `notification_utils.recipient_validation.errors.InvalidPhoneError`

--- a/notifications_utils/recipient_validation/errors.py
+++ b/notifications_utils/recipient_validation/errors.py
@@ -28,7 +28,7 @@ class InvalidPhoneError(InvalidRecipientError):
         # this catches numbers with the right length but wrong digits
         # for example UK numbers cannot start "06" as that hasn't been assigned to a purpose by ofcom,
         # or a 9 digit UK number that does not start "01" or "0800".
-        Codes.INVALID_NUMBER: "TODO: CONTENT! Number is not valid – double check the mobile number you entered",
+        Codes.INVALID_NUMBER: "Number is not valid – double check the phone number you entered",  # TODO: CONTENT!
         Codes.TOO_LONG: "Mobile number is too long",
         Codes.TOO_SHORT: "Mobile number is too short",
         Codes.NOT_A_UK_MOBILE: (
@@ -55,7 +55,7 @@ class InvalidPhoneError(InvalidRecipientError):
         super().__init__(message=self.ERROR_MESSAGES[code])
 
     @classmethod
-    def from_phonenumbers_validationresult(cls, reason: phonenumbers.ValidationResult) -> str:
+    def from_phonenumbers_validation_result(cls, reason: phonenumbers.ValidationResult) -> str:
         match reason:
             case phonenumbers.ValidationResult.TOO_LONG:
                 code = cls.Codes.TOO_LONG

--- a/notifications_utils/recipient_validation/errors.py
+++ b/notifications_utils/recipient_validation/errors.py
@@ -1,5 +1,7 @@
 from enum import StrEnum, auto
 
+import phonenumbers
+
 
 class InvalidRecipientError(Exception):
     message = "Not a valid recipient address"
@@ -23,7 +25,10 @@ class InvalidPhoneError(InvalidRecipientError):
 
     # TODO: Move this somewhere else maybe? Maybe not?
     ERROR_MESSAGES = {
-        Codes.INVALID_NUMBER: "Not a valid phone number",
+        # this catches numbers with the right length but wrong digits
+        # for example UK numbers cannot start "06" as that hasn't been assigned to a purpose by ofcom,
+        # or a 9 digit UK number that does not start "01" or "0800".
+        Codes.INVALID_NUMBER: "TODO: CONTENT! Number is not valid – double check the mobile number you entered",
         Codes.TOO_LONG: "Mobile number is too long",
         Codes.TOO_SHORT: "Mobile number is too short",
         Codes.NOT_A_UK_MOBILE: (
@@ -48,6 +53,26 @@ class InvalidPhoneError(InvalidRecipientError):
         """
         self.code = code
         super().__init__(message=self.ERROR_MESSAGES[code])
+
+    @classmethod
+    def from_phonenumbers_validationresult(cls, reason: phonenumbers.ValidationResult) -> str:
+        match reason:
+            case phonenumbers.ValidationResult.TOO_LONG:
+                code = cls.Codes.TOO_LONG
+            # is_possible_local_only implies a number without an area code. Lets just call it too short.
+            case phonenumbers.ValidationResult.TOO_SHORT | phonenumbers.ValidationResult.IS_POSSIBLE_LOCAL_ONLY:
+                code = cls.Codes.TOO_SHORT
+            case phonenumbers.ValidationResult.INVALID_COUNTRY_CODE:
+                code = cls.Codes.UNSUPPORTED_COUNTRY_CODE
+            case phonenumbers.ValidationResult.IS_POSSIBLE:
+                raise ValueError("Cannot create InvalidPhoneNumber for ValidationResult.IS_POSSIBLE")
+            case phonenumbers.ValidationResult.INVALID_LENGTH:
+                code = cls.Codes.INVALID_NUMBER
+
+            case _:
+                code = cls.Codes.INVALID_NUMBER
+
+        return cls(code=code)
 
     def get_legacy_v2_api_error_message(self):
         return self.LEGACY_V2_API_ERROR_MESSAGES[self.code]

--- a/notifications_utils/recipient_validation/phone_number.py
+++ b/notifications_utils/recipient_validation/phone_number.py
@@ -168,7 +168,7 @@ class PhoneNumber:
         try:
             self.number = self.validate_phone_number(phone_number)
         except InvalidPhoneError:
-            phone_number = self._aggressively_normalise_number(phone_number)
+            phone_number = self._thoroughly_normalise_number(phone_number)
             self.number = self.validate_phone_number(phone_number)
 
     @staticmethod
@@ -211,7 +211,7 @@ class PhoneNumber:
             ):
                 number = forced_international_number
             else:
-                raise InvalidPhoneError.from_phonenumbers_validationresult(reason)
+                raise InvalidPhoneError.from_phonenumbers_validation_result(reason)
 
         if not phonenumbers.is_valid_number(number):
             # is_possible just checks the length of a number for that country/region. is_valid checks if it's
@@ -222,7 +222,7 @@ class PhoneNumber:
         return number
 
     @staticmethod
-    def _aggressively_normalise_number(phone_number: str) -> str:
+    def _thoroughly_normalise_number(phone_number: str) -> str:
         """
         We often (up to ~3% of the time) see numbers which are not technically valid, but are close-enough-to-valid
         that we want to give our users benefit of the doubt.

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "81.0.0"  # 151ab871231fba7feb2eb8c23c908da9
+__version__ = "81.1.0"  # 151ab871231fba7feb2eb8c23c908da9

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -31,16 +31,18 @@ valid_uk_mobile_phone_numbers = [
 
 
 valid_international_phone_numbers = [
-    "71234567890",  # Russia
+    "+7 (8) (495) 123-45-67",  # russia
+    "007 (8) (495) 123-45-67",  # russia
+    "784951234567",  # Russia but without a + or 00 so it looks like it could be a uk phone number
     "1-202-555-0104",  # USA
     "+12025550104",  # USA
     "0012025550104",  # USA
     "+0012025550104",  # USA
-    "23051234567",  # Mauritius,
-    "+682 12345",  # Cook islands
-    "+3312345678",
-    "003312345678",
-    "1-2345-12345-12345",  # 15 digits
+    "230 5 2512345",  # Mauritius
+    "+682 50 123",  # Cook islands
+    "+33122334455",  # France
+    "0033122334455",  # France
+    "+43 676 111 222 333 4",  # Austrian 13 digit phone numbers
 ]
 
 
@@ -54,7 +56,7 @@ valid_uk_landlines = [
     "016064 1234",  # brampton (one digit shorter than normal)
     "020 7946 0991",  # london
     "030 1234 5678",  # non-geographic
-    "0500 123 4567",  # corporate numbering and voip services
+    "0550 123 4567",  # corporate numbering and voip services
     "0800 123 4567",  # freephone
     "0800 123 456",  # shorter freephone
     "0800 11 11",  # shortest freephone
@@ -94,10 +96,6 @@ invalid_uk_mobile_phone_numbers = sum(
                 ),
             ),
             (
-                InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.NOT_A_UK_MOBILE],
-                valid_uk_landlines + invalid_uk_landlines,
-            ),
-            (
                 InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.UNKNOWN_CHARACTER],
                 (
                     "07890x32109",
@@ -114,16 +112,7 @@ invalid_uk_mobile_phone_numbers = sum(
     [],
 )
 
-
-invalid_mobile_phone_numbers = list(
-    filter(
-        lambda number: number[0]
-        not in {
-            "712345678910",  # Could be Russia
-        },
-        invalid_uk_mobile_phone_numbers,
-    )
-) + [
+invalid_international_numbers = [
     ("80000000000", InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.UNSUPPORTED_COUNTRY_CODE]),
     ("1234567", InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.TOO_SHORT]),
     (
@@ -132,6 +121,25 @@ invalid_mobile_phone_numbers = list(
     ),  # Cook Islands phone numbers can be 5 digits
     ("+12345 12345 12345 6", InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.TOO_LONG]),
 ]
+
+
+# NOTE: includes landlines
+invalid_mobile_phone_numbers = (
+    list(
+        filter(
+            lambda number: number[0]
+            not in {
+                "712345678910",  # Could be Russia
+            },
+            invalid_uk_mobile_phone_numbers,
+        )
+    )
+    + invalid_international_numbers
+    + [
+        (num, InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.NOT_A_UK_MOBILE])
+        for num in valid_uk_landlines + invalid_uk_landlines
+    ]
+)
 
 
 @pytest.mark.parametrize("phone_number", valid_international_phone_numbers)

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -393,7 +393,7 @@ def test_format_phone_number_human_readable_doenst_throw():
     assert format_phone_number_human_readable("ALPHANUM3R1C") == "ALPHANUM3R1C"
 
 
-class TestPhoneNumbeClass:
+class TestPhoneNumberClass:
 
     @pytest.mark.parametrize("phone_number, error_message", invalid_uk_mobile_phone_numbers)
     def test_rejects_invalid_uk_mobile_phone_numbers(self, phone_number, error_message):

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -2,7 +2,7 @@ import pytest
 
 from notifications_utils.recipient_validation.errors import InvalidPhoneError
 from notifications_utils.recipient_validation.phone_number import (
-    UKLandline,
+    PhoneNumber,
     format_phone_number_human_readable,
     get_international_phone_info,
     international_phone_info,
@@ -402,19 +402,19 @@ def test_format_phone_number_human_readable_doenst_throw():
     assert format_phone_number_human_readable("ALPHANUM3R1C") == "ALPHANUM3R1C"
 
 
-class TestUKLandlineValidation:
+class TestPhoneNumbeClass:
 
     @pytest.mark.parametrize("phone_number, error_message", invalid_uk_mobile_phone_numbers)
     def test_rejects_invalid_uk_mobile_phone_numbers(self, phone_number, error_message):
         # problem is `invalid_uk_mobile_phone_numbers` also includes valid uk landlines
         with pytest.raises(InvalidPhoneError):
-            UKLandline.validate_mobile_or_uk_landline(phone_number, allow_international=False)
+            PhoneNumber(phone_number, allow_international=False)
         # assert e.value.code == InvalidPhoneError.Codes.INVALID_NUMBER
 
     @pytest.mark.parametrize("phone_number", invalid_uk_landlines)
     def test_rejects_invalid_uk_landlines(self, phone_number):
         with pytest.raises(InvalidPhoneError) as e:
-            UKLandline.validate_mobile_or_uk_landline(phone_number, allow_international=False)
+            PhoneNumber(phone_number, allow_international=False)
         assert e.value.code == InvalidPhoneError.Codes.INVALID_NUMBER
 
     @pytest.mark.parametrize(
@@ -422,16 +422,16 @@ class TestUKLandlineValidation:
     )
     def test_rejects_invalid_international_phone_numbers(self, phone_number, error_message):
         with pytest.raises(InvalidPhoneError):
-            UKLandline.validate_mobile_or_uk_landline(phone_number, allow_international=True)
+            PhoneNumber(phone_number, allow_international=True)
 
     @pytest.mark.parametrize("phone_number", valid_uk_mobile_phone_numbers)
     def test_allows_valid_uk_mobile_phone_numbers(self, phone_number):
-        UKLandline.validate_mobile_or_uk_landline(phone_number, allow_international=False)
+        PhoneNumber(phone_number, allow_international=False)
 
     @pytest.mark.parametrize("phone_number", valid_international_phone_numbers)
     def test_allows_valid_international_phone_numbers(self, phone_number):
-        UKLandline.validate_mobile_or_uk_landline(phone_number, allow_international=True)
+        PhoneNumber(phone_number, allow_international=True)
 
     @pytest.mark.parametrize("phone_number", valid_uk_landlines)
     def test_allows_valid_uk_landlines(self, phone_number):
-        UKLandline.validate_mobile_or_uk_landline(phone_number, allow_international=True)
+        PhoneNumber(phone_number, allow_international=True)

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -409,7 +409,14 @@ class TestPhoneNumbeClass:
         assert e.value.code == InvalidPhoneError.Codes.INVALID_NUMBER
 
     @pytest.mark.parametrize(
-        "phone_number, error_message", invalid_uk_mobile_phone_numbers + invalid_international_numbers
+        "phone_number, error_message",
+        invalid_uk_mobile_phone_numbers
+        + invalid_international_numbers
+        + [
+            # french number - but 87 isn't a valid start of a phone number in france as defined by libphonenumber
+            # eg https://github.com/google/libphonenumber/blob/master/resources/metadata/33/ranges.csv
+            ("0033877123456", InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.INVALID_NUMBER]),
+        ],
     )
     def test_rejects_invalid_international_phone_numbers(self, phone_number, error_message):
         with pytest.raises(InvalidPhoneError):

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -27,7 +27,7 @@ valid_uk_mobile_phone_numbers = [
     "+447123456789",
     "+44 7123 456 789",
     "+44 (0)7123 456 789",
-    "\u200b\t\t+44 (0)7123 \ufeff 456 789 \r\n",
+    "\u200b\t\t+44 (0)7123 456 789\ufeff \r\n",
 ]
 
 
@@ -114,7 +114,7 @@ invalid_uk_mobile_phone_numbers = sum(
 )
 
 invalid_international_numbers = [
-    ("80000000000", InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.UNSUPPORTED_COUNTRY_CODE]),
+    ("80100000000", InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.UNSUPPORTED_COUNTRY_CODE]),
     ("1234567", InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.TOO_SHORT]),
     (
         "+682 1234",

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -2,6 +2,7 @@ import pytest
 
 from notifications_utils.recipient_validation.errors import InvalidPhoneError
 from notifications_utils.recipient_validation.phone_number import (
+    UKLandline,
     format_phone_number_human_readable,
     get_international_phone_info,
     international_phone_info,
@@ -399,3 +400,38 @@ def test_try_format_recipient_doesnt_throw():
 
 def test_format_phone_number_human_readable_doenst_throw():
     assert format_phone_number_human_readable("ALPHANUM3R1C") == "ALPHANUM3R1C"
+
+
+class TestUKLandlineValidation:
+
+    @pytest.mark.parametrize("phone_number, error_message", invalid_uk_mobile_phone_numbers)
+    def test_rejects_invalid_uk_mobile_phone_numbers(self, phone_number, error_message):
+        # problem is `invalid_uk_mobile_phone_numbers` also includes valid uk landlines
+        with pytest.raises(InvalidPhoneError):
+            UKLandline.validate_mobile_or_uk_landline(phone_number, allow_international=False)
+        # assert e.value.code == InvalidPhoneError.Codes.INVALID_NUMBER
+
+    @pytest.mark.parametrize("phone_number", invalid_uk_landlines)
+    def test_rejects_invalid_uk_landlines(self, phone_number):
+        with pytest.raises(InvalidPhoneError) as e:
+            UKLandline.validate_mobile_or_uk_landline(phone_number, allow_international=False)
+        assert e.value.code == InvalidPhoneError.Codes.INVALID_NUMBER
+
+    @pytest.mark.parametrize(
+        "phone_number, error_message", invalid_uk_mobile_phone_numbers + invalid_international_numbers
+    )
+    def test_rejects_invalid_international_phone_numbers(self, phone_number, error_message):
+        with pytest.raises(InvalidPhoneError):
+            UKLandline.validate_mobile_or_uk_landline(phone_number, allow_international=True)
+
+    @pytest.mark.parametrize("phone_number", valid_uk_mobile_phone_numbers)
+    def test_allows_valid_uk_mobile_phone_numbers(self, phone_number):
+        UKLandline.validate_mobile_or_uk_landline(phone_number, allow_international=False)
+
+    @pytest.mark.parametrize("phone_number", valid_international_phone_numbers)
+    def test_allows_valid_international_phone_numbers(self, phone_number):
+        UKLandline.validate_mobile_or_uk_landline(phone_number, allow_international=True)
+
+    @pytest.mark.parametrize("phone_number", valid_uk_landlines)
+    def test_allows_valid_uk_landlines(self, phone_number):
+        UKLandline.validate_mobile_or_uk_landline(phone_number, allow_international=True)

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -18,16 +18,16 @@ from notifications_utils.recipients import (
 )
 
 valid_uk_mobile_phone_numbers = [
-    "7123456789",
-    "07123456789",
-    "07123 456789",
-    "07123-456-789",
-    "00447123456789",
-    "00 44 7123456789",
-    "+447123456789",
-    "+44 7123 456 789",
-    "+44 (0)7123 456 789",
-    "\u200b\t\t+44 (0)7123 456 789\ufeff \r\n",
+    "7723456789",
+    "07723456789",
+    "07723 456789",
+    "07723-456-789",
+    "00447723456789",
+    "00 44 7723456789",
+    "+447723456789",
+    "+44 7723 456 789",
+    "+44 (0)7723 456 789",
+    "\u200b\t\t+44 (0)7723 456 789\ufeff \r\n",
 ]
 
 
@@ -80,29 +80,29 @@ invalid_uk_mobile_phone_numbers = sum(
             (
                 InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.TOO_LONG],
                 (
-                    "712345678910",
-                    "0712345678910",
-                    "0044712345678910",
-                    "0044712345678910",
-                    "+44 (0)7123 456 789 10",
+                    "772345678910",
+                    "0772345678910",
+                    "0044772345678910",
+                    "0044772345678910",
+                    "+44 (0)7723 456 789 10",
                 ),
             ),
             (
                 InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.TOO_SHORT],
                 (
-                    "0712345678",
-                    "004471234567",
-                    "00447123456",
-                    "+44 (0)7123 456 78",
+                    "0772345678",
+                    "004477234567",
+                    "00447723456",
+                    "+44 (0)7723 456 78",
                 ),
             ),
             (
                 InvalidPhoneError.ERROR_MESSAGES[InvalidPhoneError.Codes.UNKNOWN_CHARACTER],
                 (
                     "07890x32109",
-                    "07123 456789...",
-                    "07123 ☟☜⬇⬆☞☝",
-                    "07123☟☜⬇⬆☞☝",
+                    "07723 456789...",
+                    "07723 ☟☜⬇⬆☞☝",
+                    "07723☟☜⬇⬆☞☝",
                     '07";DROP TABLE;"',
                     "+44 07ab cde fgh",
                     "ALPHANUM3R1C",
@@ -130,7 +130,7 @@ invalid_mobile_phone_numbers = (
         filter(
             lambda number: number[0]
             not in {
-                "712345678910",  # Could be Russia
+                "772345678910",  # Could be Russia
             },
             invalid_uk_mobile_phone_numbers,
         )
@@ -145,7 +145,7 @@ invalid_mobile_phone_numbers = (
 
 international_phone_info_fixtures = [
     (
-        "07900900123",
+        "07723456789",
         international_phone_info(
             international=False,
             crown_dependency=False,
@@ -154,16 +154,7 @@ international_phone_info_fixtures = [
         ),
     ),
     (
-        "07700900123",
-        international_phone_info(
-            international=False,
-            crown_dependency=False,
-            country_prefix="44",  # Number in TV range
-            billable_units=1,
-        ),
-    ),
-    (
-        "07700800123",
+        "07797800123",
         international_phone_info(
             international=True,
             crown_dependency=True,
@@ -190,7 +181,7 @@ international_phone_info_fixtures = [
         ),
     ),
     (
-        "1664000000000",
+        "16644913789",
         international_phone_info(
             international=True,
             crown_dependency=False,
@@ -199,7 +190,7 @@ international_phone_info_fixtures = [
         ),
     ),
     (
-        "71234567890",
+        "77234567890",
         international_phone_info(
             international=True,
             crown_dependency=False,
@@ -217,7 +208,7 @@ international_phone_info_fixtures = [
         ),
     ),
     (
-        "+23051234567",
+        "+23052512345",
         international_phone_info(
             international=True,
             crown_dependency=False,
@@ -301,18 +292,18 @@ def test_phone_number_accepts_valid_international_values(phone_number):
 
 @pytest.mark.parametrize("phone_number", valid_uk_mobile_phone_numbers)
 def test_valid_uk_phone_number_can_be_formatted_consistently(phone_number):
-    assert validate_and_format_phone_number(phone_number) == "447123456789"
+    assert validate_and_format_phone_number(phone_number) == "447723456789"
 
 
 @pytest.mark.parametrize(
     "phone_number, expected_formatted",
     [
-        ("71234567890", "71234567890"),
+        ("77234567890", "77234567890"),
         ("1-202-555-0104", "12025550104"),
         ("+12025550104", "12025550104"),
         ("0012025550104", "12025550104"),
         ("+0012025550104", "12025550104"),
-        ("23051234567", "23051234567"),
+        ("23052512345", "23052512345"),
     ],
 )
 def test_valid_international_phone_number_can_be_formatted_consistently(phone_number, expected_formatted):
@@ -342,7 +333,7 @@ def test_phone_number_rejects_invalid_international_values(phone_number, error_m
 
 @pytest.mark.parametrize("phone_number", valid_uk_mobile_phone_numbers)
 def test_validates_against_guestlist_of_phone_numbers(phone_number):
-    assert allowed_to_send_to(phone_number, ["07123456789", "07700900460", "test@example.com"])
+    assert allowed_to_send_to(phone_number, ["07723456789", "07700900460", "test@example.com"])
     assert not allowed_to_send_to(phone_number, ["07700900460", "07700900461", "test@example.com"])
 
 
@@ -444,8 +435,8 @@ class TestPhoneNumbeClass:
         "number, expected",
         [
             ("48123654789", False),  # Poland alpha: Yes
-            ("1-403-123-5687", True),  # Canada alpha: No
-            ("40123548897", False),  # Romania alpha: REG
+            ("1-403-555-0104", True),  # Canada alpha: No
+            ("40 21 201 7200", False),  # Romania alpha: REG
             ("+60123451345", True),  # Malaysia alpha: NO
         ],
     )
@@ -454,17 +445,17 @@ class TestPhoneNumbeClass:
 
     @pytest.mark.parametrize("phone_number", valid_uk_mobile_phone_numbers)
     def test_get_normalised_format_works_for_uk_mobiles(self, phone_number):
-        assert PhoneNumber(phone_number, allow_international=True).get_normalised_format() == "447123456789"
+        assert PhoneNumber(phone_number, allow_international=True).get_normalised_format() == "447723456789"
 
     @pytest.mark.parametrize(
         "phone_number, expected_formatted",
         [
-            ("71234567890", "71234567890"),
+            ("74991231212", "74991231212"),
             ("1-202-555-0104", "12025550104"),
             ("+12025550104", "12025550104"),
             ("0012025550104", "12025550104"),
             ("+0012025550104", "12025550104"),
-            ("23051234567", "23051234567"),
+            ("23052512345", "23052512345"),
         ],
     )
     def test_get_normalised_format_works_for_international_numbers(self, phone_number, expected_formatted):
@@ -473,15 +464,15 @@ class TestPhoneNumbeClass:
     @pytest.mark.parametrize(
         "phone_number, expected_formatted",
         [
-            ("07900900123", "07900 900123"),  # UK
-            ("+44(0)7900900123", "07900 900123"),  # UK
-            ("447900900123", "07900 900123"),  # UK
+            ("07723456789", "07723 456789"),  # UK
+            ("+44(0)7723456789", "07723 456789"),  # UK
+            ("447723456789", "07723 456789"),  # UK
             ("20-12-1234-1234", "+20 12 12341234"),  # Egypt
             ("00201212341234", "+20 12 12341234"),  # Egypt
-            ("1664 0000000", "+1 664-000-0000"),  # Montserrat
+            ("1664 491 3789", "+1 664-491-3789"),  # Montserrat
             ("7 499 1231212", "+7 499 123-12-12"),  # Moscow (Russia)
             ("1-202-555-0104", "+1 202-555-0104"),  # Washington DC (USA)
-            ("+23051234567", "+230 5123 4567"),  # Mauritius
+            ("+23052512345", "+230 5251 2345"),  # Mauritius
             ("33(0)1 12345678", "+33 1 12 34 56 78"),  # Paris (France)
         ],
     )


### PR DESCRIPTION
https://trello.com/c/I67noSbf/10-update-phone-number-validation-to-optionally-allow-uk-landlines

🚨 This PR is targeting invalid-phone-error-refactor for a simpler diff 🚨 

Adds a new function for UK landline validation. Instead of hand-writing more code, instead we can lean on google's [`libphonenumber`](https://github.com/google/libphonenumber), which we already have as a dependency anyway.

we already use phonenumbers in `format_phone_number_human_readable` as it nicely formats numbers. It has a whole suite of validation features too.

We often find other teams asking us how we validate phone numbers so they can replicate it on their own frontend. We link to this repo but it would be much nicer if we could just point them to a well supported third party library with a variety of implementations in different languages.

We could potentially run validation in parallel with our regular output to ensure it matches. I'm not too worried if things we currently fail are allowed in by phonenumbers, as the chances are they're more correct than we are - but it's important that any numbers we currently accept and deliver to also work in phonenumbers.

-------

TODO: 
- [ ] Merge #1125 
- [x] Investigate: which of the other functions in the file do we need to replicate?
  - [ ] ~normalise_phone_number~ - used in sms sender normalisation (so often dealing with things that aren't phone numbers, or other valid short numbers eg `119`)
  - [x] is_uk_phone_number
  - [x] get_international_phone_info
  - [x] _is_a_crown_dependency_number
  - [ ] ~get_international_prefix~ - internal utils use only, don't need to replicate
  - [ ] ~get_billable_units_for_prefix~ - internal utils use only, don't need to replicate
  - [x] use_numeric_sender
  - [ ] ~validate_uk_phone_number~ - internal utils use only, don't need to replicate
  - [x] validate_phone_number
  - [ ] ~try_validate_and_format_phone_number~ - not needed as this is used for inbound sms, sms reply to, search params (none of which are uk landline specific)
  - [x] format_phone_number_human_readable