### PR TITLE
Return Zendesk ticket ID when creating a ticket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 79.0.1
+
+* Update the `send_ticket_to_zendesk` method of the ZendeskClient to return the ID of the ticket that was created.
+
 ## 79.0.0
 
 * Switches on Pyupgrade and a bunch of other more opinionated linting rules

--- a/notifications_utils/clients/zendesk/zendesk_client.py
+++ b/notifications_utils/clients/zendesk/zendesk_client.py
@@ -80,6 +80,8 @@ class ZendeskClient:
 
         current_app.logger.info("Zendesk create ticket %s succeeded", ticket_id)
 
+        return ticket_id
+
     def _is_user_suspended(self, response):
         requester_error = response["details"].get("requester")
         return requester_error and ("suspended" in requester_error[0]["description"])

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "79.0.0"  # a19819b5ebe4704a9890ed189616f09f
+__version__ = "79.0.1"  # c3bc84a6e9be276955ecaad95d0a0caf

--- a/tests/clients/zendesk/test_zendesk_client.py
+++ b/tests/clients/zendesk/test_zendesk_client.py
@@ -42,13 +42,14 @@ def test_zendesk_client_send_ticket_to_zendesk(zendesk_client, app, rmock, caplo
 
     with caplog.at_level(logging.INFO):
         ticket = NotifySupportTicket("subject", "message", "incident")
-        zendesk_client.send_ticket_to_zendesk(ticket)
+        response = zendesk_client.send_ticket_to_zendesk(ticket)
 
     assert rmock.last_request.headers["Authorization"][:6] == "Basic "
     b64_auth = rmock.last_request.headers["Authorization"][6:]
     assert b64decode(b64_auth.encode()).decode() == "zd-api-notify@digital.cabinet-office.gov.uk/token:testkey"
     assert rmock.last_request.json() == ticket.request_data
     assert "Zendesk create ticket 12345 succeeded" in caplog.messages
+    assert response == 12345
 
 
 def test_zendesk_client_send_ticket_to_zendesk_error(zendesk_client, app, rmock, caplog):
@@ -74,12 +75,13 @@ def test_zendesk_client_send_ticket_to_zendesk_with_user_suspended_error(zendesk
         },
     )
     ticket = NotifySupportTicket("subject", "message", "incident")
-    zendesk_client.send_ticket_to_zendesk(ticket)
+    response = zendesk_client.send_ticket_to_zendesk(ticket)
 
     assert caplog.messages == [
         "Zendesk create ticket failed because user is suspended "
         "'{'requester': [{'description': 'Requester: Joe Bloggs is suspended.'}]}'"
     ]
+    assert response is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
In order to update a ticket, you need to know its ID. This returns the
ticket ID from the `send_ticket_to_zendesk` method so that we can update
a ticket immediately after creating it. We want to start adding an
internal note if a user who is not logged in creates a ticket.