### PR TITLE
Automatically copy config after version bump

### DIFF
--- a/notifications_utils/version_tools.py
+++ b/notifications_utils/version_tools.py
@@ -31,6 +31,8 @@ def upgrade_version():
 
     write_version_to_requirements_file(newest_version)
 
+    copy_config()
+
     print(  # noqa: T201
         f"{color.GREEN}✅ {color.BOLD}notifications-utils bumped to {newest_version}{color.END}\n\n"
         f"{color.YELLOW}{color.UNDERLINE}Now run:{color.END}\n\n"


### PR DESCRIPTION
A new version of utils might have introduced new requirements, or new linter options. So to keep the config in sync with the version of utils specified in the requirements file we should automatically check for new config files every time we bump the version in an app.