### PR TITLE
Reintroduce API client changes from 83.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 87.0.0
+
+* Reintroduce changes to `AntivirusClient` and `ZendeskClient` from 83.0.0
+
 ## 86.2.0
 
 * Adds `asset_fingerprinter.AssetFingerprinter` to replace the versions duplicated across our frontend apps

--- a/notifications_utils/clients/antivirus/antivirus_client.py
+++ b/notifications_utils/clients/antivirus/antivirus_client.py
@@ -21,13 +21,16 @@ class AntivirusError(Exception):
 
 
 class AntivirusClient:
+    """
+    A client for the antivirus API
+
+    This class is not thread-safe.
+    """
+
     def __init__(self, api_host=None, auth_token=None):
         self.api_host = api_host
         self.auth_token = auth_token
-
-    def init_app(self, app):
-        self.api_host = app.config["ANTIVIRUS_API_HOST"]
-        self.auth_token = app.config["ANTIVIRUS_API_KEY"]
+        self.requests_session = requests.Session()
 
     def scan(self, document_stream):
         headers = {"Authorization": f"Bearer {self.auth_token}"}
@@ -35,7 +38,7 @@ class AntivirusClient:
             headers.update(request.get_onwards_request_headers())
 
         try:
-            response = requests.post(
+            response = self.requests_session.post(
                 f"{self.api_host}/scan",
                 headers=headers,
                 files={"document": document_stream},

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "86.2.0"  # 37dac8b3e2812ede962df582c8fe48ec
+__version__ = "87.0.0"  # 33dc08fb56c391a4737819a401da58ad

--- a/tests/clients/antivirus/test_antivirus_client.py
+++ b/tests/clients/antivirus/test_antivirus_client.py
@@ -12,10 +12,10 @@ from notifications_utils.clients.antivirus.antivirus_client import (
 
 @pytest.fixture(scope="function")
 def app_antivirus_client(app, mocker):
-    client = AntivirusClient()
-    app.config["ANTIVIRUS_API_HOST"] = "https://antivirus"
-    app.config["ANTIVIRUS_API_KEY"] = "test-antivirus-key"
-    client.init_app(app)
+    client = AntivirusClient(
+        api_host="https://antivirus",
+        auth_token="test-antivirus-key",
+    )
     return app, client
 
 

--- a/tests/clients/zendesk/test_zendesk_client.py
+++ b/tests/clients/zendesk/test_zendesk_client.py
@@ -17,14 +17,8 @@ from notifications_utils.clients.zendesk.zendesk_client import (
 
 
 @pytest.fixture(scope="function")
-def zendesk_client(app):
-    client = ZendeskClient()
-
-    app.config["ZENDESK_API_KEY"] = "testkey"
-
-    client.init_app(app)
-
-    return client
+def zendesk_client():
+    return ZendeskClient(api_key="testkey")
 
 
 def test_zendesk_client_send_ticket_to_zendesk(zendesk_client, app, rmock, caplog):
@@ -63,7 +57,7 @@ def test_zendesk_client_send_ticket_to_zendesk_error(zendesk_client, app, rmock,
     assert "Zendesk create ticket request failed with 401 '{'foo': 'bar'}'" in caplog.messages
 
 
-def test_zendesk_client_send_ticket_to_zendesk_with_user_suspended_error(zendesk_client, rmock, caplog):
+def test_zendesk_client_send_ticket_to_zendesk_with_user_suspended_error(zendesk_client, app, rmock, caplog):
     rmock.request(
         "POST",
         ZendeskClient.ZENDESK_TICKET_URL,


### PR DESCRIPTION
#1145 was reverted in #1150 because not all apps were ready to be switched to them.

But we do need those changes for the long road to https://trello.com/c/ORGrd1jn/498-upgrade-docker-images-for-our-ecs-apps-to-debian-bookworm