### PR TITLE
Downgrade minimum version of requests to 2.32.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 92.0.2
+
+* Downgrade minimum version of `requests` to 2.32.3
+
 ## 92.0.1
 
 * Bumps core dependencies to latest versions

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "92.0.1"  # 4fac24d69f58d11792a4288e113bf9df
+__version__ = "92.0.2"  # ac67bdb3ed5b20ccb0a91cfb4481f4cd

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         "cachetools>=5.5.0",
         "mistune<2.0.0",  # v2 is totally incompatible with unclear benefit
-        "requests>=2.32.3",
+        "requests>=2.32.2",  # Can’t go past 2.32.2 until https://github.com/psf/requests/issues/6730 is fixed
         "python-json-logger>=2.0.7",
         "Flask>=3.1.0",
         "gunicorn[eventlet]>=20.1.0",


### PR DESCRIPTION
We can’t upgrade all apps until https://github.com/psf/requests/issues/6730 is fixed (it stops the API from talking to DVLA)