### PR TITLE
Put more common configuration and dependencies in `notifications-utils`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 80.0.0
+
+* Copies additional config files from utils into repos
+* Renames `version_tools.copy_pyproject_yaml` to `version_tools.copy_config`
+
 ## 79.0.1
 
 * Update the `send_ticket_to_zendesk` method of the ZendeskClient to return the ID of the ticket that was created.

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "79.0.1"  # c3bc84a6e9be276955ecaad95d0a0caf
+__version__ = "80.0.0"  # 9fc05f28af962334e7c9b1f089bb534b

--- a/notifications_utils/version_tools.py
+++ b/notifications_utils/version_tools.py
@@ -8,6 +8,7 @@ repo_name = "alphagov/notifications-utils"
 config_files = {
     "pyproject.toml",
     "requirements_for_test_common.txt",
+    ".pre-commit-config.yaml",
 }
 
 

--- a/notifications_utils/version_tools.py
+++ b/notifications_utils/version_tools.py
@@ -80,7 +80,7 @@ def get_file_contents_from_github(branch_or_tag, path):
     return requests.get(f"https://raw.githubusercontent.com/{repo_name}/{branch_or_tag}/{path}").text
 
 
-def copy_pyproject_toml():
+def copy_config():
     local_utils_version = get_app_version()
     remote_contents = get_file_contents_from_github(local_utils_version, "pyproject.toml")
     pyproject_file.write_text(

--- a/notifications_utils/version_tools.py
+++ b/notifications_utils/version_tools.py
@@ -4,8 +4,11 @@ import requests
 
 requirements_file = pathlib.Path("requirements.in")
 frozen_requirements_file = pathlib.Path("requirements.txt")
-pyproject_file = pathlib.Path("pyproject.toml")
 repo_name = "alphagov/notifications-utils"
+config_files = {
+    "pyproject.toml",
+    "requirements_for_test_common.txt",
+}
 
 
 class color:
@@ -82,7 +85,8 @@ def get_file_contents_from_github(branch_or_tag, path):
 
 def copy_config():
     local_utils_version = get_app_version()
-    remote_contents = get_file_contents_from_github(local_utils_version, "pyproject.toml")
-    pyproject_file.write_text(
-        f"# This file is automatically copied from notifications-utils@{local_utils_version}\n\n{remote_contents}"
-    )
+    for config_file in config_files:
+        remote_contents = get_file_contents_from_github(local_utils_version, config_file)
+        pathlib.Path(config_file).write_text(
+            f"# This file is automatically copied from notifications-utils@{local_utils_version}\n\n{remote_contents}"
+        )

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,17 +1,5 @@
 -e .
+-r requirements_for_test_common.txt
 
 celery==5.3.6
 redis>=4.3.4  # Earlier versions of redis miss features the tests need
-
-beautifulsoup4==4.11.1
-pytest==7.2.0
-pytest-env==0.8.1
-pytest-mock==3.9.0
-pytest-xdist==3.0.2
-pytest-testmon==2.1.0
-pytest-watch==4.2.0
-requests-mock==1.10.0
-freezegun==1.2.2
-
-black==24.4.0  # Also update `.pre-commit-config.yaml` if this changes
-ruff==0.3.7  # Also update `.pre-commit-config.yaml` if this changes

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,19 +1,17 @@
 -e .
 
-flask>=3.0.0 # we use 2.3.2 in some places but we need >=3 for the logger tests
 celery==5.3.6
+redis>=4.3.4  # Earlier versions of redis miss features the tests need
+
 beautifulsoup4==4.11.1
 pytest==7.2.0
+pytest-env==0.8.1
 pytest-mock==3.9.0
 pytest-xdist==3.0.2
-requests-mock==1.10.0
-freezegun==1.2.2
-flake8-bugbear==22.10.27
-flake8-print==5.0.0
-pytest-profiling==1.7.0
 pytest-testmon==2.1.0
 pytest-watch==4.2.0
-redis>=4.3.4  # Earlier versions of redis miss features the tests need
-snakeviz==2.1.1
+requests-mock==1.10.0
+freezegun==1.2.2
+
 black==24.4.0  # Also update `.pre-commit-config.yaml` if this changes
 ruff==0.3.7  # Also update `.pre-commit-config.yaml` if this changes

--- a/requirements_for_test_common.txt
+++ b/requirements_for_test_common.txt
@@ -1,0 +1,12 @@
+beautifulsoup4==4.11.1
+pytest==7.2.0
+pytest-env==0.8.1
+pytest-mock==3.9.0
+pytest-xdist==3.0.2
+pytest-testmon==2.1.0
+pytest-watch==4.2.0
+requests-mock==1.10.0
+freezegun==1.2.2
+
+black==24.4.0  # Also update `.pre-commit-config.yaml` if this changes
+ruff==0.3.7  # Also update `.pre-commit-config.yaml` if this changes

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "requests>=2.32.0",
         "python-json-logger>=2.0.7",
         "Flask>=3.0.0",
-        "gunicorn>=20.0.0",
+        "gunicorn[eventlet]>=21.2.0",
         "ordered-set>=4.1.0",
         "Jinja2>=3.1.4",
         "statsd>=4.0.1",
@@ -40,7 +40,7 @@ setup(
         "pypdf>=3.13.0",
         "itsdangerous>=2.1.2",
         "govuk-bank-holidays>=0.14",
-        "boto3>=1.34.100",
+        "boto3[crt]>=1.34.100",
         "segno>=1.5.2,<2.0.0",
     ],
 )


### PR DESCRIPTION
This will let us:
- remove more dependencies from each app’s requirements files
- share common config for pre-commit hooks, rather than having to manually maintain and update one in each app