### PR TITLE
Rewrite `SerialisedModel` to use annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 85.0.0
+
+* Removes `SerialisedModel.ALLOWED_PROPERTIES` in favour of annotations syntax
+
 ## 84.3.0
 
 * Reverts 84.1.0

--- a/notifications_utils/serialised_model.py
+++ b/notifications_utils/serialised_model.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 
 
-class SerialisedModel(ABC):
+class SerialisedModel:
     """
     A SerialisedModel takes a dictionary, typically created by
     serialising a database object. It then takes the value of specified
@@ -19,11 +19,6 @@ class SerialisedModel(ABC):
     then clear the cache, before adding that field to the
     ALLOWED_PROPERTIES list.
     """
-
-    @property
-    @abstractmethod
-    def ALLOWED_PROPERTIES(self):
-        pass
 
     def __init__(self, _dict):
         for property in self.ALLOWED_PROPERTIES:

--- a/notifications_utils/serialised_model.py
+++ b/notifications_utils/serialised_model.py
@@ -24,8 +24,13 @@ class SerialisedModel:
     annotations.
     """
 
+    def __new__(cls, *args, **kwargs):
+        for parent in cls.__mro__:
+            cls.__annotations__ = getattr(parent, "__annotations__", {}) | cls.__annotations__
+        return super().__new__(cls)
+
     def __init__(self, _dict):
-        for property, type_ in getattr(self, "__annotations__", {}).items():
+        for property, type_ in self.__annotations__.items():
             value = self.coerce_value_to_type(_dict[property], type_)
             setattr(self, property, value)
 

--- a/notifications_utils/serialised_model.py
+++ b/notifications_utils/serialised_model.py
@@ -9,19 +9,19 @@ class SerialisedModel:
     that it can be interacted with like any other object. It is cleaner
     and safer than dealing with dictionaries directly because it
     guarantees that:
-    - all of the ALLOWED_PROPERTIES are present in the underlying
+    - all of the fields in its annotations are present in the underlying
       dictionary
     - any other abritrary properties of the underlying dictionary can’t
       be accessed
 
     If you are adding a new field to a model, you should ensure that
     all sources of the cache data are updated to return that new field,
-    then clear the cache, before adding that field to the
-    ALLOWED_PROPERTIES list.
+    then clear the cache, before adding that field to the class’s
+    annotations.
     """
 
     def __init__(self, _dict):
-        for property in self.ALLOWED_PROPERTIES:
+        for property in getattr(self, "__annotations__", {}):
             setattr(self, property, _dict[property])
 
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "84.3.0"  # e8f0e1b3e2ed73b2e0962487a0292e38
+__version__ = "85.0.0"  # cd0abf61c0669711a30b4f9c4dbb6f93

--- a/tests/test_serialised_model.py
+++ b/tests/test_serialised_model.py
@@ -121,6 +121,24 @@ def test_dynamic_properties_are_introspectable():
         assert field in dir(instance)
 
 
+def test_attribute_inheritence():
+    class Parent1(SerialisedModel):
+        foo: str
+
+    class Parent2(SerialisedModel):
+        bar: str
+
+    class Child(Parent1, Parent2):
+        __sort_attribute__ = "foo"
+        baz: str
+
+    instance = Child({"foo": 1, "bar": 2, "baz": 3})
+
+    assert instance.foo == "1"
+    assert instance.bar == "2"
+    assert instance.baz == "3"
+
+
 def test_none_values_are_not_coerced():
     class Custom(SerialisedModel):
         foo: str

--- a/tests/test_serialised_model.py
+++ b/tests/test_serialised_model.py
@@ -1,4 +1,5 @@
 import sys
+from typing import Any
 
 import pytest
 
@@ -36,14 +37,14 @@ def test_cant_be_instatiated_with_abstract_properties():
 
 def test_looks_up_from_dict():
     class Custom(SerialisedModel):
-        ALLOWED_PROPERTIES = {"foo"}
+        foo: Any
 
     assert Custom({"foo": "bar"}).foo == "bar"
 
 
 def test_cant_override_custom_property_from_dict():
     class Custom(SerialisedModel):
-        ALLOWED_PROPERTIES = {"foo"}
+        foo: Any
 
         @property
         def foo(self):
@@ -66,11 +67,9 @@ def test_cant_override_custom_property_from_dict():
 )
 def test_model_raises_for_unknown_attributes(json_response):
     class Custom(SerialisedModel):
-        ALLOWED_PROPERTIES = set()
+        pass
 
     model = Custom(json_response)
-
-    assert model.ALLOWED_PROPERTIES == set()
 
     with pytest.raises(AttributeError) as e:
         model.foo  # noqa
@@ -80,7 +79,7 @@ def test_model_raises_for_unknown_attributes(json_response):
 
 def test_model_raises_keyerror_if_item_missing_from_dict():
     class Custom(SerialisedModel):
-        ALLOWED_PROPERTIES = {"foo"}
+        foo: Any
 
     with pytest.raises(KeyError) as e:
         Custom({}).foo  # noqa
@@ -97,7 +96,6 @@ def test_model_raises_keyerror_if_item_missing_from_dict():
 )
 def test_model_doesnt_swallow_attribute_errors(json_response):
     class Custom(SerialisedModel):
-        ALLOWED_PROPERTIES = set()
 
         @property
         def foo(self):
@@ -111,7 +109,9 @@ def test_model_doesnt_swallow_attribute_errors(json_response):
 
 def test_dynamic_properties_are_introspectable():
     class Custom(SerialisedModel):
-        ALLOWED_PROPERTIES = {"foo", "bar", "baz"}
+        foo: Any
+        bar: Any
+        baz: Any
 
     instance = Custom({"foo": "", "bar": "", "baz": ""})
 
@@ -130,7 +130,7 @@ def test_empty_serialised_model_collection():
 
 def test_serialised_model_collection_returns_models_from_list():
     class Custom(SerialisedModel):
-        ALLOWED_PROPERTIES = {"x"}
+        x: Any
 
     class CustomCollection(SerialisedModelCollection):
         model = Custom

--- a/tests/test_serialised_model.py
+++ b/tests/test_serialised_model.py
@@ -9,35 +9,8 @@ from notifications_utils.serialised_model import (
 
 
 def test_cant_be_instatiated_with_abstract_properties():
-    class Custom(SerialisedModel):
-        pass
-
     class CustomCollection(SerialisedModelCollection):
         pass
-
-    with pytest.raises(TypeError) as e:
-        SerialisedModel()
-
-    if sys.version_info >= (3, 12):
-        assert str(e.value) == (
-            "Can't instantiate abstract class SerialisedModel without an implementation "
-            "for abstract method 'ALLOWED_PROPERTIES'"
-        )
-    else:
-        assert str(e.value) == (
-            "Can't instantiate abstract class SerialisedModel with abstract method ALLOWED_PROPERTIES"
-        )
-
-    with pytest.raises(TypeError) as e:
-        Custom()
-
-    if sys.version_info >= (3, 12):
-        assert str(e.value) == (
-            "Can't instantiate abstract class Custom without an implementation "
-            "for abstract method 'ALLOWED_PROPERTIES'"
-        )
-    else:
-        assert str(e.value) == "Can't instantiate abstract class Custom with abstract method ALLOWED_PROPERTIES"
 
     with pytest.raises(TypeError) as e:
         SerialisedModelCollection()


### PR DESCRIPTION
Upstreams the work from https://github.com/alphagov/notifications-admin/pull/5210

# Before 

```python
class User:
    ALLOWED_PROPERTIES = {"name"}
```

# After

```python
class User:
    name: str
```