### PR TITLE
Remove flake8 config from `setup.cfg`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 91.0.5
+
+* Adds rule N804 (invalid-first-argument-name-for-class-method) to linter config
+
 ## 91.0.4
 
 * Don’t copy config when bumping utils version

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "91.0.4"  # 06f45092ed41a67176e25ce599128f2e
+__version__ = "91.0.5"  # 347985e995cab73fd1a24c3896e80e46

--- a/notifications_utils/version_tools/pyproject.toml
+++ b/notifications_utils/version_tools/pyproject.toml
@@ -20,6 +20,7 @@ lint.select = [
     "ISC",  # flake8-implicit-str-concat
     "RSE",  # flake8-raise
     "PIE",  # flake8-pie
+    "N804",  # First argument of a class method should be named `cls`
 ]
 lint.ignore = []
 exclude = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,18 +1,2 @@
 [tool:pytest]
 xfail_strict=true
-
-[flake8]
-# B901, B902 are opinionated warnings from flake8-bugbear, so must be added to
-# the `select` in order to work. Since `select` acts as an allowlist, every
-# other check has to be specified here too.
-# Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
-select=C, E, F, W, B, B901, B902
-
-# W503: line break before binary operator
-# W504: line break after binary operator
-# E203: space before/after :
-ignore = W503, W504, E203
-
-exclude = venv*,__pycache__,cache
-max-complexity = 8
-max-line-length = 120


### PR DESCRIPTION
ruff doesn’t read `setup.cfg` so the rules defined there are redundant. This is a hangover from when we used to use `flake8` directly.

I’ve copied some of the rules into pyproject.toml

Selected rules:
- B902 and implemented in ruff as N804 and N805. Only copying N804 because N805 gets tripped up by https://github.com/sqlalchemy/sqlalchemy/issues/9213
- E203 still in preview in ruff, add a note to include it later

Ignored rules:
- W503 and W504 aren’t likely to be implemented in ruff https://github.com/astral-sh/ruff/issues/4125
- E203 is [still in preview](https://docs.astral.sh/ruff/rules/whitespace-before-punctuation/) so we don’t need to worry about ignoring it (and maybe it will be fit for purpose once it’s out of preview)

Cyclomatic complexity:
- this repo has it set to 8, but everywhere else we use the default (10) so let’s not copy that into `pyproject.toml`