### PR TITLE
Don’t symlink pyproject.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 93.2.1
+
+* Replaces symlink at `./pyproject.toml` with a duplicate file
+
 ## 93.2.0
 
 * logging: add verbose eventlet context to app.request logs if request_time is over a threshold

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "93.2.0"  # e4b9280ba6f4deadbeef
+__version__ = "93.2.1"  # ebe574d569d5d8075a8e0538bef2a9a7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,1 +1,35 @@
-notifications_utils/version_tools/pyproject.toml
+[tool.black]
+line-length = 120
+
+[tool.ruff]
+line-length = 120
+
+target-version = "py311"
+
+lint.select = [
+    "E",  # pycodestyle
+    "W",  # pycodestyle
+    "F",  # pyflakes
+    "I",  # isort
+    "B",  # flake8-bugbear
+    "C90",  # mccabe cyclomatic complexity
+    "G",  # flake8-logging-format
+    "T20", # flake8-print
+    "UP",  # pyupgrade
+    "C4",  # flake8-comprehensions
+    "ISC",  # flake8-implicit-str-concat
+    "RSE",  # flake8-raise
+    "PIE",  # flake8-pie
+    "N804",  # First argument of a class method should be named `cls`
+]
+lint.ignore = []
+exclude = [
+    "migrations/versions/",
+    "venv*",
+    "__pycache__",
+    "node_modules",
+    "cache",
+    "migrations",
+    "build",
+    "sample_cap_xml_documents.py",
+]


### PR DESCRIPTION
When someone tries to access this file from the Github API it doesn’t cleanly redirect.

This is causing an error with what uv is trying to do in https://github.com/astral-sh/uv/pull/10765

We can do some work later to make sure these 2 files don’t get out of sync, or some other longer-term fix.