### PR TITLE
`LazyLocalGetter` improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # CHANGELOG
 
+## 82.7.0
+
+* Add `expected_type` mechanism to `LazyLocalGetter`
+
 # 82.6.1
 
 * Adds validation check to `PhoneNumber` so that it returns the expected error message `TOO_SHORT` if an empty string is passed. This has caused issues with users of the v2 API getting inconsistent error messages
 
 ## 82.6.0
 
-* Add LazyLocalGetter class for lazily-initialized context-local resources
+* Add `LazyLocalGetter` class for lazily-initialized context-local resources
 
 ## 82.5.0
 

--- a/notifications_utils/local_vars.py
+++ b/notifications_utils/local_vars.py
@@ -12,20 +12,38 @@ class LazyLocalGetter(Generic[T]):
 
     context_var: ContextVar[T | None]
     factory: Callable[[], T]
+    expected_type: type[T] | None
 
-    def __init__(self, context_var: ContextVar[T | None], factory: Callable[[], T]):
+    def __init__(
+        self,
+        context_var: ContextVar[T | None],
+        factory: Callable[[], T],
+        expected_type: type[T] | None = None,
+    ):
         """
         Given a reference to a `context_var`, the resulting instance will be a callable that
         returns the current context's contents of that `context_var`, pre-populating it with
-        the results of a (zero-argument) call to `factory` if it is empty or None
+        the results of a (zero-argument) call to `factory` if it is empty or None.
+
+        If `expected_type` is specified, the `factory` call's return value is checked to be
+        of that type, but in return the `.expected_type` attribute is accessible without
+        triggering population.
         """
         self.context_var = context_var
         self.factory = factory
+        self.expected_type = expected_type
 
     def __call__(self) -> T:
         r = self.context_var.get(None)
         if r is None:
             r = self.factory()
+
+            # exact type testing here, none of your issubclass flexibility
+            if self.expected_type is not None and type(r) is not self.expected_type:
+                raise TypeError(
+                    f"factory returned value (of type {type(r)}) that is not of the expected type {self.expected_type}"
+                )
+
             self.context_var.set(r)
 
         return r

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "82.6.1"  # b4df1ae664036399e4b5661f55b2d3e5
+__version__ = "82.7.0"  # b21ed1702bc409f764d6898e729430b7


### PR DESCRIPTION
On the long road to https://trello.com/c/ORGrd1jn/498-upgrade-docker-images-for-our-ecs-apps-to-debian-bookworm

Because of the odd way the `api` app (at least) uses its api clients it becomes useful to be able to see a `LazyLocalGetter`'s inner type without populating it.

But to ensure this information is never *wrong* expose this as an _enforced_ `expected_type` mechanism.

~Also add `LazyLocalGetterResetter` which is (in this iteration) just a simple wrapper around a list that allows all the registered `LazyLocalGetter`s to be reset in a single call.~