### PR TITLE
bump requests

### DIFF
--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "91.0.1"  # 6ef58042c75f3634df830d87bb74ee62
+__version__ = "91.0.2"  # a78fe727dc92de3c3d8d130e597fc7fa

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         "cachetools>=5.3.3",
         "mistune<2.0.0",  # v2 is totally incompatible with unclear benefit
-        "requests>=2.32.0",
+        "requests>=2.32.2",
         "python-json-logger>=2.0.7",
         "Flask>=3.0.0",
         "gunicorn[eventlet]>=20.1.0",


### PR DESCRIPTION
2.32.0 and 2.32.1 were yanked due to issues with CVE-2024-35195[^1], so lets make sure we require newer versions

[^1]: https://pypi.org/project/requests/2.32.1/#history