### PR TITLE
logging: add verbose eventlet context if `request_time` is over a threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 93.2.0
+
+* logging: add verbose eventlet context to app.request logs if request_time is over a threshold
+
 ## 93.1.0
 
 * Introduce `NOTIFY_LOG_LEVEL_HANDLERS` config variable for separate control of handler log level

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "93.1.0"  # 9cc2b70dbe2edeadbeef
+__version__ = "93.2.0"  # e4b9280ba6f4deadbeef


### PR DESCRIPTION
This will emit the raw values of the thread_time and perf_counter for the eventlet hub greenlet and, if the server greenlet has been helpfully annotated on to the flask application, that too.

These values aren't very useful on their own but cpu usage can inferred from the difference between successive calls.