### PR TITLE
Update args for the `on_retry` method of `NotifyTask`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 95.1.2
+
+* Fix to the number of arguments the `on_retry` of the `NotifyTask` class takes.
+
 ## 95.1.1
 
 * Add `RUF100` rule to linter config (checks for inapplicable uses of `# noqa`)

--- a/notifications_utils/celery.py
+++ b/notifications_utils/celery.py
@@ -54,7 +54,7 @@ def make_task(app):
                     elapsed_time,
                 )
 
-        def on_retry(self, retval, task_id, args, kwargs):
+        def on_retry(self, exc, task_id, args, kwargs, einfo):
             # enables request id tracing for these logs
             with self.app_context():
                 elapsed_time = time.monotonic() - self.start

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "95.1.1"  # 5634c78180fe1a817650f156ec524813
+__version__ = "95.1.2"  # a47171c8774fee6d72573d446710b651

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -1,7 +1,9 @@
+import inspect
 import logging
 import uuid
 
 import pytest
+from celery import Task
 from flask import g
 from freezegun import freeze_time
 
@@ -211,3 +213,10 @@ def test_send_task_injects_id_from_request(
         None,  # kwargs
         headers={"notify_request_id": "1234"},  # other kwargs
     )
+
+
+@pytest.mark.parametrize("method, _value", list(inspect.getmembers(Task, predicate=inspect.isfunction)))
+def test_method_signatures(celery_app, async_task, method, _value):
+    if method == "run":
+        return
+    assert inspect.signature(getattr(async_task.__class__, method)) == inspect.signature(getattr(Task, method))

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -73,7 +73,7 @@ def test_retry_should_log_and_call_statsd(celery_app, async_task, caplog):
         async_task()
         frozen.tick(5)
 
-        async_task.on_retry(retval=None, task_id=1234, args=[], kwargs={})
+        async_task.on_retry(exc=Exception, task_id="1234", args=[], kwargs={}, einfo=None)
 
     statsd_mock.assert_called_once_with(f"celery.test-queue.{async_task.name}.retry", 5.0)
     assert f"Celery task {async_task.name} (queue: test-queue) failed for retry after 5.0000" in caplog.messages
@@ -86,7 +86,7 @@ def test_retry_queue_when_applied_synchronously(celery_app, celery_task, caplog)
         celery_task()
         frozen.tick(5)
 
-        celery_task.on_retry(retval=None, task_id=1234, args=[], kwargs={})
+        celery_task.on_retry(exc=Exception, task_id="1234", args=[], kwargs={}, einfo=None)
 
     statsd_mock.assert_called_once_with(f"celery.none.{celery_task.name}.retry", 5.0)
     assert f"Celery task {celery_task.name} (queue: none) failed for retry after 5.0000" in caplog.messages


### PR DESCRIPTION
We [saw an error](https://govuk-notify-gds.sentry.io/issues/6332986034/?alert_rule_id=14332524&alert_timestamp=1740541085693&alert_type=email&environment=production&notification_uuid=0102d137-d24c-410c-9528-6171992721d0&project=4504949770092544&referrer=alert_email) when the `on_retry` method was called in production:
`make_task.<locals>.NotifyTask.on_retry() takes 5 positional arguments
but 6 were given`.

This updates the method to use the [same args as the Celery code](https://github.com/celery/celery/blob/e73b71ed2090e83765b14162cadde771c6b520ed/celery/app/task.py#L1048) specifies.