### PR TITLE
Fix ascension island bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 91.0.3
+
+* Fix validating supported international country codes for phone numbers without a leading "+" that look a bit like UK numbers
+
 ## 91.0.1
 
 * Adds public utility method to check if a phonenumber is international (with correct handling for OFCOM TV numbers)

--- a/notifications_utils/international_billing_rates.py
+++ b/notifications_utils/international_billing_rates.py
@@ -23,4 +23,4 @@ from pathlib import Path
 import yaml
 
 INTERNATIONAL_BILLING_RATES = yaml.safe_load((Path(__file__).parent / "international_billing_rates.yml").read_text())
-COUNTRY_PREFIXES = sorted(INTERNATIONAL_BILLING_RATES.keys(), key=len, reverse=True)
+COUNTRY_PREFIXES = set(INTERNATIONAL_BILLING_RATES.keys())

--- a/notifications_utils/recipient_validation/phone_number.py
+++ b/notifications_utils/recipient_validation/phone_number.py
@@ -84,9 +84,14 @@ class PhoneNumber:
         if not allow_uk_landline and is_landline:
             raise InvalidPhoneError(code=InvalidPhoneError.Codes.NOT_A_UK_MOBILE)
 
+    def _raise_if_unsupported_country(self):
+        if str(self.number.country_code) not in COUNTRY_PREFIXES + ["+44"]:
+            raise InvalidPhoneError(code=InvalidPhoneError.Codes.UNSUPPORTED_COUNTRY_CODE)
+
     def validate(self, allow_international_number: bool = False, allow_uk_landline: bool = False) -> None:
         self._raise_if_service_cannot_send_to_international_but_tries_to(allow_international=allow_international_number)
         self._raise_if_service_cannot_send_to_uk_landline_but_tries_to(allow_uk_landline=allow_uk_landline)
+        self._raise_if_unsupported_country()
 
     @staticmethod
     def _try_parse_number(phone_number):
@@ -130,9 +135,6 @@ class PhoneNumber:
             if str(number.national_number) in EMERGENCY_THREE_DIGIT_NUMBERS:
                 raise InvalidPhoneError(code=InvalidPhoneError.Codes.UNSUPPORTED_EMERGENCY_NUMBER)
             return number
-
-        if str(number.country_code) not in COUNTRY_PREFIXES + ["+44"]:
-            raise InvalidPhoneError(code=InvalidPhoneError.Codes.UNSUPPORTED_COUNTRY_CODE)
 
         if (reason := phonenumbers.is_possible_number_with_reason(number)) != phonenumbers.ValidationResult.IS_POSSIBLE:
             if forced_international_number := self._validate_forced_international_number(phone_number):

--- a/notifications_utils/recipient_validation/phone_number.py
+++ b/notifications_utils/recipient_validation/phone_number.py
@@ -85,7 +85,7 @@ class PhoneNumber:
             raise InvalidPhoneError(code=InvalidPhoneError.Codes.NOT_A_UK_MOBILE)
 
     def _raise_if_unsupported_country(self):
-        if str(self.number.country_code) not in COUNTRY_PREFIXES + ["+44"]:
+        if str(self.number.country_code) not in COUNTRY_PREFIXES | {"+44"}:
             raise InvalidPhoneError(code=InvalidPhoneError.Codes.UNSUPPORTED_COUNTRY_CODE)
 
     def validate(self, allow_international_number: bool = False, allow_uk_landline: bool = False) -> None:

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "91.0.2"  # a78fe727dc92de3c3d8d130e597fc7fa
+__version__ = "91.0.3"  # ab4aaf1416f48181c64587da7ece9a4e

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -614,6 +614,13 @@ class TestPhoneNumberClass:
         except InvalidPhoneError:
             pytest.fail("Unexpected InvalidPhoneError")
 
+    def test_validation_fails_for_unsupported_country_codes(self):
+        number = PhoneNumber("24741111")
+
+        with pytest.raises(InvalidPhoneError) as exc:
+            number.validate(allow_international_number=True, allow_uk_landline=False)
+        assert exc.value.code == InvalidPhoneError.Codes.UNSUPPORTED_COUNTRY_CODE
+
 
 def test_empty_phone_number_is_rejected_with_correct_v2_error_message():
     phone_number = ""


### PR DESCRIPTION
### fix: unsupported countries were not being rejected

if you parse the phone number "24741111", the parser doesn't know if it's international, so starts off assuming it has a country code of +44.  Then, as that number isn't a valid UK number, we'd go down the "forced_international_number" route - and stick a plus on the beginning and parse again. This would prompt phonenumbers to realise it's not a UK phone number but actually one from the Ascension Island - and in fact is a valid number there.

The problem is that we don't support Ascension Island. However, the unsupported country code check takes place before the forced international code branch - and compares against the assumed "+44" code.

This led to a bug where the phone number appeared valid, but if you tried to call `get_international_phone_info` it would KeyError when trying to find billing multiplier info.

Moving this check to validate ensures that we're checking our business logic against the final number that we'll try and send to, rather than an earlier version of the number we may end up manipulating further