### PR TITLE
Bug Fix: Updates PhoneNumbers to 8.13.48 to apply fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 88.1.1
+
+* Bug fix: applies minor version bump of PhoneNumbers to v8.13.48 to apply a fix to the UG metadata which was causing validation to fail in error
+
 ## 88.1.0
 
 * logging: slightly redesign filters behaviour to allow log-call-supplied request_id, span_id, user_id, service_id to be used if they are not available by normal means. Supply these manually for the streaming-response-closed log message.

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "88.1.0"  # df76155d068c42324bc7cd7c6fa33959
+__version__ = "88.1.1"  # 5096672ad79b5b5bc5b35bbdef2f9d25

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "statsd>=4.0.1",
         "Flask-Redis>=0.4.0",
         "pyyaml>=6.0.1",
-        "phonenumbers>=8.13.45",
+        "phonenumbers>=8.13.48",
         "pytz>=2024.1",
         "smartypants>=2.0.1",
         "pypdf>=3.13.0",


### PR DESCRIPTION
to metadata that was causing some ugandan numbers to fail in error.