### PR TITLE
Updates phone_numbers library to 8.13.45 to fix a validation bug with certain Jersey phone numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+# 83.0.1
+
+* Updates phone_numbers to 8.13.45 to apply a fix to the metadata for phone numbers that was discovered causing a subset of valid Jersey numbers to be incorrectly invalidated
+
 ## 83.0.0
 
 * `AntivirusClient` and `ZendeskClient` are no longer thread-safe because they now use persistent requests sessions. Thread-local instances should be used in place of any global instances in any situations where threading is liable to be used

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "83.0.0"  # 9ec4c0e5f2c033df86cfa33627e3c483
+__version__ = "83.0.1"  # b5ba071d02969864cf049d54563c94f6

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "statsd>=4.0.1",
         "Flask-Redis>=0.4.0",
         "pyyaml>=6.0.1",
-        "phonenumbers>=8.13.18",
+        "phonenumbers>=8.13.45",
         "pytz>=2024.1",
         "smartypants>=2.0.1",
         "pypdf>=3.13.0",

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -46,6 +46,14 @@ valid_international_phone_numbers = [
     "+43 676 111 222 333 4",  # Austrian 13 digit phone numbers
 ]
 
+# placeholder to be removed when the old validation code is removed
+# categorising these numbers as international numbers will cause old checks
+# for uk numbers to fail
+valid_channel_island_numbers = [
+    "+447797292290",  # Jersey
+    "+447797333214",  # Jersey
+]
+
 
 valid_mobile_phone_numbers = valid_uk_mobile_phone_numbers + valid_international_phone_numbers
 
@@ -563,6 +571,16 @@ class TestPhoneNumberClass:
         with pytest.raises(InvalidPhoneError) as exc:
             PhoneNumber(phone_number, allow_international=False)
         assert exc.value.code == expected_error_code
+
+    # We discovered a bug with the phone_numbers library causing some valid JE numbers
+    # to evaluate as invalid. Realiably sending to Crown Dependencies is very important
+    # this test serves to alert us if a known failing edge case arises again.
+    @pytest.mark.parametrize("phone_number", valid_channel_island_numbers)
+    def test_channel_island_numbers_are_valid(self, phone_number):
+        try:
+            PhoneNumber(phone_number, allow_international=True)
+        except InvalidPhoneError:
+            pytest.fail("Unexpected InvalidPhoneError")
 
 
 def test_empty_phone_number_is_rejected_with_correct_v2_error_message():


### PR DESCRIPTION
It was discovered that a subset of valid Jersey phone numbers were being incorrectly invalidated by the phone_numbers library code due to a bug in the regex phone numbers were being validated against for the Jersey region. This new code provides a fix