### PR TITLE
Remove hangul filler character from emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 91.1.1
+
+* Remove hangul filler character from rendered emails
+
 ## 91.1.0
 
 * bump all libs in requirements_for_test_common.in

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -321,4 +321,4 @@ def remove_whitespace(value):
 
 
 def strip_unsupported_characters(value):
-    return value.replace("\u2028", "")
+    return value.replace("\u2028", "").replace("\u3164", "")

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "91.1.0"  # b5eb0bb517341f01c239099829230fc7
+__version__ = "91.1.1"  # ec81ca3fdf32b1a92b9e47109c60401a

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -480,20 +480,17 @@ def test_escaping_govuk_in_email_templates(template_content, expected):
     )
 
 
-def test_stripping_of_unsupported_characters_in_email_templates():
-    template_content = "line one\u2028line two"
-    expected = "line oneline two"
-    assert expected in str(
-        PlainTextEmailTemplate(
-            {
-                "content": template_content,
-                "subject": "",
-                "template_type": "email",
-            }
-        )
-    )
-    assert expected in str(
-        HTMLEmailTemplate(
+@pytest.mark.parametrize(
+    "template_content",
+    (
+        "line one\u2028line two",
+        "line one\u3164line two",
+    ),
+)
+@pytest.mark.parametrize("template_class", (PlainTextEmailTemplate, HTMLEmailTemplate))
+def test_stripping_of_unsupported_characters_in_email_templates(template_content, template_class):
+    assert "line oneline two" in str(
+        template_class(
             {
                 "content": template_content,
                 "subject": "",


### PR DESCRIPTION
You can bypass newline truncation<sup>1</sup> by sending the dreaded unicode ‘hangul filler’ character<sup>2</sup> in my personalisation.

This could be utilised by a dodgy character who wants to hide some portion of the email content (if, say, they've utilised template injection to create a phishing email)

***

Fixes #1119

***

1. Defined at https://github.com/alphagov/notifications-utils/blob/88c57d5eb530b88794814e57249c2403227aa664/notifications_utils/markdown.py#L222
2. https://unicode-explorer.com/c/3164