### PR TITLE
Add `ruff.toml` to `MANIFEST.in`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 94.0.1
+
+* Add `ruff.toml` to `MANIFEST.in`
+
 ## 94.0.0
 
 * `version_tools.copy_config` will now copy `ruff.toml` instead of `pyproject.toml`. Apps should maintain their own `pyproject.toml`, if required

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,5 @@ recursive-include notifications_utils *.json
 recursive-include notifications_utils *.txt
 include notifications_utils/international_billing_rates.yml
 include notifications_utils/version_tools/.pre-commit-config.yaml
-include notifications_utils/version_tools/pyproject.toml
+include notifications_utils/version_tools/ruff.toml
 include notifications_utils/version_tools/requirements_for_test_common.in

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "94.0.0"  # 52c43983a6cb0c115776892536350c68
+__version__ = "94.0.1"  # 8598515f3f9fd07cb41c0516e2f4bbcf


### PR DESCRIPTION
Otherwise consuming apps won’t have access to it