### PR TITLE
disallow premium numbers when validating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,16 @@
 # CHANGELOG
 
+## 82.3.0
+* Extends the validation logic for the `PhoneNumber` class to disallow premium rate numbers
+
 ## 82.2.1
 
 * Add fix to recipient_validation/phone_number.py to raise correct error if a service tries to send to an international number without that permission
 
 ## 82.2.0
-
 * Add `unsubscribe_link` argument to email templates
 
 ## 82.1.2
-
 * Write updated version number to `requirements.txt` if no `requirements.in` file found
 
 ## 82.1.1

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "82.2.1"  # dec63cb8da7dab6a8ff9993e711d3c96
+__version__ = "82.3.0"  # c6ba6a75ce00d7c25a2c8fbfe9fb1dcb

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -58,11 +58,6 @@ valid_uk_landlines = [
     "020 7946 0991",  # london
     "030 1234 5678",  # non-geographic
     "0550 123 4567",  # corporate numbering and voip services
-    "0800 123 4567",  # freephone
-    "0800 123 456",  # shorter freephone
-    "0800 11 11",  # shortest freephone
-    "0845 46 46",  # short premium
-    "0900 123 4567",  # premium
 ]
 
 invalid_uk_landlines = [
@@ -71,6 +66,8 @@ invalid_uk_landlines = [
     "0300 46 46",  # short but not 01x or 08x
     "0800 11 12",  # short but not 01x or 08x
     "0845 46 31",  # short but not 01x or 08x
+    "0845 46 46",  # short premium
+    "0900 123 4567",  # premium
 ]
 
 invalid_uk_mobile_phone_numbers = sum(


### PR DESCRIPTION
Premium rate numbers are a known vector of attack. This updates the phonenumber validation code to raise an exception and fail if a service tries to create an sms notification destined for a premium rate number.