### PR TITLE
Migrate `AssetFingerprinter` into utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 84.3.0
+
+* Adds `asset_fingerprinter.AssetFingerprinter` to replace the versions duplicated across our frontend apps
+
 ## 84.2.0
 
 * The Zendesk client takes a new optional argument, `user_created_at` which populates a new field on the Notify Zendesk form if provided.

--- a/notifications_utils/asset_fingerprinter.py
+++ b/notifications_utils/asset_fingerprinter.py
@@ -1,0 +1,45 @@
+import hashlib
+
+
+class AssetFingerprinter:
+    """
+    Get a unique hash for an asset file, so that it doesn't stay cached
+    when it changes
+
+    Usage:
+
+        in the application
+        template_data.asset_fingerprinter = AssetFingerprinter()
+
+        where template data is how you pass variables to every template.
+
+        in template.html:
+        {{ asset_fingerprinter.get_url('stylesheets/application.css') }}
+
+    * 'app/static' is assumed to be the root for all asset files
+    """
+
+    def __init__(self, asset_root="/static/", filesystem_path="app/static/"):
+        self._cache = {}
+        self._asset_root = asset_root
+        self._filesystem_path = filesystem_path
+
+    def get_url(self, asset_path, with_querystring_hash=True):
+        if not with_querystring_hash:
+            return self._asset_root + asset_path
+        if asset_path not in self._cache:
+            self._cache[asset_path] = (
+                self._asset_root + asset_path + "?" + self.get_asset_fingerprint(self._filesystem_path + asset_path)
+            )
+        return self._cache[asset_path]
+
+    def get_asset_fingerprint(self, asset_file_path):
+        return hashlib.md5(self.get_asset_file_contents(asset_file_path)).hexdigest()
+
+    def get_asset_file_contents(self, asset_file_path):
+        with open(asset_file_path, "rb") as asset_file:
+            contents = asset_file.read()
+        return contents
+
+
+asset_fingerprinter = AssetFingerprinter()

--- a/notifications_utils/asset_fingerprinter.py
+++ b/notifications_utils/asset_fingerprinter.py
@@ -1,4 +1,5 @@
 import hashlib
+import pathlib
 
 
 class AssetFingerprinter:
@@ -37,9 +38,7 @@ class AssetFingerprinter:
         return hashlib.md5(self.get_asset_file_contents(asset_file_path)).hexdigest()
 
     def get_asset_file_contents(self, asset_file_path):
-        with open(asset_file_path, "rb") as asset_file:
-            contents = asset_file.read()
-        return contents
+        return pathlib.Path(asset_file_path).read_bytes()
 
 
 asset_fingerprinter = AssetFingerprinter()

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "84.2.0"  # 6c167f6c73b099d58fdd5952e7c237b0
+__version__ = "84.3.0"  # 37dac8b3e2812ede962df582c8fe48ec

--- a/tests/test_asset_fingerprinter.py
+++ b/tests/test_asset_fingerprinter.py
@@ -55,7 +55,7 @@ class TestAssetFingerprint:
         js_hash = asset_fingerprinter.get_asset_fingerprint("application.js")
         assert js_hash != css_hash
 
-    def test_hash_gets_cached(self, mocker):
+    def test_gets_fingerprint_from_cache(self, mocker):
         get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
         get_file_content_mock.return_value = b"""
             body {

--- a/tests/test_asset_fingerprinter.py
+++ b/tests/test_asset_fingerprinter.py
@@ -1,0 +1,98 @@
+from notifications_utils.asset_fingerprinter import AssetFingerprinter
+
+
+class TestAssetFingerprint:
+    def test_url_format(self, mocker):
+        get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
+        get_file_content_mock.return_value = """
+            body {
+                font-family: nta;
+            }
+        """.encode(
+            "utf-8"
+        )
+        asset_fingerprinter = AssetFingerprinter(asset_root="/suppliers/static/")
+        assert (
+            asset_fingerprinter.get_url("application.css")
+            == "/suppliers/static/application.css?418e6f4a6cdf1142e45c072ed3e1c90a"  # noqa
+        )
+        assert (
+            asset_fingerprinter.get_url("application-ie6.css")
+            == "/suppliers/static/application-ie6.css?418e6f4a6cdf1142e45c072ed3e1c90a"  # noqa
+        )
+
+    def test_building_file_path(self, mocker):
+        get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
+        get_file_content_mock.return_value = """
+            document.write('Hello world!');
+        """.encode(
+            "utf-8"
+        )
+        fingerprinter = AssetFingerprinter()
+        fingerprinter.get_url("javascripts/application.js")
+        fingerprinter.get_asset_file_contents.assert_called_with("app/static/javascripts/application.js")
+
+    def test_hashes_are_consistent(self, mocker):
+        get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
+        get_file_content_mock.return_value = """
+            body {
+                font-family: nta;
+            }
+        """.encode(
+            "utf-8"
+        )
+        asset_fingerprinter = AssetFingerprinter()
+        assert asset_fingerprinter.get_asset_fingerprint(
+            "application.css"
+        ) == asset_fingerprinter.get_asset_fingerprint("same_contents.css")
+
+    def test_hashes_are_different_for_different_files(self, mocker):
+        get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
+        asset_fingerprinter = AssetFingerprinter()
+        get_file_content_mock.return_value = """
+            body {
+                font-family: nta;
+            }
+        """.encode(
+            "utf-8"
+        )
+        css_hash = asset_fingerprinter.get_asset_fingerprint("application.css")
+        get_file_content_mock.return_value = """
+            document.write('Hello world!');
+        """.encode(
+            "utf-8"
+        )
+        js_hash = asset_fingerprinter.get_asset_fingerprint("application.js")
+        assert js_hash != css_hash
+
+    def test_hash_gets_cached(self, mocker):
+        get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
+        get_file_content_mock.return_value = """
+            body {
+                font-family: nta;
+            }
+        """.encode(
+            "utf-8"
+        )
+        fingerprinter = AssetFingerprinter()
+        assert fingerprinter.get_url("application.css") == "/static/application.css?418e6f4a6cdf1142e45c072ed3e1c90a"
+        fingerprinter._cache["application.css"] = "a1a1a1"
+        assert fingerprinter.get_url("application.css") == "a1a1a1"
+        fingerprinter.get_asset_file_contents.assert_called_once_with("app/static/application.css")
+
+    def test_without_hash_if_requested(self, mocker):
+        fingerprinter = AssetFingerprinter()
+        assert (
+            fingerprinter.get_url(
+                "application.css",
+                with_querystring_hash=False,
+            )
+            == "/static/application.css"
+        )
+        assert fingerprinter._cache == {}
+
+
+class TestAssetFingerprintWithUnicode:
+    def test_can_read_self(self):
+        "Ralph’s apostrophe is a string containing a unicode character"
+        AssetFingerprinter(filesystem_path="tests/").get_url("test_asset_fingerprinter.py")

--- a/tests/test_asset_fingerprinter.py
+++ b/tests/test_asset_fingerprinter.py
@@ -4,13 +4,11 @@ from notifications_utils.asset_fingerprinter import AssetFingerprinter
 class TestAssetFingerprint:
     def test_url_format(self, mocker):
         get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
-        get_file_content_mock.return_value = """
+        get_file_content_mock.return_value = b"""
             body {
                 font-family: nta;
             }
-        """.encode(
-            "utf-8"
-        )
+        """
         asset_fingerprinter = AssetFingerprinter(asset_root="/suppliers/static/")
         assert (
             asset_fingerprinter.get_url("application.css")
@@ -23,24 +21,20 @@ class TestAssetFingerprint:
 
     def test_building_file_path(self, mocker):
         get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
-        get_file_content_mock.return_value = """
+        get_file_content_mock.return_value = b"""
             document.write('Hello world!');
-        """.encode(
-            "utf-8"
-        )
+        """
         fingerprinter = AssetFingerprinter()
         fingerprinter.get_url("javascripts/application.js")
         fingerprinter.get_asset_file_contents.assert_called_with("app/static/javascripts/application.js")
 
     def test_hashes_are_consistent(self, mocker):
         get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
-        get_file_content_mock.return_value = """
+        get_file_content_mock.return_value = b"""
             body {
                 font-family: nta;
             }
-        """.encode(
-            "utf-8"
-        )
+        """
         asset_fingerprinter = AssetFingerprinter()
         assert asset_fingerprinter.get_asset_fingerprint(
             "application.css"
@@ -49,31 +43,25 @@ class TestAssetFingerprint:
     def test_hashes_are_different_for_different_files(self, mocker):
         get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
         asset_fingerprinter = AssetFingerprinter()
-        get_file_content_mock.return_value = """
+        get_file_content_mock.return_value = b"""
             body {
                 font-family: nta;
             }
-        """.encode(
-            "utf-8"
-        )
+        """
         css_hash = asset_fingerprinter.get_asset_fingerprint("application.css")
-        get_file_content_mock.return_value = """
+        get_file_content_mock.return_value = b"""
             document.write('Hello world!');
-        """.encode(
-            "utf-8"
-        )
+        """
         js_hash = asset_fingerprinter.get_asset_fingerprint("application.js")
         assert js_hash != css_hash
 
     def test_hash_gets_cached(self, mocker):
         get_file_content_mock = mocker.patch.object(AssetFingerprinter, "get_asset_file_contents")
-        get_file_content_mock.return_value = """
+        get_file_content_mock.return_value = b"""
             body {
                 font-family: nta;
             }
-        """.encode(
-            "utf-8"
-        )
+        """
         fingerprinter = AssetFingerprinter()
         assert fingerprinter.get_url("application.css") == "/static/application.css?418e6f4a6cdf1142e45c072ed3e1c90a"
         fingerprinter._cache["application.css"] = "a1a1a1"


### PR DESCRIPTION
So we can share it between our frontend apps.

This continues its journey, having been:
- introduced here: https://github.com/Crown-Commercial-Service/digitalmarketplace-buyer-frontend/pull/111
- refactored into shared code here: https://github.com/Crown-Commercial-Service/digitalmarketplace-utils/pull/102
- copied into Notify here: https://github.com/alphagov/notifications-admin/pull/171 (“They have it in a shared codebase, we only have one frontend app so don’t need to do that.”)
- copied into Document Download here: https://github.com/alphagov/document-download-frontend/pull/1