### PR TITLE
RecipientsCSV validates UK landlines for services with sms_to_uk_landlines enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 82.5.0
+
+* Add support for validation of UK landlines for services with sms_to_uk_landlines enabled using CSV flow
+
 ## 82.4.0
 
 * Add support for sending SMS to more international numbers. Sending to Eritrea, Wallis and Futuna, Niue, Kiribati, and Tokelau is now supported.

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "82.4.0"  # 4b2b1200cd9552377dbbae4704df096b
+__version__ = "82.5.0"  # 6f61f59189d11bdb2c96fc37faafe2d1

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -737,6 +737,39 @@ def test_international_recipients(file_contents, rows_with_bad_recipients):
     assert _index_rows(recipients.rows_with_bad_recipients) == rows_with_bad_recipients
 
 
+@pytest.mark.parametrize(
+    "file_contents,rows_with_bad_recipients",
+    [
+        (
+            """
+            phone number
+            800000000000
+            1234
+            +447900123
+        """,
+            {0, 1, 2},
+        ),
+        (
+            """
+            phone number
+            +441709510122
+            020 3002 4300
+            44117 925 1001
+
+        """,
+            set(),
+        ),
+    ],
+)
+def test_sms_to_uk_landlines(file_contents, rows_with_bad_recipients):
+    recipients = RecipientCSV(
+        file_contents,
+        template=_sample_template("sms"),
+        allow_sms_to_uk_landline=True,
+    )
+    assert _index_rows(recipients.rows_with_bad_recipients) == rows_with_bad_recipients
+
+
 def test_errors_when_too_many_rows():
     recipients = RecipientCSV(
         "email address\n" + ("a@b.com\n" * 101),


### PR DESCRIPTION
updates RecipientsCSV to use new validation code for services with sms_to_uk_landlines enabled

CSV validation currently fails on admin if a csv file contains a valid UK landline number. This update will let us add the required logic to admin, to validate against the latest validation code which allows UK landlines for services with this feature enabled