### PR TITLE
Empty strings for phone numbers return "TOO_SHORT" error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# 82.6.1
+
+* Adds validation check to `PhoneNumber` so that it returns the expected error message `TOO_SHORT` if an empty string is passed. This has caused issues with users of the v2 API getting inconsistent error messages
+
 ## 82.6.0
 
 * Add LazyLocalGetter class for lazily-initialized context-local resources

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # notifications-utils
 
-Shared Python code for GOV.UK Notify applications. Standardises how to do logging, rendering message templates, parsing spreadsheets, talking to external services and more. 
+Shared Python code for GOV.UK Notify applications. Standardises how to do logging, rendering message templates, parsing spreadsheets, talking to external services and more.
 
 ## Setting up
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # notifications-utils
 
-Shared Python code for GOV.UK Notify applications. Standardises how to do logging, rendering message templates, parsing spreadsheets, talking to external services and more.
+Shared Python code for GOV.UK Notify applications. Standardises how to do logging, rendering message templates, parsing spreadsheets, talking to external services and more. 
 
 ## Setting up
 

--- a/notifications_utils/recipient_validation/phone_number.py
+++ b/notifications_utils/recipient_validation/phone_number.py
@@ -203,6 +203,11 @@ class PhoneNumber:
         if chars - {*ALL_WHITESPACE + "()-+" + "0123456789"}:
             raise InvalidPhoneError(code=InvalidPhoneError.Codes.UNKNOWN_CHARACTER)
 
+    @staticmethod
+    def _raise_if_phone_number_is_empty(number: str) -> None:
+        if number == "":
+            raise InvalidPhoneError(code=InvalidPhoneError.Codes.TOO_SHORT)
+
     def validate_phone_number(self, phone_number: str) -> phonenumbers.PhoneNumber:
         """
         Validate a phone number and return the PhoneNumber object
@@ -215,6 +220,9 @@ class PhoneNumber:
           changes whether it is parsed as international or not.
         * Convert error codes to match existing Notify error codes
         """
+
+        self._raise_if_phone_number_is_empty(phone_number)
+
         # notify's old validation code is stricter than phonenumbers in not allowing letters etc, so need to catch some
         # of those cases separately before we parse with the phonenumbers library
         self._raise_if_phone_number_contains_invalid_characters(phone_number)

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "82.6.0"  # 5c32a8390c476
+__version__ = "82.6.1"  # b4df1ae664036399e4b5661f55b2d3e5

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -563,3 +563,11 @@ class TestPhoneNumberClass:
         with pytest.raises(InvalidPhoneError) as exc:
             PhoneNumber(phone_number, allow_international=False)
         assert exc.value.code == expected_error_code
+
+
+def test_empty_phone_number_is_rejected_with_correct_v2_error_message():
+    phone_number = ""
+    error_message = InvalidPhoneError(code=InvalidPhoneError.Codes.TOO_SHORT)
+    with pytest.raises(InvalidPhoneError) as e:
+        PhoneNumber(phone_number=phone_number, allow_international=True)
+    assert str(error_message) == str(e.value)


### PR DESCRIPTION
Adds validation check to PhoneNumber so that the error `TOO_SHORT` is raised if an empty string is passed into the object as a phone number

Users of the v2 api expect, and often require, consistent error messages to be returned from the API as their code often does comparisons against errors as strings to handle notify errors. In the case of empty strings, an error corresponding to InvalidPhoneError.Codes.TOO_SHORT is expected