### PR TITLE
Use github api when fetching files from github

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+
+## 89.2.0
+
+* Use github API rather than fetching from their CDN in version_tools
+
 ## 89.1.0
 
 * Change version_tools to a package that uses importlib to grab common reqs/config, rather than fetching common files from github. This repo's usage of those common files are now symlinks to the sources of truth found within notification_utils/version_tools/

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "89.1.0"  # 496cef70d70ea4edc758a44094df6d10
+__version__ = "89.2.0"  # 79ca3772d8936323985871de2e5b46af

--- a/notifications_utils/version_tools/__init__.py
+++ b/notifications_utils/version_tools/__init__.py
@@ -1,4 +1,5 @@
 import pathlib
+from base64 import b64decode
 from importlib import resources as importlib_resources
 from importlib.metadata import version
 
@@ -92,10 +93,10 @@ def get_relevant_changelog_lines(current_version, newest_version):
     return "\n".join(new_changelog.split("\n")[header_lines : header_lines + lines_added])
 
 
-def get_file_contents_from_github(branch_or_tag, path):
-    response = requests.get(f"https://raw.githubusercontent.com/{repo_name}/{branch_or_tag}/{path}")
+def get_file_contents_from_github(branch_or_tag, path) -> str:
+    response = requests.get(f"https://api.github.com/repos/{repo_name}/contents/{path}?ref={branch_or_tag}")
     response.raise_for_status()
-    return response.text
+    return b64decode(response.json()["content"]).decode(encoding="utf-8")
 
 
 def copy_config():


### PR DESCRIPTION
This might have solved our issues with version_tools without changing to importlib - but it was probs a good idea to do that anyway.

This'll fix some issues i ran into with the bump-utils script that the other repos run though