### PR TITLE
Drop Girobank’s postcode from validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 84.0.1
+
+* Remove GIR 0AA from valid postcodes
+
 ## 84.0.0
 
 * `AntivirusClient` and `ZendeskClient` have returned to their behaviour as of 82.x.x to allow the 83.0.1 fix to go out to apps without the required changes.

--- a/notifications_utils/recipient_validation/postal_address.py
+++ b/notifications_utils/recipient_validation/postal_address.py
@@ -243,8 +243,7 @@ def normalise_postcode(postcode):
 
 def _is_a_real_uk_postcode(postcode):
     normalised = normalise_postcode(postcode)
-    # GIR0AA is Girobank
-    pattern = re.compile(rf"(({'|'.join(UK_POSTCODE_ZONES)})[0-9][0-9A-Z]?[0-9][A-BD-HJLNP-UW-Z]{{2}})|(GIR0AA)")
+    pattern = re.compile(rf"(({'|'.join(UK_POSTCODE_ZONES)})[0-9][0-9A-Z]?[0-9][A-BD-HJLNP-UW-Z]{{2}})")
     return bool(pattern.fullmatch(normalised))
 
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "84.0.0"  # e8765b4f80e01f
+__version__ = "84.0.1"  # 87c24ae9785f1425177135de028b83e8

--- a/tests/recipient_validation/test_postal_address.py
+++ b/tests/recipient_validation/test_postal_address.py
@@ -718,9 +718,8 @@ def test_normalise_postcode(postcode, normalised_postcode):
         ("BF1 3AA", True),
         ("BF13AA", True),
         (" BF2 0FR ", True),
-        # Giro Bank valid postcode and invalid postcode
-        ("GIR0AA", True),
-        ("GIR0AB", False),
+        # Giro Bank’s vanity postcode is deprecated
+        ("GIR0AA", False),
         # Gibraltar’s one postcode is not valid because it’s in the
         # Europe postal zone
         ("GX111AA", False),


### PR DESCRIPTION
This postcode hasn’t been used for a while:

> GIR 0AA […] is the traditional Postcode of Girobank, now part of the Santander group. This Postcode appears on the Postzon product but not on PAF® nor on other raw data products. 

– https://www.poweredbypaf.com/wp-content/uploads/2017/07/Latest-Programmers_guide_Edition-7-Version-6.pdf (2017)

If a postcode isn’t in PAF then it isn’t addressable so we shouldn’t try to send letters to it, and by removing it we can make our code a bit simpler.