### PR TITLE
Bump minimum jinja2 version to latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 92.1.1
+
+* Bump minimum version of `jinja2` to 3.1.5
+
 ## 92.1.0
 
 * RequestCache: add CacheResultWrapper to allow dynamic cache decisions

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "92.1.0"  # 982357932659deadbeef
+__version__ = "92.1.1"  # defeaed2e5fb6beb0e73c116bd6a1375

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "Flask>=3.1.0",
         "gunicorn[eventlet]>=20.1.0",
         "ordered-set>=4.1.0",
-        "Jinja2>=3.1.4",
+        "Jinja2>=3.1.5",
         "statsd>=4.0.1",
         "Flask-Redis>=0.4.0",
         "pyyaml>=6.0.2",


### PR DESCRIPTION
This fixes a couple of moderate security vulnerabilities.

Have tested locally against the admin app and there’s no breakages.