### PR TITLE
Fix inset text bottom margin in emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 97.0.4
+
+* Fix inset text block styling
+
 ## 97.0.3
 
 * Bump minimum jinja2 version to 3.1.6

--- a/notifications_utils/markdown.py
+++ b/notifications_utils/markdown.py
@@ -218,12 +218,14 @@ class NotifyEmailMarkdownRenderer(NotifyLetterMarkdownPreviewRenderer):
 
     def block_quote(self, text):
         return (
+            '<div style="Margin: 0 0 20px 0;">'
             "<blockquote "
-            'style="Margin: 0 0 20px 0; border-left: 10px solid #B1B4B6;'
+            'style="Margin: 0; border-left: 10px solid #B1B4B6;'
             'padding: 15px 0 0.1px 15px; font-size: 19px; line-height: 25px;"'
             ">"
             f"{text}"
             "</blockquote>"
+            "</div>"
         )
 
     def link(self, link, title, content):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "97.0.3"  # 43fcdfa6e4588a095aac727b26d2fb7b
+__version__ = "97.0.4"  # 597ba88ca9820431248841288ca7d179

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -160,12 +160,14 @@ def test_block_code(markdown_function, expected):
         [
             notify_email_markdown,
             (
+                '<div style="Margin: 0 0 20px 0;">'
                 "<blockquote "
-                'style="Margin: 0 0 20px 0; border-left: 10px solid #B1B4B6;'
+                'style="Margin: 0; border-left: 10px solid #B1B4B6;'
                 "padding: 15px 0 0.1px 15px; font-size: 19px; line-height: 25px;"
                 '">'
                 '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">inset text</p>'
                 "</blockquote>"
+                "</div>"
             ),
         ],
         [


### PR DESCRIPTION
Addresses https://trello.com/c/7vrT4qfU/104-inset-text-sometimes-has-no-margin-bottom

To reliably have bottom margin applied across clients, bottom margin had to be moved to a wrapping div element.

**Before**
https://app.emailonacid.com/shared-preview/YNbYn8N9oO

**After**
https://app.emailonacid.com/shared-preview/IzCFf5SNC8