### PR TITLE
Bump test requirements to the latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,12 @@ repos:
   - id: check-yaml
   - id: debug-statements
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.3.7'
+  rev: 'v0.6.4'
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
 - repo: https://github.com/psf/black
-  rev: 24.4.0
+  rev: 24.8.0
   hooks:
     - id: black
       name: black (python)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 82.7.0
+
+* Bump versions of common test dependencies (run `make bootstrap` to copy these into your app)
+
 # 82.6.1
 
 * Adds validation check to `PhoneNumber` so that it returns the expected error message `TOO_SHORT` if an empty string is passed. This has caused issues with users of the v2 API getting inconsistent error messages

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "82.6.1"  # b4df1ae664036399e4b5661f55b2d3e5
+__version__ = "82.7.0"  # 0351e385960ad4dcd89342dcb4563721

--- a/requirements_for_test_common.txt
+++ b/requirements_for_test_common.txt
@@ -1,12 +1,12 @@
-beautifulsoup4==4.11.1
-pytest==7.2.0
-pytest-env==0.8.1
-pytest-mock==3.9.0
-pytest-xdist==3.0.2
-pytest-testmon==2.1.0
+beautifulsoup4==4.12.3
+pytest==8.3.2
+pytest-env==1.1.3
+pytest-mock==3.14.0
+pytest-xdist==3.6.1
+pytest-testmon==2.1.1
 pytest-watch==4.2.0
-requests-mock==1.10.0
-freezegun==1.2.2
+requests-mock==1.12.1
+freezegun==1.5.1
 
-black==24.4.0  # Also update `.pre-commit-config.yaml` if this changes
-ruff==0.3.7  # Also update `.pre-commit-config.yaml` if this changes
+black==24.8.0  # Also update `.pre-commit-config.yaml` if this changes
+ruff==0.6.4  # Also update `.pre-commit-config.yaml` if this changes

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -20,8 +20,8 @@ def test_get_handlers_sets_up_logging_appropriately_with_debug():
     handlers = logging.get_handlers(app, extra_filters=[])
 
     assert len(handlers) == 1
-    assert type(handlers[0]) == builtin_logging.StreamHandler
-    assert type(handlers[0].formatter) == logging.Formatter
+    assert type(handlers[0]) is builtin_logging.StreamHandler
+    assert type(handlers[0].formatter) is logging.Formatter
 
 
 def test_get_handlers_sets_up_logging_appropriately_without_debug():
@@ -37,8 +37,8 @@ def test_get_handlers_sets_up_logging_appropriately_without_debug():
     handlers = logging.get_handlers(app, extra_filters=[])
 
     assert len(handlers) == 1
-    assert type(handlers[0]) == builtin_logging.StreamHandler
-    assert type(handlers[0].formatter) == logging.JSONFormatter
+    assert type(handlers[0]) is builtin_logging.StreamHandler
+    assert type(handlers[0].formatter) is logging.JSONFormatter
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Mainly doing this because the output of Pytest is much nicer in version 8 (see below). But I figure it can’t hurt to get bug fixes and improvements from the other dependencies too.

# Before

<img width="853" alt="Screenshot 2024-08-09 at 10 44 27" src="https://github.com/user-attachments/assets/fecefdcd-893e-4391-946a-6552eecfb9db">

# After

<img width="852" alt="Screenshot 2024-08-09 at 10 48 07" src="https://github.com/user-attachments/assets/1c3296e2-1a6a-4682-ba8f-1e0f7a0224ed">
