### PR TITLE
flask logging: add `NOTIFY_LOG_LEVEL_HANDLERS` config variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 93.1.0
+
+* Introduce `NOTIFY_LOG_LEVEL_HANDLERS` config variable for separate control of handler log level
+
 ## 93.0.0
 
 * BREAKING CHANGE: logging: all contents of `logging/__init__.py` have been moved to `logging/flask.py` because they all assume a flask(-like) environment and this way we don't implicitly import all of flask etc. every time anything under `logging` is imported.

--- a/notifications_utils/logging/flask.py
+++ b/notifications_utils/logging/flask.py
@@ -104,6 +104,7 @@ def _log_response_closed(
 
 def init_app(app, statsd_client=None, extra_filters: Sequence[logging.Filter] = ()):
     app.config.setdefault("NOTIFY_LOG_LEVEL", "INFO")
+    app.config.setdefault("NOTIFY_LOG_LEVEL_HANDLERS", app.config["NOTIFY_LOG_LEVEL"])
     app.config.setdefault("NOTIFY_APP_NAME", "none")
     app.config.setdefault("NOTIFY_LOG_DEBUG_PATH_LIST", {"/_status", "/metrics"})
     app.config.setdefault("NOTIFY_REQUEST_LOG_LEVEL", "CRITICAL")
@@ -252,7 +253,7 @@ def get_handlers(app, extra_filters: Sequence[logging.Filter]):
 
 
 def configure_handler(handler, app, formatter, *, extra_filters: Sequence[logging.Filter]):
-    handler.setLevel(logging.getLevelName(app.config["NOTIFY_LOG_LEVEL"]))
+    handler.setLevel(logging.getLevelName(app.config["NOTIFY_LOG_LEVEL_HANDLERS"]))
     handler.setFormatter(formatter)
     handler.addFilter(AppNameFilter(app.config["NOTIFY_APP_NAME"]))
     handler.addFilter(RequestIdFilter())

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "93.0.0"  # be07bef3f012f0ac2c700237176bb412
+__version__ = "93.1.0"  # 9cc2b70dbe2edeadbeef

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -14,7 +14,7 @@ from notifications_utils.testing.comparisons import AnyStringMatching, Restricte
 
 def test_get_handlers_sets_up_logging_appropriately_with_debug():
     class App:
-        config = {"NOTIFY_APP_NAME": "bar", "NOTIFY_LOG_LEVEL": "ERROR"}
+        config = {"NOTIFY_APP_NAME": "bar", "NOTIFY_LOG_LEVEL": "ERROR", "NOTIFY_LOG_LEVEL_HANDLERS": "ERROR"}
         debug = True
 
     app = App()
@@ -31,6 +31,7 @@ def test_get_handlers_sets_up_logging_appropriately_without_debug():
         config = {
             "NOTIFY_APP_NAME": "bar",
             "NOTIFY_LOG_LEVEL": "ERROR",
+            "NOTIFY_LOG_LEVEL_HANDLERS": "ERROR",
         }
         debug = False
 
@@ -58,6 +59,7 @@ def test_log_timeformat_fractional_seconds(frozen_time, logged_time, tmpdir):
             config = {
                 "NOTIFY_APP_NAME": "bar",
                 "NOTIFY_LOG_LEVEL": "INFO",
+                "NOTIFY_LOG_LEVEL_HANDLERS": "INFO",
             }
             debug = False
 


### PR DESCRIPTION
This allows the handler's log level to be set differently from `NOTIFY_LOG_LEVEL`, but it should continue to fall back to `NOTIFY_LOG_LEVEL`'s value if not set explicitly.

This is a stopgap workaround to introduce a little bit of flexibility into our weirdly inflexible log setup (i.e. to make it possible to get some use out of `NOTIFY_REQUEST_LOG_LEVEL` without having to raise the global log level.