### PR TITLE
AntivirusClient, ZendeskClient: use persistent requests sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 83.0.0
+
+* `AntivirusClient` and `ZendeskClient` are no longer thread-safe because they now use persistent requests sessions. Thread-local instances should be used in place of any global instances in any situations where threading is liable to be used
+* `AntivirusClient` and `ZendeskClient` have had their `init_app(...)` methods removed as this is an awkward pattern to use for initializing thread-local instances. It is recommended to use `LazyLocalGetter` to construct new instances on-demand, passing configuration parameters via the constructor arguments in a `factory` function.
+
 ## 82.7.0
 
 * Add `expected_type` mechanism to `LazyLocalGetter`

--- a/notifications_utils/clients/antivirus/antivirus_client.py
+++ b/notifications_utils/clients/antivirus/antivirus_client.py
@@ -21,13 +21,16 @@ class AntivirusError(Exception):
 
 
 class AntivirusClient:
+    """
+    A client for the antivirus API
+
+    This class is not thread-safe.
+    """
+
     def __init__(self, api_host=None, auth_token=None):
         self.api_host = api_host
         self.auth_token = auth_token
-
-    def init_app(self, app):
-        self.api_host = app.config["ANTIVIRUS_API_HOST"]
-        self.auth_token = app.config["ANTIVIRUS_API_KEY"]
+        self.requests_session = requests.Session()
 
     def scan(self, document_stream):
         headers = {"Authorization": f"Bearer {self.auth_token}"}
@@ -35,7 +38,7 @@ class AntivirusClient:
             headers.update(request.get_onwards_request_headers())
 
         try:
-            response = requests.post(
+            response = self.requests_session.post(
                 f"{self.api_host}/scan",
                 headers=headers,
                 files={"document": document_stream},

--- a/notifications_utils/clients/zendesk/zendesk_client.py
+++ b/notifications_utils/clients/zendesk/zendesk_client.py
@@ -48,6 +48,12 @@ class NotifySupportTicketComment:
 
 
 class ZendeskClient:
+    """
+    A client for the Zendesk API
+
+    This class is not thread-safe.
+    """
+
     # the account used to authenticate with. If no requester is provided, the ticket will come from this account.
     NOTIFY_ZENDESK_EMAIL = "zd-api-notify@digital.cabinet-office.gov.uk"
 
@@ -55,14 +61,12 @@ class ZendeskClient:
     ZENDESK_UPDATE_TICKET_URL = "https://govuk.zendesk.com/api/v2/tickets/{ticket_id}"
     ZENDESK_UPLOAD_FILE_URL = "https://govuk.zendesk.com/api/v2/uploads.json"
 
-    def __init__(self):
-        self.api_key = None
-
-    def init_app(self, app, *args, **kwargs):
-        self.api_key = app.config.get("ZENDESK_API_KEY")
+    def __init__(self, api_key):
+        self.api_key = api_key
+        self.requests_session = requests.Session()
 
     def send_ticket_to_zendesk(self, ticket):
-        response = requests.post(
+        response = self.requests_session.post(
             self.ZENDESK_TICKET_URL, json=ticket.request_data, auth=(f"{self.NOTIFY_ZENDESK_EMAIL}/token", self.api_key)
         )
 
@@ -91,7 +95,7 @@ class ZendeskClient:
 
         upload_url = self.ZENDESK_UPLOAD_FILE_URL + "?" + urlencode(query_params)
 
-        response = requests.post(
+        response = self.requests_session.post(
             upload_url,
             headers={"Content-Type": attachment.content_type},
             data=attachment.filedata,
@@ -137,7 +141,7 @@ class ZendeskClient:
             data["ticket"]["status"] = status.value
 
         update_url = self.ZENDESK_UPDATE_TICKET_URL.format(ticket_id=ticket_id)
-        response = requests.put(
+        response = self.requests_session.put(
             update_url,
             json=data,
             auth=(f"{self.NOTIFY_ZENDESK_EMAIL}/token", self.api_key),

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "82.7.0"  # b21ed1702bc409f764d6898e729430b7
+__version__ = "83.0.0"  # 9ec4c0e5f2c033df86cfa33627e3c483

--- a/tests/clients/antivirus/test_antivirus_client.py
+++ b/tests/clients/antivirus/test_antivirus_client.py
@@ -12,10 +12,10 @@ from notifications_utils.clients.antivirus.antivirus_client import (
 
 @pytest.fixture(scope="function")
 def app_antivirus_client(app, mocker):
-    client = AntivirusClient()
-    app.config["ANTIVIRUS_API_HOST"] = "https://antivirus"
-    app.config["ANTIVIRUS_API_KEY"] = "test-antivirus-key"
-    client.init_app(app)
+    client = AntivirusClient(
+        api_host="https://antivirus",
+        auth_token="test-antivirus-key",
+    )
     return app, client
 
 

--- a/tests/clients/zendesk/test_zendesk_client.py
+++ b/tests/clients/zendesk/test_zendesk_client.py
@@ -17,14 +17,8 @@ from notifications_utils.clients.zendesk.zendesk_client import (
 
 
 @pytest.fixture(scope="function")
-def zendesk_client(app):
-    client = ZendeskClient()
-
-    app.config["ZENDESK_API_KEY"] = "testkey"
-
-    client.init_app(app)
-
-    return client
+def zendesk_client():
+    return ZendeskClient(api_key="testkey")
 
 
 def test_zendesk_client_send_ticket_to_zendesk(zendesk_client, app, rmock, caplog):
@@ -63,7 +57,7 @@ def test_zendesk_client_send_ticket_to_zendesk_error(zendesk_client, app, rmock,
     assert "Zendesk create ticket request failed with 401 '{'foo': 'bar'}'" in caplog.messages
 
 
-def test_zendesk_client_send_ticket_to_zendesk_with_user_suspended_error(zendesk_client, rmock, caplog):
+def test_zendesk_client_send_ticket_to_zendesk_with_user_suspended_error(zendesk_client, app, rmock, caplog):
     rmock.request(
         "POST",
         ZendeskClient.ZENDESK_TICKET_URL,


### PR DESCRIPTION
On the long road to https://trello.com/c/ORGrd1jn/498-upgrade-docker-images-for-our-ecs-apps-to-debian-bookworm

This is a breaking change as it effectively makes these clients non-thread-safe. But it's better to declare them as non-thread-safe and only expect each to be used from one thread than to push all the complexity of managing different contexts into each class.