### PR TITLE
Bug fix to allow validation of UK mobile "TV numbers"

### DIFF
--- a/notifications_utils/recipient_validation/phone_number.py
+++ b/notifications_utils/recipient_validation/phone_number.py
@@ -1,3 +1,4 @@
+import re
 from collections import namedtuple
 from contextlib import suppress
 
@@ -217,9 +218,23 @@ class PhoneNumber:
             # is_possible just checks the length of a number for that country/region. is_valid checks if it's
             # a valid sequence of numbers. This doesn't cover "is this number registered to an MNO".
             # For example UK numbers cannot start "06" as that hasn't been assigned to a purpose by ofcom
-            raise InvalidPhoneError(code=InvalidPhoneError.Codes.INVALID_NUMBER)
+            if self._is_tv_number(number):
+                return number
+            else:
+                raise InvalidPhoneError(code=InvalidPhoneError.Codes.INVALID_NUMBER)
 
         return number
+
+    @staticmethod
+    def _is_tv_number(phone_number) -> bool:
+        """
+        The phonenumbers library does not consider TV numbers (fake numbers OFCOM reserves use in TV, film etc)
+        valid. This method checks whether a normalised phone number that has failed the library's validation is
+        in fact a valid TV number
+        """
+        phone_number_as_string = str(phone_number.national_number)
+        if re.match("7700[900000-900999]", phone_number_as_string):
+            return True
 
     @staticmethod
     def _thoroughly_normalise_number(phone_number: str) -> str:

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "81.1.0"  # 151ab871231fba7feb2eb8c23c908da9
+__version__ = "81.1.1"  # 43e5473167e33eed2d599e31aeda43ef

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -543,3 +543,11 @@ class TestPhoneNumberClass:
         with pytest.raises(InvalidPhoneError) as exc:
             PhoneNumber(phone_number, allow_international=True)
         assert exc.value.code == expected_error_code
+
+    @pytest.mark.parametrize(
+        "phone_number, expected_valid_number",
+        [("07700900010", "447700900010"), ("447700900020", "447700900020"), ("+447700900030", "447700900030")],
+    )
+    def test_tv_number_passes(self, phone_number, expected_valid_number):
+        number = PhoneNumber(phone_number, allow_international=True)
+        assert expected_valid_number == str(number)


### PR DESCRIPTION
Adds validation logic allowing UK mobile numbers reserved by OFCOM for use in TV and Radio dramas, as these are (correctly) considered in valid by the `phonenumbers` library.

This fix prevents a number of unit tests in notifications-api from failing (as they use TV numbers in their testing).