### PR TITLE
[bug fix] Only show barcode on first page of letter preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 97.0.0
+
+* for bilingual letters preview, only show barcodes on the first page (patch).
+* rename `include_notify_tag` argument to `includes_first_page` (major).
+
 ## 96.0.0
 
 * BREAKING CHANGE: the `gunicorn_defaults` module has been moved to `gunicorn.defaults` to make space for gunicorn-related utils that don't have the restricted-import constraints of the gunicorn defaults. Imports of `notifications_utils.gunicorn_defaults` should be changed to `notifications_utils.gunicorn.defaults`.

--- a/notifications_utils/jinja_templates/letter_pdf/preview.jinja2
+++ b/notifications_utils/jinja_templates/letter_pdf/preview.jinja2
@@ -1,3 +1,6 @@
 {% include 'letter_pdf/_head.jinja2' %}
 {% include 'letter_pdf/_main_css.jinja2' %}
+{% if not includes_first_page %}
+    {% include 'letter_pdf/_print_only_hide_barcodes_css.jinja2' %}
+{% endif %}
 {% include 'letter_pdf/_body.jinja2' %}

--- a/notifications_utils/jinja_templates/letter_pdf/print.jinja2
+++ b/notifications_utils/jinja_templates/letter_pdf/print.jinja2
@@ -1,6 +1,6 @@
 {% include 'letter_pdf/_head.jinja2' %}
 {% include 'letter_pdf/_main_css.jinja2' %}
-{% if include_notify_tag %}
+{% if includes_first_page %}
 {% include 'letter_pdf/_print_only_add_tag_css.jinja2' %}
 {% endif %}
 {% include 'letter_pdf/_print_only_hide_barcodes_css.jinja2' %}

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -726,7 +726,7 @@ class LetterPrintTemplate(LetterPreviewTemplate):
         redact_missing_personalisation=False,
         date=None,
         language="english",
-        include_notify_tag: bool = True,
+        includes_first_page: bool = True,
     ):
         super().__init__(
             template,
@@ -738,11 +738,11 @@ class LetterPrintTemplate(LetterPreviewTemplate):
             date=date,
             language=language,
         )
-        self.include_notify_tag = include_notify_tag
+        self.includes_first_page = includes_first_page
 
     @property
     def render_params(self):
-        return super().render_params | {"include_notify_tag": self.include_notify_tag}
+        return super().render_params | {"includes_first_page": self.includes_first_page}
 
 
 def get_sms_fragment_count(character_count, non_gsm_characters):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -579,6 +579,7 @@ class BaseLetterTemplate(SubjectMixin, Template):
         redact_missing_personalisation=False,
         date=None,
         language="english",
+        includes_first_page: bool = True,
     ):
         self.contact_block = (contact_block or "").strip()
         super().__init__(
@@ -592,6 +593,7 @@ class BaseLetterTemplate(SubjectMixin, Template):
             self.content = template["content"]
         else:
             self.content = template.get("letter_welsh_content", "")
+        self.includes_first_page = includes_first_page
 
     @property
     def subject(self):
@@ -704,6 +706,7 @@ class LetterPreviewTemplate(BaseLetterTemplate):
             "contact_block": self._contact_block,
             "date": self._date,
             "language": self.language,
+            "includes_first_page": self.includes_first_page,
         }
 
     def __str__(self):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "96.0.0"  # 6fdd72884bdeadbeef
+__version__ = "97.0.0"  # 30cda215ff802d90fad96e1efd98a03b

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -777,6 +777,7 @@ def test_letter_preview_renderer(
             "logo_file_name": expected_logo_file_name,
             "logo_class": expected_logo_class,
             "language": "english",
+            "includes_first_page": True,
         }
     )
     letter_markdown.assert_called_once_with(Markup("Foo\n"))
@@ -2248,6 +2249,17 @@ def test_rendered_letter_template_for_print_can_toggle_notify_tag_and_always_hid
     )
     assert ("content: 'NOTIFY';" in str(template)) == should_have_notify_tag
     assert "#mdi,\n  #barcode,\n  #qrcode {\n    display: none;\n  }" in str(template).strip()
+
+
+@pytest.mark.parametrize("includes_first_page", [True, False])
+def test_rendered_letter_template_for_preview_displays_barcodes_only_if_file_includes_first_page(includes_first_page):
+    template = LetterPreviewTemplate(
+        template={"template_type": "letter", "subject": "subject", "content": "content"},
+        includes_first_page=includes_first_page,
+    )
+    assert (
+        "#mdi,\n  #barcode,\n  #qrcode {\n    display: none;\n  }" in str(template).strip()
+    ) is not includes_first_page
 
 
 @pytest.mark.parametrize(

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -2237,8 +2237,8 @@ def test_letter_qr_codes_with_too_much_data(content, values, should_error):
     "extra_template_kwargs, should_have_notify_tag",
     (
         ({}, True),
-        ({"include_notify_tag": True}, True),
-        ({"include_notify_tag": False}, False),
+        ({"includes_first_page": True}, True),
+        ({"includes_first_page": False}, False),
     ),
 )
 def test_rendered_letter_template_for_print_can_toggle_notify_tag_and_always_hides_barcodes(


### PR DESCRIPTION
For bilingual letters, only show the barcodes on the Welsh first page, and not on the English first page - as this is how it will look when printed.

Review commit by commit.

Trello ticket: https://trello.com/c/Hr4MDKlM/152-barcodes-show-on-pages-after-the-1st-on-bilingual-letters

Related template-preview PR: https://github.com/alphagov/notifications-template-preview/pull/872

|BEFORE|AFTER|
|:---|:---|
|![Screenshot 2025-03-04 at 14 42 34](https://github.com/user-attachments/assets/a11fc90f-2c15-4043-b95f-0e6ecbaf763f)|![Screenshot 2025-03-04 at 14 39 39](https://github.com/user-attachments/assets/784bf017-121c-480b-a898-d52bccb6a4b3)|

