### PR TITLE
add `LazyLocalGetter` and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 82.6.0
+
+* Add LazyLocalGetter class for lazily-initialized context-local resources
+
 ## 82.5.0
 
 * Add support for validation of UK landlines for services with sms_to_uk_landlines enabled using CSV flow

--- a/notifications_utils/local_vars.py
+++ b/notifications_utils/local_vars.py
@@ -1,0 +1,34 @@
+from collections.abc import Callable
+from contextvars import ContextVar
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class LazyLocalGetter(Generic[T]):
+    """
+    Wrapper for lazily-constructed context-local resources
+    """
+
+    context_var: ContextVar[T | None]
+    factory: Callable[[], T]
+
+    def __init__(self, context_var: ContextVar[T | None], factory: Callable[[], T]):
+        """
+        Given a reference to a `context_var`, the resulting instance will be a callable that
+        returns the current context's contents of that `context_var`, pre-populating it with
+        the results of a (zero-argument) call to `factory` if it is empty or None
+        """
+        self.context_var = context_var
+        self.factory = factory
+
+    def __call__(self) -> T:
+        r = self.context_var.get(None)
+        if r is None:
+            r = self.factory()
+            self.context_var.set(r)
+
+        return r
+
+    def clear(self) -> None:
+        self.context_var.set(None)

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "82.5.0"  # 6f61f59189d11bdb2c96fc37faafe2d1
+__version__ = "82.6.0"  # 5c32a8390c476

--- a/tests/test_local_vars.py
+++ b/tests/test_local_vars.py
@@ -1,0 +1,44 @@
+from contextvars import ContextVar
+from itertools import count
+from unittest import mock
+
+from notifications_utils.local_vars import LazyLocalGetter
+
+
+def test_lazy_local_getter_reuses_first_constructed(request):
+    # we're not supposed to construct ContextVars inside functions because they can't
+    # really be garbage-collected, but otherwise it's difficult to ensure we're getting
+    # a "clean" ContextVar for this test
+    cv = ContextVar(request.node.name)  # ensure name is unique across test session
+
+    factory = mock.Mock(
+        spec=("__call__",),
+        side_effect=(getattr(mock.sentinel, f"some_object_{i}") for i in count()),
+    )
+
+    llg = LazyLocalGetter(cv, factory)
+
+    assert llg() is mock.sentinel.some_object_0
+    assert llg() is mock.sentinel.some_object_0
+
+    assert factory.call_args_list == [mock.call()]  # despite two accesses
+
+
+def test_lazy_local_getter_clear(request):
+    # ...same caveat about locally-declared ContextVar...
+    cv = ContextVar(request.node.name)  # ensure name is unique across test session
+
+    factory = mock.Mock(
+        spec=("__call__",),
+        side_effect=(getattr(mock.sentinel, f"some_object_{i}") for i in count()),
+    )
+
+    llg = LazyLocalGetter(cv, factory)
+
+    assert llg() is mock.sentinel.some_object_0
+    assert factory.call_args_list == [mock.call()]
+    factory.reset_mock()
+
+    llg.clear()
+    assert llg() is mock.sentinel.some_object_1
+    assert factory.call_args_list == [mock.call()]


### PR DESCRIPTION
Distant yak-shave ultimately for https://trello.com/c/ORGrd1jn/498-upgrade-docker-images-for-our-ecs-apps-to-debian-bookworm

The intention is to use this in apps where we need to move from (ab)using globals to context/thread-local pseudo-globals. This is because some of those resources currently referenced through globals need changes that will make them thread-unsafe, and it's cleaner pushing the thread-safety concerns out of those resources than internalizing it.