### PR TITLE
Add validation for fixed abode addresses to `PostalAddress`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 82.0.0
+
+* Change `PostalAddress` to add `has_no_fixed_abode_address` method. No fixed abode addresses are now considered invalid.
+
 ## 81.1.1
 *  Adds condition to validation to allow TV Numbers (https://www.ofcom.org.uk/phones-and-broadband/phone-numbers/numbers-for-drama/) for UK mobiles
 

--- a/notifications_utils/recipient_validation/postal_address.py
+++ b/notifications_utils/recipient_validation/postal_address.py
@@ -147,6 +147,19 @@ class PostalAddress:
         )
 
     @property
+    def has_no_fixed_abode_address(self):
+        """
+        We don't want users to sent to no fixed abode addresses, so validate that
+        - no lines just consist of "NFA" (case insensitive)
+        - the address does not contain "no fixed abode" or "no fixed address" (case insensitive)
+        """
+        if any(line.lower() == "nfa" for line in self.normalised_lines):
+            return True
+        if re.search(r"no fixed (abode|address)", self.normalised, re.IGNORECASE):
+            return True
+        return False
+
+    @property
     def has_invalid_country_for_bfpo_address(self):
         """We don't want users to specify the country if they provide a BFPO number. Some BFPO numbers may resolve
         to non-UK addresses, but this will be handled as part of the BFPO delivery."""
@@ -220,6 +233,7 @@ class PostalAddress:
             and not self.has_too_many_lines
             and not self.has_invalid_characters
             and not (self.international and self.is_bfpo_address)
+            and not self.has_no_fixed_abode_address
         )
 
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "81.1.1"  # 43e5473167e33eed2d599e31aeda43ef
+__version__ = "82.0.0"  # bcab8038b94ee470f6dae8bd7893619f

--- a/tests/recipient_validation/test_postal_address.py
+++ b/tests/recipient_validation/test_postal_address.py
@@ -276,6 +276,75 @@ def test_has_invalid_characters(address, expected_result):
 
 
 @pytest.mark.parametrize(
+    "address, expected_result",
+    [
+        (
+            "",
+            False,
+        ),
+        (
+            """
+        123 Example Street
+        NFA NFA2024
+        SW1 A 1 AA
+        """,
+            False,
+        ),
+        (
+            """
+        User with no Fixed Address,
+        London
+        SW1 A 1 AA
+        """,
+            True,
+        ),
+        (
+            """
+        A Person
+        NFA
+        SW1A 1AA
+        """,
+            True,
+        ),
+        (
+            """
+        A Person
+        NFA,
+        SW1A 1AA
+        """,
+            True,
+        ),
+        (
+            """
+        A Person
+        no fixed Abode
+        SW1A 1AA
+        """,
+            True,
+        ),
+        (
+            """
+        A Person
+        NO FIXED ADDRESS
+        SW1A 1AA
+        """,
+            True,
+        ),
+        (
+            """
+        nfa
+        Berlin
+        Deutschland
+        """,
+            True,
+        ),
+    ],
+)
+def test_has_no_fixed_abode_address(address, expected_result):
+    assert PostalAddress(address).has_no_fixed_abode_address is expected_result
+
+
+@pytest.mark.parametrize(
     "address, expected_international",
     (
         (
@@ -749,6 +818,15 @@ def test_format_postcode_for_printing(postcode, postcode_with_space):
         ),
         (
             """
+            House
+            No fixed abode
+            France
+        """,
+            False,
+            False,
+        ),
+        (
+            """
             No postcode or country
             Service can’t send internationally
             3
@@ -839,6 +917,12 @@ def test_valid_last_line_too_short_too_long(address):
 def test_valid_with_invalid_characters():
     address = "Valid\nExcept\n[For one character\nBhutan\n"
     assert PostalAddress(address, allow_international_letters=True).valid is False
+
+
+def test_valid_with_nfa_address():
+    postal_address = PostalAddress("User\nNo fixed abode\nSW1 1AA")
+    assert postal_address.valid is False
+    assert postal_address.has_valid_last_line is True
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The `has_no_fixed_abode_address` method checks that no address lines
simply consist of "NFA" or "NFA," and that "no fixed address" or "no
fixed abode" is not in the address (all case insensitive). Letters sent
to no fixed abode addresses have been causing issues since they often
contain invalid addresses and weren't intended to be sent.