### PR TITLE
Fix heading levels in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 * Add `RUF100` rule to linter config (checks for inapplicable uses of `# noqa`)
 
-# 95.1.0
+## 95.1.0
 
 * Adds log message and statsd metric for retried celery tasks
 
-# 95.0.0
+## 95.0.0
 
 * Reverts 92.0.0 to restore new validation code
 


### PR DESCRIPTION
If these are level 1 headings they get interpreted as comments in a commit message.

The version tools module expects a level 2 heading here:
https://github.com/alphagov/notifications-utils/blob/361486ff4960b5d02c162118b1fd64b097f9cb96/notifications_utils/version_tools/__init__.py#L84-L86