### PR TITLE
Fix the way we log the request_size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 82.1.1
+*  Fix the way we log the request_size. Accessing the data at this point can trigger a validation error early and cause a 500 error
+
 ## 82.1.0
 *  Adds new logging fields to request logging. Namely environment_name, request_size and response_size
 

--- a/notifications_utils/logging/__init__.py
+++ b/notifications_utils/logging/__init__.py
@@ -26,7 +26,7 @@ def _common_request_extra_log_context():
         "method": request.method,
         "url": request.url,
         "environment": current_app.config["NOTIFY_ENVIRONMENT"] if "NOTIFY_ENVIRONMENT" in current_app.config else "",
-        "request_size": len(request.data),
+        "request_size": request.content_length if request.content_length is not None else 0,
         "endpoint": request.endpoint,
         "remote_addr": request.remote_addr,
         "user_agent": request.user_agent.string,

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "82.1.0"  # 450091ac5e62d2eb58f0bb3f9b5032a0
+__version__ = "82.1.1"  # 30e69c4868a9dd1981c0d79c8677d2c4


### PR DESCRIPTION
What
----

Fix the way we log the request_size.

Why
---

Accessing the data at this point can trigger a validation error early and cause a 500 error.