### PR TITLE
Implement `InsensitiveSet.__contains__`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 95.2.0
+
+* Implement `InsensitiveSet.__contains__`
+
 ## 95.1.2
 
 * Fix to the number of arguments the `on_retry` of the `NotifyTask` class takes.

--- a/notifications_utils/insensitive_dict.py
+++ b/notifications_utils/insensitive_dict.py
@@ -63,3 +63,6 @@ class InsensitiveDict(dict):
 class InsensitiveSet(OrderedSet):
     def __init__(self, iterable):
         return super().__init__(InsensitiveDict.from_keys(iterable).values())
+
+    def __contains__(self, key):
+        return key in InsensitiveDict.from_keys(self)

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "95.1.2"  # a47171c8774fee6d72573d446710b651
+__version__ = "95.2.0"  # e423953f9dec74010897c62aa4e035de

--- a/tests/test_insensitive_dict.py
+++ b/tests/test_insensitive_dict.py
@@ -112,6 +112,27 @@ def test_insensitive_set():
     )
 
 
+def test_insensitive_set_contains():
+    foobar = InsensitiveSet(("foo", "bar"))
+
+    for key in (
+        "foo",
+        "F o o ",
+        "F_O_O",
+        "B_A_R",
+        "B a r",
+        "bar",
+    ):
+        assert key in foobar
+
+    for key in (
+        "baz",
+        "barz",
+        "z foo",
+    ):
+        assert key not in foobar
+
+
 @pytest.mark.parametrize(
     "extra_args, expected_dict",
     (


### PR DESCRIPTION
I was surprised that `"first name" in InsensitiveSet(['firstname'])` evaluated to `False`.

This commit makes it work the way you’d expect.

We don’t use this in production code yet, but don’t think it can hurt.