### PR TITLE
Add allow landline flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 85.0.0
+
+* BREAKING CHANGE: The `Phonenumber` class now accepts a flag `allow_landline`, which defaults to False. This changes the previous default behaviour, allowing landlines.
+
 ## 84.3.0
 
 * Reverts 84.1.0

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -321,10 +321,10 @@ class RecipientCSV:
                     email_address.validate_email_address(value)
                 if self.template_type == "sms":
                     if self.allow_sms_to_uk_landline:
-                        PhoneNumber(
-                            value,
-                            allow_international=self.allow_international_sms,
-                            allow_landline=self.allow_sms_to_uk_landline,
+                        number = PhoneNumber(value)
+                        number.validate(
+                            allow_international_number=self.allow_international_sms,
+                            allow_uk_landline=self.allow_sms_to_uk_landline,
                         )
                     else:
                         phone_number.validate_phone_number(

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -321,9 +321,16 @@ class RecipientCSV:
                     email_address.validate_email_address(value)
                 if self.template_type == "sms":
                     if self.allow_sms_to_uk_landline:
-                        PhoneNumber(value, allow_international=self.allow_international_sms)
+                        PhoneNumber(
+                            value,
+                            allow_international=self.allow_international_sms,
+                            allow_landline=self.allow_sms_to_uk_landline,
+                        )
                     else:
-                        phone_number.validate_phone_number(value, international=self.allow_international_sms)
+                        phone_number.validate_phone_number(
+                            value,
+                            international=self.allow_international_sms,
+                        )
             except InvalidRecipientError as error:
                 return str(error)
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "84.3.0"  # e8f0e1b3e2ed73b2e0962487a0292e38
+__version__ = "85.0.0"  # 3ddeb73a2a12440eb7213b918b644d08

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -410,7 +410,7 @@ class TestPhoneNumberClass:
     @pytest.mark.parametrize("phone_number", invalid_uk_landlines)
     def test_rejects_invalid_uk_landlines(self, phone_number):
         with pytest.raises(InvalidPhoneError) as e:
-            PhoneNumber(phone_number, allow_international=False)
+            PhoneNumber(phone_number, allow_international=False, allow_landline=True)
         assert e.value.code == InvalidPhoneError.Codes.INVALID_NUMBER
 
     @pytest.mark.parametrize(
@@ -437,7 +437,13 @@ class TestPhoneNumberClass:
 
     @pytest.mark.parametrize("phone_number", valid_uk_landlines)
     def test_allows_valid_uk_landlines(self, phone_number):
-        assert PhoneNumber(phone_number, allow_international=True).is_uk_phone_number() is True
+        assert PhoneNumber(phone_number, allow_international=True, allow_landline=True).is_uk_phone_number() is True
+
+    @pytest.mark.parametrize("phone_number", valid_uk_landlines)
+    def test_rejects_valid_uk_landlines_if_allow_landline_is_false(self, phone_number):
+        with pytest.raises(InvalidPhoneError) as exc:
+            PhoneNumber(phone_number, allow_international=True, allow_landline=False)
+        assert exc.value.code == InvalidPhoneError.Codes.NOT_A_UK_MOBILE
 
     @pytest.mark.parametrize("phone_number, expected_info", international_phone_info_fixtures)
     def test_get_international_phone_info(self, phone_number, expected_info):
@@ -516,7 +522,7 @@ class TestPhoneNumberClass:
         ],
     )
     def test_validate_normalised_succeeds(self, phone_number, expected_normalised_number):
-        normalised_number = PhoneNumber(phone_number, allow_international=True)
+        normalised_number = PhoneNumber(phone_number, allow_international=True, allow_landline=True)
         assert str(normalised_number) == expected_normalised_number
 
     # TODO: decide if all these tests are useful to have.
@@ -569,7 +575,7 @@ class TestPhoneNumberClass:
     )
     def test_international_does_not_normalise_to_uk_number(self, phone_number, expected_error_code):
         with pytest.raises(InvalidPhoneError) as exc:
-            PhoneNumber(phone_number, allow_international=False)
+            PhoneNumber(phone_number, allow_international=False, allow_landline=True)
         assert exc.value.code == expected_error_code
 
     # We discovered a bug with the phone_numbers library causing some valid JE numbers


### PR DESCRIPTION
The default behaviour of `notifications_utils.recipient_validation.phone_number.PhoneNumber` validates landline numbers. We want to be able to toggle this on or off _via_ a constructor argument so that this code can be used to validate phone numbers for **all** services, not just those with the `sms_to_uk_landline` permission.

This change adds the constructor argument `allow_landline` and makes changes to the validation code to throw an exception if a valid landline is passed when `allow_landline=False`.