### PR TITLE
Reduce minimum required version of Gunicorn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 80.0.1
+
+* Reduces minimum required Gunicorn version for compatibility
+
 ## 80.0.0
 
 * Copies additional config files from utils into repos

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "80.0.0"  # 9fc05f28af962334e7c9b1f089bb534b
+__version__ = "80.0.1"  # 5d80aecac00f9145ca76d05c62848a87

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         "requests>=2.32.0",
         "python-json-logger>=2.0.7",
         "Flask>=3.0.0",
-        "gunicorn[eventlet]>=21.2.0",
+        "gunicorn[eventlet]>=20.1.0",
         "ordered-set>=4.1.0",
         "Jinja2>=3.1.4",
         "statsd>=4.0.1",


### PR DESCRIPTION
The API has the Gunicorn version pinned here:
https://github.com/alphagov/notifications-api/blob/e175f90d8f56c4a1190f2c29dfa1954ff6b87e64/requirements.in#L13

This resolves to version 20.1.0 here:
https://github.com/benoitc/gunicorn/blob/1299ea9e967a61ae2edebe191082fd169b864c64/gunicorn/__init__.py#L6C16-L6C26

So to avoid a dependency conflict we need to reduce the required version to a common baseline in this repo.