### PR TITLE
Update Zendesk client to add a new optional argument for the date a user was created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 84.2.0
+
+* The Zendesk client takes a new optional argument, `user_created_at` which populates a new field on the Notify Zendesk form if provided.
+
 ## 84.1.1
 
 * Remove GIR 0AA from valid postcodes

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "84.1.1"  # 87c24ae9785f1425177135de028b83e8
+__version__ = "84.2.0"  # 6c167f6c73b099d58fdd5952e7c237b0


### PR DESCRIPTION
The Zendesk client now takes an optional argument called `user_created_date`. If provided, this value is used to populate a new field we have on the form which is a calendar date picker. This will let us analyse how long the people opening tickets have been using Notify for.