### PR TITLE
raise an exception if we cant fetch from github

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+
+## 89.0.1
+
+* Raise an exception if we cant fetch remote github files in version_tools.py
+
 ## 89.0.0
 
 * `requirements_for_test_common.txt` is now `requirements_for_test_common.in`. Apps should freeze this into a local requirements file for fully reproducible dependencies

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "89.0.0"  # c04319c900acda86919ca7fb1b753455
+__version__ = "89.0.1"  # f6994912f0a7aaad4564c8c16b25d825

--- a/notifications_utils/version_tools.py
+++ b/notifications_utils/version_tools.py
@@ -88,7 +88,9 @@ def get_relevant_changelog_lines(current_version, newest_version):
 
 
 def get_file_contents_from_github(branch_or_tag, path):
-    return requests.get(f"https://raw.githubusercontent.com/{repo_name}/{branch_or_tag}/{path}").text
+    response = requests.get(f"https://raw.githubusercontent.com/{repo_name}/{branch_or_tag}/{path}")
+    response.raise_for_status()
+    return response.text
 
 
 def copy_config():


### PR DESCRIPTION
currently, it just returns whatever is at the URL (for example an error page). We saw problems on concourse where it just wrote an error page to a requirements_common file and then just tried to carry on happily