### PR TITLE
Write to `requirements.txt` if `requirements.in` doesn’t exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+
+## 82.1.2
+
+* Write updated version number to `requirements.txt` if no `requirements.in` file found
+
 ## 82.1.1
 *  Fix the way we log the request_size. Accessing the data at this point can trigger a validation error early and cause a 500 error
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "82.1.1"  # 30e69c4868a9dd1981c0d79c8677d2c4
+__version__ = "82.1.2"  # 277b159c4272d04e2cca81ea7a754fc9

--- a/notifications_utils/version_tools.py
+++ b/notifications_utils/version_tools.py
@@ -58,11 +58,16 @@ def write_version_to_requirements_file(version):
             return f"notifications-utils @ git+https://github.com/{repo_name}.git@{version}\n"
         return line
 
+    if requirements_file.exists():
+        requirements_file_to_modify = requirements_file
+    else:
+        requirements_file_to_modify = frozen_requirements_file
+
     new_requirements_file_contents = "".join(
-        replace_line(line) for line in requirements_file.read_text().splitlines(True)
+        replace_line(line) for line in requirements_file_to_modify.read_text().splitlines(True)
     )
 
-    requirements_file.write_text(new_requirements_file_contents)
+    requirements_file_to_modify.write_text(new_requirements_file_contents)
 
 
 def get_relevant_changelog_lines(current_version, newest_version):


### PR DESCRIPTION
Not all of our repos freeze their requirements from a `requirements.in` file into a `requirements.txt` file.

Some have only a `requirements.txt` file which is edited directly.

So our version script should write to that instead, if it can’t find a `requirements.in` file.