### PR TITLE
Add `unsubscribe_link` argument to email templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 82.2.0
+
+* Add `unsubscribe_link` argument to email templates
 
 ## 82.1.2
 

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -402,12 +402,22 @@ class SubjectMixin:
 class BaseEmailTemplate(SubjectMixin, Template):
     template_type = "email"
 
+    def __init__(self, template, values=None, unsubscribe_link=None, **kwargs):
+        self.unsubscribe_link = unsubscribe_link
+        super().__init__(template, values, **kwargs)
+
+    @property
+    def content_with_unsubscribe_link(self):
+        if self.unsubscribe_link:
+            return f"{self.content}\n\n---\n\n[Unsubscribe from these emails]({self.unsubscribe_link})"
+        return self.content
+
     @property
     def html_body(self):
         return (
             Take(
                 Field(
-                    self.content,
+                    self.content_with_unsubscribe_link,
                     self.values,
                     html="escape",
                     markdown_lists=True,
@@ -462,7 +472,7 @@ class BaseEmailTemplate(SubjectMixin, Template):
 class PlainTextEmailTemplate(BaseEmailTemplate):
     def __str__(self):
         return (
-            Take(Field(self.content, self.values, html="passthrough", markdown_lists=True))
+            Take(Field(self.content_with_unsubscribe_link, self.values, html="passthrough", markdown_lists=True))
             .then(unlink_govuk_escaped)
             .then(strip_unsupported_characters)
             .then(add_trailing_newline)
@@ -505,8 +515,9 @@ class HTMLEmailTemplate(BaseEmailTemplate):
         brand_colour=None,
         brand_banner=False,
         brand_alt_text=None,
+        **kwargs,
     ):
-        super().__init__(template, values)
+        super().__init__(template, values, **kwargs)
         self.govuk_banner = govuk_banner
         self.complete_html = complete_html
         self.brand_logo = brand_logo
@@ -562,8 +573,9 @@ class EmailPreviewTemplate(BaseEmailTemplate):
         reply_to=None,
         show_recipient=True,
         redact_missing_personalisation=False,
+        **kwargs,
     ):
-        super().__init__(template, values, redact_missing_personalisation=redact_missing_personalisation)
+        super().__init__(template, values, redact_missing_personalisation=redact_missing_personalisation, **kwargs)
         self.from_name = from_name
         self.reply_to = reply_to
         self.show_recipient = show_recipient

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "82.1.2"  # 277b159c4272d04e2cca81ea7a754fc9
+__version__ = "82.2.0"  # dec63cb8da7dab6a8ff9993e711d3c96

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -2439,3 +2439,61 @@ def test_rendered_letter_template_for_print_can_toggle_notify_tag_and_always_hid
     )
     assert ("content: 'NOTIFY';" in str(template)) == should_have_notify_tag
     assert "#mdi,\n  #barcode,\n  #qrcode {\n    display: none;\n  }" in str(template).strip()
+
+
+@pytest.mark.parametrize(
+    "template_class, expected_content",
+    (
+        (
+            EmailPreviewTemplate,
+            (
+                '<hr style="border: 0; height: 1px; background: #B1B4B6; Margin: 30px 0 30px 0;">'
+                '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
+                '<a style="word-wrap: break-word; color: #1D70B8;" href="https://www.example.com">'
+                "Unsubscribe from these emails"
+                "</a>"
+                "</p>\n"
+            ),
+        ),
+        (
+            HTMLEmailTemplate,
+            (
+                '<hr style="border: 0; height: 1px; background: #B1B4B6; Margin: 30px 0 30px 0;">'
+                '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">'
+                '<a style="word-wrap: break-word; color: #1D70B8;" href="https://www.example.com">'
+                "Unsubscribe from these emails"
+                "</a>"
+                "</p>\n"
+            ),
+        ),
+        (
+            PlainTextEmailTemplate,
+            (
+                "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n"
+                "\n"
+                "Unsubscribe from these emails: https://www.example.com\n"
+            ),
+        ),
+    ),
+)
+def test_unsubscribe_link_is_rendered(
+    template_class,
+    expected_content,
+):
+    assert expected_content in (
+        str(
+            template_class(
+                {"content": "Hello world", "subject": "subject", "template_type": "email"},
+                {},
+                unsubscribe_link="https://www.example.com",
+            )
+        )
+    )
+    assert expected_content not in (
+        str(
+            template_class(
+                {"content": "Hello world", "subject": "subject", "template_type": "email"},
+                {},
+            )
+        )
+    )


### PR DESCRIPTION
We have started sending `list-unsubscribe` headers if a user marks a template as unsubscribeable, for teams who aren’t using the API.

However we are already telling these teams to add unsubscribe links to the body of their emails.

This means:
- there are two different ways to add unsubscribe links
- user will have to manage requests to unsubscribe coming from two different places

This will be confusing, and make it harder for us to write good guidance that users will be able to follow, and harder to explain what the ‘let users unsubscribe from these emails’ checkbox does.

If we have a confusing product proposition and users cant follow our guidance then we risk our spam score rising.

This commit adds a way to insert an unsubscribe link (which we will generate) to the footer of every email. The API can then start generating these links, and the admin app can start responding to them.

We can then report unsubscribes back to the team in the same way, no matter if the recipient has clicked the button in their email client or the link at the end of the email.

***

<img width="784" alt="image" src="https://github.com/user-attachments/assets/b5979b57-44a8-483c-83c6-4e577460e78c">
