### PR TITLE
Revert "Bump test requirements to the latest versions"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,12 +7,12 @@ repos:
   - id: check-yaml
   - id: debug-statements
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.6.4'
+  rev: 'v0.3.7'
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
 - repo: https://github.com/psf/black
-  rev: 24.8.0
+  rev: 24.4.0
   hooks:
     - id: black
       name: black (python)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 84.3.0
+
+* Reverts 84.1.0
+
 ## 84.2.0
 
 * The Zendesk client takes a new optional argument, `user_created_at` which populates a new field on the Notify Zendesk form if provided.

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "84.2.0"  # 6c167f6c73b099d58fdd5952e7c237b0
+__version__ = "84.3.0"  # e8f0e1b3e2ed73b2e0962487a0292e38

--- a/requirements_for_test_common.txt
+++ b/requirements_for_test_common.txt
@@ -1,12 +1,12 @@
-beautifulsoup4==4.12.3
-pytest==8.3.2
-pytest-env==1.1.3
-pytest-mock==3.14.0
-pytest-xdist==3.6.1
-pytest-testmon==2.1.1
+beautifulsoup4==4.11.1
+pytest==7.2.0
+pytest-env==0.8.1
+pytest-mock==3.9.0
+pytest-xdist==3.0.2
+pytest-testmon==2.1.0
 pytest-watch==4.2.0
-requests-mock==1.12.1
-freezegun==1.5.1
+requests-mock==1.10.0
+freezegun==1.2.2
 
-black==24.8.0  # Also update `.pre-commit-config.yaml` if this changes
-ruff==0.6.4  # Also update `.pre-commit-config.yaml` if this changes
+black==24.4.0  # Also update `.pre-commit-config.yaml` if this changes
+ruff==0.3.7  # Also update `.pre-commit-config.yaml` if this changes


### PR DESCRIPTION
This reverts commit d72195a650ec4cd63a689a1d6c57cd0c599a4398.

These new versions were not compatible with existing dependencies in the API