### PR TITLE
Allow leading empty columns in CSV files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
 
+## 90.0.0
+
+* Allow leading empty columns in CSV files
+* Change second argument of `formatters.strip_all_whitespace` (this argument is not used in other apps)
+
 ## 89.2.0
 
 * Use github API rather than fetching from their CDN in version_tools

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -291,10 +291,12 @@ def remove_smart_quotes_from_email_addresses(value):
     )
 
 
-def strip_all_whitespace(value, extra_characters=""):
-    # Removes from the beginning and end of the string all whitespace characters and `extra_characters`
-    if value is not None and hasattr(value, "strip"):
-        return value.strip(ALL_WHITESPACE + extra_characters)
+def strip_all_whitespace(value, extra_trailing_characters=""):
+    # Removes:
+    # - all whitespace characters from beginning and end of the string
+    # - and also any `extra_trailing_characters` from just the end of the string
+    if value is not None and hasattr(value, "lstrip") and hasattr(value, "rstrip"):
+        return value.lstrip(ALL_WHITESPACE).rstrip(ALL_WHITESPACE + extra_trailing_characters)
     return value
 
 

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -50,7 +50,7 @@ class RecipientCSV:
         allow_sms_to_uk_landline=False,
         should_validate=True,
     ):
-        self.file_data = strip_all_whitespace(file_data, extra_characters=",")
+        self.file_data = strip_all_whitespace(file_data, extra_trailing_characters=",")
         self.max_errors_shown = max_errors_shown
         self.max_initial_rows_shown = max_initial_rows_shown
         self.guestlist = guestlist

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "89.2.0"  # 79ca3772d8936323985871de2e5b46af
+__version__ = "90.0.0"  # 369cf7cff7e15e90f80b6d8912ffa069

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -686,6 +686,16 @@ def test_recipient_column(content, file_contents, template_type):
             set(),
             set(),
         ),
+        (
+            """
+                ,,,,,,,,,Phone number
+                ,,,,,,,,,07700900100
+                ,,,,,,,,,07700900100
+            """,
+            "sms",
+            set(),
+            set(),
+        ),
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
We were stripping leading commas from the CSV data.

This mean that a file which looks like

```CSV
,,,phone number
,,,07900900123
```

1| | | phone number
-|-|-|-
2| | | 07900900123

Got turned into
```CSV
phone number
,,,07900900123
```

1| phone number | |&#9;
-|-|-|-
2| | | 07900900123

This meant that the `phone number` header and the phone number itself were no longer in the same column, causing an unexpected error.

We still want to strip commas from the end of the file, in order to remove any completely empty rows.