### PR TITLE
Remove EmailPreviewTemplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 88.0.0
+
+* Removes `template.EmailPreviewTemplate` (only used in admin app)
+
 ## 87.0.0
 
 * Reintroduce changes to `AntivirusClient` and `ZendeskClient` from 83.0.0

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -562,54 +562,6 @@ class HTMLEmailTemplate(BaseEmailTemplate):
         )
 
 
-class EmailPreviewTemplate(BaseEmailTemplate):
-    jinja_template = template_env.get_template("email_preview_template.jinja2")
-
-    def __init__(
-        self,
-        template,
-        values=None,
-        from_name=None,
-        reply_to=None,
-        show_recipient=True,
-        redact_missing_personalisation=False,
-        **kwargs,
-    ):
-        super().__init__(template, values, redact_missing_personalisation=redact_missing_personalisation, **kwargs)
-        self.from_name = from_name
-        self.reply_to = reply_to
-        self.show_recipient = show_recipient
-
-    def __str__(self):
-        return Markup(
-            self.jinja_template.render(
-                {
-                    "body": self.html_body,
-                    "subject": self.subject,
-                    "from_name": escape_html(self.from_name),
-                    "reply_to": self.reply_to,
-                    "recipient": Field("((email address))", self.values, with_brackets=False),
-                    "show_recipient": self.show_recipient,
-                }
-            )
-        )
-
-    @property
-    def subject(self):
-        return (
-            Take(
-                Field(
-                    self._subject,
-                    self.values,
-                    html="escape",
-                    redact_missing_personalisation=self.redact_missing_personalisation,
-                )
-            )
-            .then(do_nice_typography)
-            .then(normalise_whitespace)
-        )
-
-
 class BaseLetterTemplate(SubjectMixin, Template):
     template_type = "letter"
     max_page_count = LETTER_MAX_PAGE_COUNT

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "87.0.0"  # 33dc08fb56c391a4737819a401da58ad
+__version__ = "88.0.0"  # 716596cfea485c72b196eb0bda96c1df

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -18,7 +18,7 @@ from notifications_utils.recipients import (
     first_column_headings,
 )
 from notifications_utils.template import (
-    EmailPreviewTemplate,
+    HTMLEmailTemplate,
     LetterPreviewTemplate,
     SMSMessageTemplate,
 )
@@ -26,7 +26,7 @@ from notifications_utils.template import (
 
 def _sample_template(template_type, content="foo"):
     return {
-        "email": EmailPreviewTemplate({"content": content, "subject": "bar", "template_type": "email"}),
+        "email": HTMLEmailTemplate({"content": content, "subject": "bar", "template_type": "email"}),
         "sms": SMSMessageTemplate({"content": content, "template_type": "sms"}),
         "letter": LetterPreviewTemplate(
             {"content": content, "subject": "bar", "template_type": "letter"},


### PR DESCRIPTION
The only thing using it was the admin app and we moved the code into notifications-admin in https://github.com/alphagov/notifications-admin/pull/5266