### PR TITLE
Fix qrcode with amp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 97.0.1
+
+* Fix QR code URL with '&' encoded as '&amp;'
+
 ## 97.0.0
 
 * for bilingual letters preview, only show barcodes on the first page (patch).

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -6,7 +6,7 @@ import mistune
 from ordered_set import OrderedSet
 
 from notifications_utils import MAGIC_SEQUENCE, magic_sequence_regex
-from notifications_utils.formatters import create_sanitised_html_for_url, replace_svg_dashes
+from notifications_utils.formatters import create_sanitised_html_for_url, replace_svg_dashes, unescape_strict
 from notifications_utils.qr_code import (
     QR_CODE_MAX_BYTES,
     QrCodeTooLong,
@@ -67,7 +67,7 @@ class NotifyLetterMarkdownPreviewRenderer(mistune.Renderer):
         if "<span class='placeholder" in data or '<span class="placeholder' in data:
             placeholder = qr_code_placeholder(data)
             return replace_svg_dashes(placeholder)
-
+        data = unescape_strict(data)
         qr_data = qr_code_as_svg(data)
         return f"<div class='qrcode'>{replace_svg_dashes(qr_data)}</div>"
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "97.0.0"  # 30cda215ff802d90fad96e1efd98a03b
+__version__ = "97.0.1"  # 00ec821d5d989563632f396ed0dd1b3e

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -656,6 +656,31 @@ def test_letter_qr_code_works_with_extra_whitespace():
             "notifications_utils.markdown.qr_code_as_svg",
             "arbitrary data not a URL",
         ),
+        (
+            "qr: www.gov.uk/search?q=foo&r=bar",
+            "notifications_utils.markdown.qr_code_as_svg",
+            "www.gov.uk/search?q=foo&r=bar",
+        ),
+        (
+            "qr: www.gov.uk/search?q=hello!@#$%^&*<>[]()\"'world",
+            "notifications_utils.markdown.qr_code_as_svg",
+            "www.gov.uk/search?q=hello!@#$%^&*<>[]()\"'world",
+        ),
+        (
+            "qr: www.gov.uk/search?q=hello world",
+            "notifications_utils.markdown.qr_code_as_svg",
+            "www.gov.uk/search?q=hello world",
+        ),
+        (
+            "qr: www.gov.uk/search?q=hello-world",
+            "notifications_utils.markdown.qr_code_as_svg",
+            "www.gov.uk/search?q=hello-world",
+        ),
+        (
+            "qr: www.gov.uk/search?q=user@example.com",
+            "notifications_utils.markdown.qr_code_as_svg",
+            "www.gov.uk/search?q=user@example.com",
+        ),
     ),
 )
 def test_letter_qr_code_only_passes_through_url(


### PR DESCRIPTION
QR codes in letters whose URL includes an ‘&' sign will have it encoded as the '&’ HTML entity. More details on [this card](https://trello.com/c/YESkaUO9/94-qr-codes-with-logos-in-have-encoded-as-amp). There is generic html escape which does not handle the URL use case. So when creating the QR code unescape html to get the original URL.