### PR TITLE
logging: don't `calculate_content_length()` for `after_request` logs of streaming responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 87.1.0
+
+* logging: don't calculate_content_length() for after_request logs of streaming responses - this caused attempted streaming responses to be eagerly consumed, negating the point of streaming responses. Instead emit the after_request log when status code and header is returned and a separate log message when a streaming response is closed.
+
 ## 87.0.0
 
 * Reintroduce changes to `AntivirusClient` and `ZendeskClient` from 83.0.0

--- a/notifications_utils/logging/__init__.py
+++ b/notifications_utils/logging/__init__.py
@@ -3,6 +3,7 @@ import logging.handlers
 import sys
 import time
 from collections.abc import Sequence
+from functools import partial
 from itertools import product
 from os import getpid
 from pathlib import Path
@@ -40,6 +41,29 @@ def _common_request_extra_log_context():
         # existing parameter name to prevent LogRecord from complaining
         "process_": getpid(),
     }
+
+
+def _log_response_closed(
+    log_level,
+    response,
+    before_request_real_time,
+    common_request_extra_log_context,
+):
+    context = {
+        "status": response.status_code,
+        "request_time": (
+            (time.perf_counter() - before_request_real_time) if before_request_real_time is not None else None
+        ),
+        # response size not reliably available at this point :(
+        "response_streamed": True,
+        **common_request_extra_log_context,
+    }
+    current_app.logger.getChild("request").log(
+        log_level,
+        "Streaming response for %(method)s %(url)s %(status)s closed after %(request_time)ss",
+        context,
+        extra=context,
+    )
 
 
 def init_app(app, statsd_client=None, extra_filters: Sequence[logging.Filter] = ()):
@@ -93,6 +117,19 @@ def init_app(app, statsd_client=None, extra_filters: Sequence[logging.Filter] = 
             context,
             extra=context,
         )
+
+        if response.is_streamed:
+            response.call_on_close(
+                partial(
+                    _log_response_closed,
+                    log_level,
+                    response,
+                    getattr(request, "before_request_real_time", None),
+                    # call_on_close hook can't use `request` itself, so we need to "bake" this for
+                    # it now
+                    _common_request_extra_log_context(),
+                )
+            )
 
         return response
 

--- a/notifications_utils/logging/__init__.py
+++ b/notifications_utils/logging/__init__.py
@@ -83,7 +83,8 @@ def init_app(app, statsd_client=None, extra_filters: Sequence[logging.Filter] = 
                 if hasattr(request, "before_request_real_time")
                 else None
             ),
-            "response_size": response.calculate_content_length(),
+            "response_size": None if response.is_streamed else response.calculate_content_length(),
+            "response_streamed": response.is_streamed,
             **_common_request_extra_log_context(),
         }
         current_app.logger.getChild("request").log(

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "87.0.0"  # 33dc08fb56c391a4737819a401da58ad
+__version__ = "87.1.0"  # 72db8be450a964e5a5e71b9fc1971474


### PR DESCRIPTION
Adding this (useful) field to the logs causes the response to be eagerly consumed in an attempt to calculate the final length, which negates the point of streaming responses. This may be why we observed our streaming responses apparently "not working" recently.

However simply making them skip the calculation for streaming responses does change behaviour - it means `after_request` logs are now emitted when we return the response status and headers. Which would leave us with no visibility of when the streamed request "ended". So this also adds a new log message for streamed responses being "closed".

Unfortunately from what I can see, flask/werkzeug doesn't really keep a tally of bytes returned in streamed responses, so it's not trivially possible to include a "final" response size in this latter log message.