### PR TITLE
Add new areas to international billing rates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 82.4.0
+
+* Add support for sending SMS to more international numbers. Sending to Eritrea, Wallis and Futuna, Niue, Kiribati, and Tokelau is now supported.
+
 ## 82.3.0
 * Extends the validation logic for the `PhoneNumber` class to disallow premium rate numbers
 

--- a/notifications_utils/international_billing_rates.yml
+++ b/notifications_utils/international_billing_rates.yml
@@ -1371,6 +1371,19 @@
   billable_units: 2
   names:
   - Comoros
+'291':
+  attributes:
+    alpha: 'YES'
+    comment: null
+    dlr: 'YES'
+    generic_sender: null
+    numeric: 'YES'
+    sc: null
+    sender_and_registration_info: null
+    text_restrictions: null
+  billable_units: 4
+  names:
+  - Eritrea
 '297':
   attributes:
     alpha: null
@@ -2204,6 +2217,19 @@
   billable_units: 3
   names:
   - Palau
+'681':
+  attributes:
+    alpha: 'YES'
+    comment: null
+    dlr: Carrier DLR
+    generic_sender: null
+    numeric: 'YES'
+    sc: null
+    sender_and_registration_info: null
+    text_restrictions: null
+  billable_units: 4
+  names:
+  - Wallis and Futuna
 '682':
   attributes:
     alpha: null
@@ -2217,6 +2243,19 @@
   billable_units: 3
   names:
   - Cook Islands
+'683':
+  attributes:
+    alpha: 'YES'
+    comment: null
+    dlr: Carrier DLR
+    generic_sender: null
+    numeric: 'YES'
+    sc: null
+    sender_and_registration_info: null
+    text_restrictions: null
+  billable_units: 4
+  names:
+  - Niue
 '685':
   attributes:
     alpha: null
@@ -2230,6 +2269,19 @@
   billable_units: 3
   names:
   - Samoa
+'686':
+  attributes:
+    alpha: 'YES'
+    comment: null
+    dlr: Carrier DLR
+    generic_sender: null
+    numeric: 'YES'
+    sc: null
+    sender_and_registration_info: null
+    text_restrictions: null
+  billable_units: 4
+  names:
+  - Kiribati
 '687':
   attributes:
     alpha: 'YES'
@@ -2256,6 +2308,19 @@
   billable_units: 2
   names:
   - French Polynesia
+'690':
+  attributes:
+    alpha: 'YES'
+    comment: null
+    dlr: Carrier DLR
+    generic_sender: null
+    numeric: 'YES'
+    sc: null
+    sender_and_registration_info: null
+    text_restrictions: null
+  billable_units: 4
+  names:
+  - Tokelau
 '691':
   attributes:
     alpha: null

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "82.3.0"  # c6ba6a75ce00d7c25a2c8fbfe9fb1dcb
+__version__ = "82.4.0"  # 4b2b1200cd9552377dbbae4704df096b

--- a/tests/test_international_billing_rates.py
+++ b/tests/test_international_billing_rates.py
@@ -30,7 +30,7 @@ def test_international_billing_rates_are_in_correct_format(country_prefix, value
 
 
 def test_country_codes():
-    assert len(COUNTRY_PREFIXES) == 215
+    assert len(COUNTRY_PREFIXES) == 220
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This adds the following to `international_billing_rates.yml` so that we can send SMS to them:
* Eritrea
* Wallis and Futuna
* Niue
* Kiribati
* Tokelau