### PR TITLE
Fix validation error for international numbers for services without international permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 82.2.1
+
+* Add fix to recipient_validation/phone_number.py to raise correct error if a service tries to send to an international number without that permission
+
 ## 82.2.0
 
 * Add `unsubscribe_link` argument to email templates

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "82.2.0"  # dec63cb8da7dab6a8ff9993e711d3c96
+__version__ = "82.2.1"  # dec63cb8da7dab6a8ff9993e711d3c96

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -551,3 +551,18 @@ class TestPhoneNumberClass:
     def test_tv_number_passes(self, phone_number, expected_valid_number):
         number = PhoneNumber(phone_number, allow_international=True)
         assert expected_valid_number == str(number)
+
+    @pytest.mark.parametrize(
+        "phone_number, expected_error_code",
+        [
+            ("+14158961600", InvalidPhoneError.Codes.NOT_A_UK_MOBILE),
+            ("+3225484211", InvalidPhoneError.Codes.NOT_A_UK_MOBILE),
+            ("+1 202-483-3000", InvalidPhoneError.Codes.NOT_A_UK_MOBILE),
+            ("+7 495 308-78-41", InvalidPhoneError.Codes.NOT_A_UK_MOBILE),
+            ("+74953087842", InvalidPhoneError.Codes.NOT_A_UK_MOBILE),
+        ],
+    )
+    def test_international_does_not_normalise_to_uk_number(self, phone_number, expected_error_code):
+        with pytest.raises(InvalidPhoneError) as exc:
+            PhoneNumber(phone_number, allow_international=False)
+        assert exc.value.code == expected_error_code


### PR DESCRIPTION
Separate out check for if service can't send to international but tries to

When this check was happening with all the rest of the number validation, when it failed we re-run it with a throoghly normalised number, which made phonenumbers libary think it's a UK landline that's too long for US numbers.

When we do it separately, we raise the NOT_A_UK_MOBILE error as we should, and we don't try to overnormalise when we get it.