### PR TITLE
Revert "Automatically copy config after version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 91.0.4
+
+* Don’t copy config when bumping utils version
+
 ## 91.0.3
 
 * Fix validating supported international country codes for phone numbers without a leading "+" that look a bit like UK numbers

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "91.0.3"  # ab4aaf1416f48181c64587da7ece9a4e
+__version__ = "91.0.4"  # 06f45092ed41a67176e25ce599128f2e

--- a/notifications_utils/version_tools/__init__.py
+++ b/notifications_utils/version_tools/__init__.py
@@ -37,8 +37,6 @@ def upgrade_version():
 
     write_version_to_requirements_file(newest_version)
 
-    copy_config()
-
     print(  # noqa: T201
         f"{color.GREEN}✅ {color.BOLD}notifications-utils bumped to {newest_version}{color.END}\n\n"
         f"{color.YELLOW}{color.UNDERLINE}Now run:{color.END}\n\n"


### PR DESCRIPTION
This reverts commit https://github.com/alphagov/notifications-utils/commit/484d4530885448ef4a61ce811bcefa015bc3e941.

We now do this as part of the freeze-requirements step in the repos.

Also because the script now pulls the config files from the local install (not over the network) the files it will be pulling will be out of date at this point (before installing the new utils version).