### PR TITLE
logging: refactor filters to fall back to provided record fields if app context not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 88.1.0
+
+* logging: slightly redesign filters behaviour to allow log-call-supplied request_id, span_id, user_id, service_id to be used if they are not available by normal means. Supply these manually for the streaming-response-closed log message.
+
 ## 88.0.1
 
 * logging: don't use current_app in _log_response_closed

--- a/notifications_utils/logging/__init__.py
+++ b/notifications_utils/logging/__init__.py
@@ -127,9 +127,16 @@ def init_app(app, statsd_client=None, extra_filters: Sequence[logging.Filter] = 
                     log_level,
                     response,
                     getattr(request, "before_request_real_time", None),
-                    # call_on_close hook can't use `request` itself, so we need to "bake" this for
-                    # it now
-                    _common_request_extra_log_context(),
+                    # this is horrible, but call_on_close hook can't use `request` itself, meaning these filters
+                    # and _common_request_extra_log_context() won't work normally when that is called, meaning
+                    # we need to "pre-bake" their values now.
+                    {
+                        "request_id": RequestIdFilter().request_id,
+                        "service_id": ServiceIdFilter().service_id,
+                        "span_id": SpanIdFilter().span_id,
+                        "user_id": UserIdFilter().user_id,
+                        **_common_request_extra_log_context(),
+                    },
                 )
             )
 

--- a/notifications_utils/logging/__init__.py
+++ b/notifications_utils/logging/__init__.py
@@ -227,10 +227,10 @@ class RequestIdFilter(logging.Filter):
         elif has_app_context() and "request_id" in g:
             return g.request_id
         else:
-            return "no-request-id"
+            return None
 
     def filter(self, record):
-        record.request_id = self.request_id
+        record.request_id = self.request_id or getattr(record, "request_id", None) or "no-request-id"
 
         return record
 
@@ -243,10 +243,10 @@ class SpanIdFilter(logging.Filter):
         elif has_app_context() and "span_id" in g:
             return g.span_id
         else:
-            return "no-span-id"
+            return None
 
     def filter(self, record):
-        record.span_id = self.span_id
+        record.span_id = self.span_id or getattr(record, "span_id", None) or "no-span-id"
 
         return record
 
@@ -257,10 +257,10 @@ class ServiceIdFilter(logging.Filter):
         if has_app_context() and "service_id" in g:
             return g.service_id
         else:
-            return "no-service-id"
+            return None
 
     def filter(self, record):
-        record.service_id = self.service_id
+        record.service_id = self.service_id or getattr(record, "service_id", None) or "no-service-id"
 
         return record
 
@@ -274,5 +274,5 @@ class UserIdFilter(logging.Filter):
             return None
 
     def filter(self, record):
-        record.user_id = self.user_id
+        record.user_id = self.user_id or getattr(record, "user_id", None)
         return record

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "88.0.1"  # 3b20db86e541b5aad900d88c0e0f720a
+__version__ = "88.1.0"  # df76155d068c42324bc7cd7c6fa33959

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -118,7 +118,14 @@ def test_app_request_logs_level_by_status_code(
         time.sleep(0.05)
         return iter("foobar") if stream_response else "foobar", status_code
 
-    test_response = app.test_client().get("/", headers={"x-b3-parentspanid": "deadbeef"})
+    test_response = app.test_client().get(
+        "/",
+        headers={
+            "x-b3-parentspanid": "deadbeef",
+            "x-b3-spanid": "abadcafe",
+            "x-b3-traceid": "feedface",
+        },
+    )
 
     assert (
         mock.call(
@@ -228,6 +235,10 @@ def test_app_request_logs_level_by_status_code(
                 "endpoint": "some_route",
                 "remote_addr": "127.0.0.1",
                 "parent_span_id": "deadbeef" if with_request_helper else None,
+                "request_id": "feedface" if with_request_helper else None,
+                "span_id": "abadcafe" if with_request_helper else None,
+                "service_id": None,
+                "user_id": None,
                 "status": status_code,
                 "request_time": RestrictedAny(lambda value: isinstance(value, float) and 0.1 <= value),
                 "process_": RestrictedAny(lambda value: isinstance(value, int)),
@@ -244,6 +255,10 @@ def test_app_request_logs_level_by_status_code(
                 "endpoint": "some_route",
                 "remote_addr": "127.0.0.1",
                 "parent_span_id": "deadbeef" if with_request_helper else None,
+                "request_id": "feedface" if with_request_helper else None,
+                "span_id": "abadcafe" if with_request_helper else None,
+                "service_id": None,
+                "user_id": None,
                 "status": status_code,
                 "request_time": RestrictedAny(lambda value: isinstance(value, float) and 0.1 <= value),
                 "process_": RestrictedAny(lambda value: isinstance(value, int)),
@@ -721,6 +736,10 @@ def test_app_request_logs_responses_on_post(app_with_mocked_logger, stream_respo
                 "endpoint": "post",
                 "remote_addr": "127.0.0.1",
                 "parent_span_id": None,
+                "request_id": None,
+                "span_id": None,
+                "service_id": None,
+                "user_id": None,
                 "status": 200,
                 "request_time": RestrictedAny(lambda value: isinstance(value, float)),
                 "process_": RestrictedAny(lambda value: isinstance(value, int)),
@@ -737,6 +756,10 @@ def test_app_request_logs_responses_on_post(app_with_mocked_logger, stream_respo
                 "endpoint": "post",
                 "remote_addr": "127.0.0.1",
                 "parent_span_id": None,
+                "request_id": None,
+                "span_id": None,
+                "service_id": None,
+                "user_id": None,
                 "status": 200,
                 "request_time": RestrictedAny(lambda value: isinstance(value, float)),
                 "process_": RestrictedAny(lambda value: isinstance(value, int)),


### PR DESCRIPTION
See commit messages for more information.

This is to address fields like `request_id` not being available on the streaming-response-closed log message due to not being in a request context at the time of generation.

Not pretty, but blame flask/werkzeug's damn silly context system.