### PR TITLE
Add lint rule (RUF100) for inapplicable `# noqa`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 95.1.1
+
+* Add `RUF100` rule to linter config (checks for inapplicable uses of `# noqa`)
+
 # 95.1.0
 
 * Adds log message and statsd metric for retried celery tasks

--- a/notifications_utils/recipient_validation/email_address.py
+++ b/notifications_utils/recipient_validation/email_address.py
@@ -15,7 +15,7 @@ VALID_LOCAL_CHARS = r"a-zA-Z0-9.!#$%&'*+/=?^_`{|}~\-"
 EMAIL_REGEX_PATTERN = rf"^[{VALID_LOCAL_CHARS}]+@([^.@][^@\s]+)$"
 
 
-def validate_email_address(email_address):  # noqa (C901 too complex)
+def validate_email_address(email_address):
     # almost exactly the same as by https://github.com/wtforms/wtforms/blob/master/wtforms/validators.py,
     # with minor tweaks for SES compatibility - to avoid complications we are a lot stricter with the local part
     # than neccessary - we don't allow any double quotes or semicolons to prevent SES Technical Failures

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "95.1.0"  # 3a34fa03b60deadbeef
+__version__ = "95.1.1"  # 5634c78180fe1a817650f156ec524813

--- a/notifications_utils/version_tools/ruff.toml
+++ b/notifications_utils/version_tools/ruff.toml
@@ -29,5 +29,6 @@ select = [
     "RSE",  # flake8-raise
     "PIE",  # flake8-pie
     "N804",  # First argument of a class method should be named `cls`
+    "RUF100",  # Checks for noqa directives that are no longer applicable
 ]
 ignore = []

--- a/tests/test_asset_fingerprinter.py
+++ b/tests/test_asset_fingerprinter.py
@@ -12,11 +12,11 @@ class TestAssetFingerprint:
         asset_fingerprinter = AssetFingerprinter(asset_root="/suppliers/static/")
         assert (
             asset_fingerprinter.get_url("application.css")
-            == "/suppliers/static/application.css?418e6f4a6cdf1142e45c072ed3e1c90a"  # noqa
+            == "/suppliers/static/application.css?418e6f4a6cdf1142e45c072ed3e1c90a"
         )
         assert (
             asset_fingerprinter.get_url("application-ie6.css")
-            == "/suppliers/static/application-ie6.css?418e6f4a6cdf1142e45c072ed3e1c90a"  # noqa
+            == "/suppliers/static/application-ie6.css?418e6f4a6cdf1142e45c072ed3e1c90a"
         )
 
     def test_building_file_path(self, mocker):

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -29,11 +29,11 @@ from notifications_utils.template import (
     [
         (
             """https://example.com/"onclick="alert('hi')""",
-            """<a class="govuk-link govuk-link--no-visited-state" href="https://example.com/%22onclick=%22alert%28%27hi%27%29">https://example.com/"onclick="alert('hi')</a>""",  # noqa
+            """<a class="govuk-link govuk-link--no-visited-state" href="https://example.com/%22onclick=%22alert%28%27hi%27%29">https://example.com/"onclick="alert('hi')</a>""",
         ),
         (
             """https://example.com/"style='text-decoration:blink'""",
-            """<a class="govuk-link govuk-link--no-visited-state" href="https://example.com/%22style=%27text-decoration:blink%27">https://example.com/"style='text-decoration:blink'</a>""",  # noqa
+            """<a class="govuk-link govuk-link--no-visited-state" href="https://example.com/%22style=%27text-decoration:blink%27">https://example.com/"style='text-decoration:blink'</a>""",
         ),
     ],
 )

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -88,18 +88,18 @@ def test_handles_placeholders_in_urls():
     [
         (
             """https://example.com"onclick="alert('hi')""",
-            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22onclick=%22alert%28%27hi">https://example.com"onclick="alert('hi</a>')""",  # noqa
-            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22onclick=%22alert%28%27hi">https://example.com"onclick="alert('hi</a>‘)""",  # noqa
+            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22onclick=%22alert%28%27hi">https://example.com"onclick="alert('hi</a>')""",
+            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22onclick=%22alert%28%27hi">https://example.com"onclick="alert('hi</a>‘)""",
         ),
         (
             """https://example.com/login?redirect=%2Fhomepage%3Fsuccess=true%26page=blue""",
-            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com/login?redirect=%2Fhomepage%3Fsuccess=true%26page=blue">https://example.com/login?redirect=%2Fhomepage%3Fsuccess=true%26page=blue</a>""",  # noqa
-            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com/login?redirect=%2Fhomepage%3Fsuccess=true%26page=blue">https://example.com/login?redirect=%2Fhomepage%3Fsuccess=true%26page=blue</a>""",  # noqa
+            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com/login?redirect=%2Fhomepage%3Fsuccess=true%26page=blue">https://example.com/login?redirect=%2Fhomepage%3Fsuccess=true%26page=blue</a>""",
+            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com/login?redirect=%2Fhomepage%3Fsuccess=true%26page=blue">https://example.com/login?redirect=%2Fhomepage%3Fsuccess=true%26page=blue</a>""",
         ),
         (
             """https://example.com"style='text-decoration:blink'""",
-            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22style=%27text-decoration:blink">https://example.com"style='text-decoration:blink</a>'""",  # noqa
-            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22style=%27text-decoration:blink">https://example.com"style='text-decoration:blink</a>’""",  # noqa
+            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22style=%27text-decoration:blink">https://example.com"style='text-decoration:blink</a>'""",
+            """<a style="word-wrap: break-word; color: #1D70B8;" href="https://example.com%22style=%27text-decoration:blink">https://example.com"style='text-decoration:blink</a>’""",
         ),
     ],
 )


### PR DESCRIPTION
Noticed this during a PR review and think it’s better to use a rule (where one exists) rather than a discussion back and forth.

> A noqa directive that no longer matches any diagnostic violations is likely included by mistake, and should be removed to avoid confusion.

– https://docs.astral.sh/ruff/rules/unused-noqa/