### PR TITLE
logging: don't use `current_app` in `_log_response_closed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 88.0.1
+
+* logging: don't use current_app in _log_response_closed
+
 ## 88.0.0
 
 * Removes `template.EmailPreviewTemplate` (only used in admin app)

--- a/notifications_utils/logging/__init__.py
+++ b/notifications_utils/logging/__init__.py
@@ -44,6 +44,7 @@ def _common_request_extra_log_context():
 
 
 def _log_response_closed(
+    logger,
     log_level,
     response,
     before_request_real_time,
@@ -58,7 +59,7 @@ def _log_response_closed(
         "response_streamed": True,
         **common_request_extra_log_context,
     }
-    current_app.logger.getChild("request").log(
+    logger.getChild("request").log(
         log_level,
         "Streaming response for %(method)s %(url)s %(status)s closed after %(request_time)ss",
         context,
@@ -122,6 +123,7 @@ def init_app(app, statsd_client=None, extra_filters: Sequence[logging.Filter] = 
             response.call_on_close(
                 partial(
                     _log_response_closed,
+                    current_app.logger,
                     log_level,
                     response,
                     getattr(request, "before_request_real_time", None),

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "88.0.0"  # 716596cfea485c72b196eb0bda96c1df
+__version__ = "88.0.1"  # 3b20db86e541b5aad900d88c0e0f720a


### PR DESCRIPTION
We aren't in app context when this is called by a real wsgi server.