### PR TITLE
Replace `black` with `ruff format`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 95.0.0
+
+* Replace `black` formatter with `ruff format`
+
 ## 94.0.0
 
 * `version_tools.copy_config` will now copy `ruff.toml` instead of `pyproject.toml`. Apps should maintain their own `pyproject.toml`, if required

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ bootstrap: ## Build project
 .PHONY: test
 test: ## Run tests
 	ruff check .
-	black --check .
+	ruff format --check .
 	pytest -n auto
 	python setup.py sdist
 

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -11,17 +11,17 @@ from notifications_utils.sanitise_text import SanitiseSMS
 from . import email_with_smart_quotes_regex
 
 OBSCURE_ZERO_WIDTH_WHITESPACE = (
-    "\u180E"  # Mongolian vowel separator
-    "\u200B"  # zero width space
-    "\u200C"  # zero width non-joiner
-    "\u200D"  # zero width joiner
+    "\u180e"  # Mongolian vowel separator
+    "\u200b"  # zero width space
+    "\u200c"  # zero width non-joiner
+    "\u200d"  # zero width joiner
     "\u2060"  # word joiner
-    "\uFEFF"  # zero width non-breaking space
+    "\ufeff"  # zero width non-breaking space
     "\u2028"  # line separator
     "\u2029"  # paragraph separator
 )
 
-OBSCURE_FULL_WIDTH_WHITESPACE = "\u00A0\u202F"  # non breaking space  # narrow no break space
+OBSCURE_FULL_WIDTH_WHITESPACE = "\u00a0\u202f"  # non breaking space  # narrow no break space
 
 ALL_WHITESPACE = string.whitespace + OBSCURE_ZERO_WIDTH_WHITESPACE + OBSCURE_FULL_WIDTH_WHITESPACE
 
@@ -56,7 +56,7 @@ more_than_two_newlines_in_a_row = re.compile(r"\n{3,}")
 
 
 def unlink_govuk_escaped(message):
-    return re.sub(govuk_not_a_link, r"\1\2\3" + ".\u200B" + r"\4", message)  # Unicode zero-width space
+    return re.sub(govuk_not_a_link, r"\1\2\3" + ".\u200b" + r"\4", message)  # Unicode zero-width space
 
 
 def nl2br(value):

--- a/notifications_utils/letter_timings.py
+++ b/notifications_utils/letter_timings.py
@@ -26,7 +26,8 @@ non_working_days_dvla = BankHolidays(
     weekend=(5, 6),
 )
 non_working_days_royal_mail = BankHolidays(
-    use_cached_holidays=True, weekend=(6,)  # Only Sunday (day 6 of the week) is a non-working day
+    use_cached_holidays=True,
+    weekend=(6,),  # Only Sunday (day 6 of the week) is a non-working day
 )
 
 

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -297,8 +297,7 @@ class RecipientCSV:
                     # Work out which columns are shared between the possible
                     # letter address columns and the columns in the user’s
                     # spreadsheet (`&` means set intersection)
-                    set_to_check
-                    & self.column_headers_as_column_keys
+                    set_to_check & self.column_headers_as_column_keys
                 )
                 >= self.count_of_required_recipient_columns
             ):

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -12,16 +12,16 @@ class SanitiseText:
         "’": "'",  # RIGHT SINGLE QUOTATION MARK (U+2019)
         "“": '"',  # LEFT DOUBLE QUOTATION MARK (U+201C)
         "”": '"',  # RIGHT DOUBLE QUOTATION MARK (U+201D)
-        "\u180E": "",  # Mongolian vowel separator
-        "\u200B": "",  # zero width space
-        "\u200C": "",  # zero width non-joiner
-        "\u200D": "",  # zero width joiner
+        "\u180e": "",  # Mongolian vowel separator
+        "\u200b": "",  # zero width space
+        "\u200c": "",  # zero width non-joiner
+        "\u200d": "",  # zero width joiner
         "\u2060": "",  # word joiner
-        "\uFEFF": "",  # zero width non-breaking space
+        "\ufeff": "",  # zero width non-breaking space
         "\u2028": "",  # line separator
         "\u2029": "",  # paragraph separator
-        "\u00A0": " ",  # NON BREAKING WHITE SPACE (U+200B)
-        "\u202F": " ",  # narrow no break space
+        "\u00a0": " ",  # NON BREAKING WHITE SPACE (U+200B)
+        "\u202f": " ",  # narrow no break space
         "\t": " ",  # TAB
         "Ł": "L",  # LATIN CAPITAL LETTER L WITH STROKE (U+0141)
         "ł": "l",  # LATIN SMALL LETTER L WITH STROKE (U+0142)

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "94.0.0"  # 51e5c8ff93e67b55c22b89eb9be46d63
+__version__ = "95.0.0"  # 407446dabaace971269726f8643fa217

--- a/notifications_utils/version_tools/.pre-commit-config.yaml
+++ b/notifications_utils/version_tools/.pre-commit-config.yaml
@@ -11,8 +11,4 @@ repos:
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
-- repo: https://github.com/psf/black
-  rev: 24.10.0
-  hooks:
-    - id: black
-      name: black (python)
+    - id: ruff-format

--- a/notifications_utils/version_tools/requirements_for_test_common.in
+++ b/notifications_utils/version_tools/requirements_for_test_common.in
@@ -7,5 +7,4 @@ pytest-testmon==2.1.1
 requests-mock==1.12.1
 freezegun==1.5.1
 
-black==24.10.0  # Also update `.pre-commit-config.yaml` if this changes
 ruff==0.8.2  # Also update `.pre-commit-config.yaml` if this changes

--- a/notifications_utils/version_tools/ruff.toml
+++ b/notifications_utils/version_tools/ruff.toml
@@ -25,7 +25,6 @@ select = [
     "T20", # flake8-print
     "UP",  # pyupgrade
     "C4",  # flake8-comprehensions
-    "ISC",  # flake8-implicit-str-concat
     "RSE",  # flake8-raise
     "PIE",  # flake8-pie
     "N804",  # First argument of a class method should be named `cls`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,0 @@
-[tool.black]
-line-length = 120

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -8,8 +8,6 @@ beautifulsoup4==4.12.3
     # via -r requirements_for_test_common.in
 billiard==4.2.1
     # via celery
-black==24.10.0
-    # via -r requirements_for_test_common.in
 blinker==1.9.0
     # via flask
 boto3==1.35.87
@@ -28,7 +26,6 @@ charset-normalizer==3.4.0
     # via requests
 click==8.1.7
     # via
-    #   black
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -86,21 +83,14 @@ markupsafe==3.0.2
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils (setup.py)
-mypy-extensions==1.0.0
-    # via black
 ordered-set==4.1.0
     # via notifications-utils (setup.py)
 packaging==24.1
     # via
-    #   black
     #   gunicorn
     #   pytest
-pathspec==0.12.1
-    # via black
 phonenumbers==8.13.52
     # via notifications-utils (setup.py)
-platformdirs==4.3.6
-    # via black
 pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.48

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -427,7 +427,6 @@ def test_format_phone_number_human_readable_doenst_throw():
 
 
 class TestPhoneNumberClass:
-
     @pytest.mark.parametrize("phone_number, error_message", invalid_uk_mobile_phone_numbers)
     def test_rejects_invalid_uk_mobile_phone_numbers(self, phone_number, error_message):
         # problem is `invalid_uk_mobile_phone_numbers` also includes valid uk landlines

--- a/tests/recipient_validation/test_postal_address.py
+++ b/tests/recipient_validation/test_postal_address.py
@@ -1038,20 +1038,17 @@ def test_bfpo_address_lines_error():
 
 
 def test_bfpo_address_with_country_still_shows_country_in_normalised_lines_even_if_invalid():
-    assert (
-        PostalAddress(
-            """International BFPO
+    assert PostalAddress(
+        """International BFPO
             BFPO 1
             BF1 1AA
             usa"""
-        ).normalised_lines
-        == [
-            "International BFPO",
-            "BF1 1AA",
-            "BFPO 1",
-            "United States",
-        ]
-    )
+    ).normalised_lines == [
+        "International BFPO",
+        "BF1 1AA",
+        "BFPO 1",
+        "United States",
+    ]
 
 
 def test_postal_address_equality():

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -121,7 +121,10 @@ def test_send_task_injects_global_request_id_into_headers(
     notify_celery.send_task("some-task")
 
     super_apply.assert_called_with(
-        "some-task", None, None, headers={"notify_request_id": "1234"}  # name  # args  # kwargs  # other kwargs
+        "some-task",
+        None,
+        None,
+        headers={"notify_request_id": "1234"},  # name  # args  # kwargs  # other kwargs
     )
 
 
@@ -157,7 +160,10 @@ def test_send_task_injects_request_id_with_none_headers(
     )
 
     super_apply.assert_called_with(
-        "some-task", None, None, headers={"notify_request_id": "1234"}  # name  # args  # kwargs  # other kwargs
+        "some-task",
+        None,
+        None,
+        headers={"notify_request_id": "1234"},  # name  # args  # kwargs  # other kwargs
     )
 
 
@@ -174,5 +180,8 @@ def test_send_task_injects_id_from_request(
         notify_celery.send_task("some-task")
 
     super_apply.assert_called_with(
-        "some-task", None, None, headers={"notify_request_id": "1234"}  # name  # args  # kwargs  # other kwargs
+        "some-task",
+        None,
+        None,
+        headers={"notify_request_id": "1234"},  # name  # args  # kwargs  # other kwargs
     )

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -121,10 +121,10 @@ def test_send_task_injects_global_request_id_into_headers(
     notify_celery.send_task("some-task")
 
     super_apply.assert_called_with(
-        "some-task",
-        None,
-        None,
-        headers={"notify_request_id": "1234"},  # name  # args  # kwargs  # other kwargs
+        "some-task",  # name
+        None,  # args
+        None,  # kwargs
+        headers={"notify_request_id": "1234"},  # other kwargs
     )
 
 
@@ -153,7 +153,7 @@ def test_send_task_injects_request_id_with_none_headers(
     g.request_id = "1234"
 
     notify_celery.send_task(
-        "some-task",
+        "some-task",  # name
         None,  # args
         None,  # kwargs
         headers=None,  # other kwargs (task retry set headers to "None")
@@ -180,8 +180,8 @@ def test_send_task_injects_id_from_request(
         notify_celery.send_task("some-task")
 
     super_apply.assert_called_with(
-        "some-task",
-        None,
-        None,
-        headers={"notify_request_id": "1234"},  # name  # args  # kwargs  # other kwargs
+        "some-task",  # name
+        None,  # args
+        None,  # kwargs
+        headers={"notify_request_id": "1234"},  # other kwargs
     )

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -251,7 +251,7 @@ def test_what_will_trigger_conditional_placeholder(value):
             "list: ",
         ),
         (
-            {"placeholder": [" ", " \t ", "\u180E"]},
+            {"placeholder": [" ", " \t ", "\u180e"]},
             "list: ",
             "list: ",
         ),

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -64,7 +64,7 @@ def test_HTML_template_has_URLs_replaced_with_links():
 
 def test_escaping_govuk_in_email_templates():
     template_content = "GOV.UK"
-    expected = "GOV.\u200BUK"
+    expected = "GOV.\u200bUK"
     assert unlink_govuk_escaped(template_content) == expected
     template_json = {"content": template_content, "subject": "", "template_type": "email"}
     assert expected in str(PlainTextEmailTemplate(template_json))
@@ -75,17 +75,17 @@ def test_escaping_govuk_in_email_templates():
     "template_content,expected",
     [
         # Cases that we add the breaking space
-        ("GOV.UK", "GOV.\u200BUK"),
-        ("gov.uk", "gov.\u200Buk"),
-        ("content with space infront GOV.UK", "content with space infront GOV.\u200BUK"),
-        ("content with tab infront\tGOV.UK", "content with tab infront\tGOV.\u200BUK"),
-        ("content with newline infront\nGOV.UK", "content with newline infront\nGOV.\u200BUK"),
-        ("*GOV.UK", "*GOV.\u200BUK"),
-        ("#GOV.UK", "#GOV.\u200BUK"),
-        ("^GOV.UK", "^GOV.\u200BUK"),
-        (" #GOV.UK", " #GOV.\u200BUK"),
-        ("GOV.UK with CONTENT after", "GOV.\u200BUK with CONTENT after"),
-        ("#GOV.UK with CONTENT after", "#GOV.\u200BUK with CONTENT after"),
+        ("GOV.UK", "GOV.\u200bUK"),
+        ("gov.uk", "gov.\u200buk"),
+        ("content with space infront GOV.UK", "content with space infront GOV.\u200bUK"),
+        ("content with tab infront\tGOV.UK", "content with tab infront\tGOV.\u200bUK"),
+        ("content with newline infront\nGOV.UK", "content with newline infront\nGOV.\u200bUK"),
+        ("*GOV.UK", "*GOV.\u200bUK"),
+        ("#GOV.UK", "#GOV.\u200bUK"),
+        ("^GOV.UK", "^GOV.\u200bUK"),
+        (" #GOV.UK", " #GOV.\u200bUK"),
+        ("GOV.UK with CONTENT after", "GOV.\u200bUK with CONTENT after"),
+        ("#GOV.UK with CONTENT after", "#GOV.\u200bUK with CONTENT after"),
         # Cases that we don't add the breaking space
         ("https://gov.uk", "https://gov.uk"),
         ("https://www.gov.uk", "https://www.gov.uk"),
@@ -338,7 +338,7 @@ def test_unicode_dash_lookup():
         """
         \t    bar
     """,
-        " \u180E\u200B \u200C bar \u200D \u2060\uFEFF ",
+        " \u180e\u200b \u200c bar \u200d \u2060\ufeff ",
     ],
 )
 def test_strip_all_whitespace(value):
@@ -350,7 +350,7 @@ def test_strip_all_whitespace(value):
     [
         "notifications-email",
         "  \tnotifications-email \x0c ",
-        "\rn\u200Coti\u200Dfi\u200Bcati\u2060ons-\u180Eemai\uFEFFl\uFEFF",
+        "\rn\u200coti\u200dfi\u200bcati\u2060ons-\u180eemai\ufeffl\ufeff",
     ],
 )
 def test_strip_and_remove_obscure_whitespace(value):
@@ -363,21 +363,18 @@ def test_strip_and_remove_obscure_whitespace_only_removes_normal_whitespace_from
 
 
 def test_remove_smart_quotes_from_email_addresses():
-    assert (
-        remove_smart_quotes_from_email_addresses(
-            """
+    assert remove_smart_quotes_from_email_addresses(
+        """
         line one’s quote
         first.o’last@example.com is someone’s email address
         line ‘three’
     """
-        )
-        == (
-            """
+    ) == (
+        """
         line one’s quote
         first.o'last@example.com is someone’s email address
         line ‘three’
     """
-        )
     )
 
 
@@ -388,14 +385,14 @@ def test_strip_unsupported_characters():
 @pytest.mark.parametrize(
     "value",
     [
-        "\u200C Your tax   is\ndue\n\n",
+        "\u200c Your tax   is\ndue\n\n",
         "  Your tax is due  ",
         # Non breaking spaces replaced by single spaces
-        "\u00A0Your\u00A0tax\u00A0 is\u00A0\u00A0due\u00A0",
+        "\u00a0Your\u00a0tax\u00a0 is\u00a0\u00a0due\u00a0",
         # Narrow no break spaces replaced by single spaces
-        "\u202FYour\u202Ftax\u202F is\u202F\u202Fdue\u202F",
+        "\u202fYour\u202ftax\u202f is\u202f\u202fdue\u202f",
         # zero width spaces are removed
-        "\u180EYour \u200Btax\u200C is \u200D\u2060due \uFEFF\u2028\u2029",
+        "\u180eYour \u200btax\u200c is \u200d\u2060due \ufeff\u2028\u2029",
         # tabs are replaced by single spaces
         "\tYour tax\tis due  ",
     ],

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -953,14 +953,14 @@ def test_ignores_spaces_and_case_in_placeholders(key, expected):
         ("\n", None),  # newline
         ("\r", None),  # carriage return
         ("\t", None),  # tab
-        ("\u180E", "MONGOLIAN VOWEL SEPARATOR"),
-        ("\u200B", "ZERO WIDTH SPACE"),
-        ("\u200C", "ZERO WIDTH NON-JOINER"),
-        ("\u200D", "ZERO WIDTH JOINER"),
+        ("\u180e", "MONGOLIAN VOWEL SEPARATOR"),
+        ("\u200b", "ZERO WIDTH SPACE"),
+        ("\u200c", "ZERO WIDTH NON-JOINER"),
+        ("\u200d", "ZERO WIDTH JOINER"),
         ("\u2060", "WORD JOINER"),
-        ("\uFEFF", "ZERO WIDTH NO-BREAK SPACE"),
+        ("\ufeff", "ZERO WIDTH NO-BREAK SPACE"),
         # all the things
-        (" \n\r\t\u000A\u000D\u180E\u200B\u200C\u200D\u2060\uFEFF", None),
+        (" \n\r\t\u000a\u000d\u180e\u200b\u200c\u200d\u2060\ufeff", None),
     ),
 )
 def test_ignores_leading_whitespace_in_file(character, name):

--- a/tests/test_sanitise_text.py
+++ b/tests/test_sanitise_text.py
@@ -12,7 +12,7 @@ params, ids = zip(
     (("–", "-"), "compatibility transform unicode char (EN DASH (U+2013)"),
     (("—", "-"), "compatibility transform unicode char (EM DASH (U+2014)"),
     (("…", "..."), "compatibility transform unicode char (HORIZONTAL ELLIPSIS (U+2026)"),
-    (("\u200B", ""), "compatibility transform unicode char (ZERO WIDTH SPACE (U+200B)"),
+    (("\u200b", ""), "compatibility transform unicode char (ZERO WIDTH SPACE (U+200B)"),
     (("‘", "'"), "compatibility transform unicode char (LEFT SINGLE QUOTATION MARK (U+2018)"),
     (("’", "'"), "compatibility transform unicode char (RIGHT SINGLE QUOTATION MARK (U+2019)"),
     (("“", '"'), "compatibility transform unicode char (LEFT DOUBLE QUOTATION MARK (U+201C)	"),
@@ -93,7 +93,7 @@ def test_encode_string(content, expected):
         ("Ŵêlsh chârâctêrs ârê cômpâtîblê wîth SanitiseSMS", SanitiseSMS, set()),
         ("Lots of GSM chars that arent ascii compatible:\n\r€", SanitiseSMS, set()),
         ("Lots of GSM chars that arent ascii compatible:\n\r€", SanitiseASCII, {"\n", "\r", "€"}),
-        ("Obscure\u00A0whitespace\u202Fcharacters which \u2028we \u2029normalise o\u180Eut", SanitiseSMS, set()),
+        ("Obscure\u00a0whitespace\u202fcharacters which \u2028we \u2029normalise o\u180eut", SanitiseSMS, set()),
     ],
 )
 def test_sms_encoding_get_non_compatible_characters(content, cls, expected):

--- a/tests/test_serialised_model.py
+++ b/tests/test_serialised_model.py
@@ -98,7 +98,6 @@ def test_model_raises_keyerror_if_item_missing_from_dict():
 )
 def test_model_doesnt_swallow_attribute_errors(json_response):
     class Custom(SerialisedModel):
-
         @property
         def foo(self):
             raise AttributeError("Something has gone wrong")

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -448,9 +448,9 @@ def test_HTML_template_has_URLs_replaced_with_links(content, html_snippet):
 @pytest.mark.parametrize(
     "template_content,expected",
     [
-        ("gov.uk", "gov.\u200Buk"),
-        ("GOV.UK", "GOV.\u200BUK"),
-        ("Gov.uk", "Gov.\u200Buk"),
+        ("gov.uk", "gov.\u200buk"),
+        ("GOV.UK", "GOV.\u200bUK"),
+        ("Gov.uk", "Gov.\u200buk"),
         ("https://gov.uk", "https://gov.uk"),
         ("https://www.gov.uk", "https://www.gov.uk"),
         ("www.gov.uk", "www.gov.uk"),
@@ -645,7 +645,7 @@ def test_sms_message_normalises_newlines(content):
     ),
 )
 def test_phone_templates_normalise_whitespace(template_class):
-    content = "  Hi\u00A0there\u00A0 what's\u200D up\t"
+    content = "  Hi\u00a0there\u00a0 what's\u200d up\t"
     assert (
         str(template_class({"content": content, "template_type": template_class.template_type})) == "Hi there what's up"
     )
@@ -1883,7 +1883,7 @@ def test_whitespace_in_subjects(template_class, template_type, subject, extra_ar
 def test_whitespace_in_subject_placeholders(template_class):
     assert (
         template_class(
-            {"content": "", "subject": "\u200C Your tax   ((status))", "template_type": "email"},
+            {"content": "", "subject": "\u200c Your tax   ((status))", "template_type": "email"},
             values={"status": " is\ndue "},
         ).subject
         == "Your tax is due"


### PR DESCRIPTION
It’s faster and means we have one fewer dependencies.

While ruff aims for 99.9% compatibility with black our codebase is big enough to hit a couple of the differences, hence some slight changes to Python code, and the need to consider this a breaking change for consuming apps.