### PR TITLE
Add s3 multipart upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 99.2.0
+
+* Add s3 multipart upload lifecycle (create, upload, complete, abort)
+
 ## 99.1.2
 
 * Normalise unusual dashes and spacing characters in phone numbers

--- a/notifications_utils/s3.py
+++ b/notifications_utils/s3.py
@@ -1,7 +1,7 @@
 import urllib
 
 import botocore
-from boto3 import resource
+from boto3 import client, resource
 from flask import current_app
 
 
@@ -45,3 +45,68 @@ def s3download(bucket_name, filename):
         return key.get()["Body"]
     except botocore.exceptions.ClientError as error:
         raise S3ObjectNotFound(error.response, error.operation_name) from error
+
+
+S3_MULTIPART_UPLOAD_MIN_PART_SIZE = 5 * 1024 * 1024  # 5MB minimum multi part upload size
+
+
+def s3_multipart_upload_create(bucket_name, file_location, content_type="binary/octet-stream"):
+    s3 = client("s3")
+
+    args = {"Bucket": bucket_name, "Key": file_location, "ServerSideEncryption": "AES256", "ContentType": content_type}
+
+    try:
+        response = s3.create_multipart_upload(**args)
+        return response
+    except botocore.exceptions.ClientError as e:
+        current_app.logger.error(
+            "Unable to create multipart upload in S3 bucket %s for file %s", bucket_name, file_location
+        )
+        raise e
+
+
+def s3_multipart_upload_part(part_number, bucket_name, filename, upload_id, data_bytes):
+    s3 = client("s3")
+
+    try:
+        response = s3.upload_part(
+            Bucket=bucket_name,
+            Key=filename,
+            PartNumber=part_number,
+            UploadId=upload_id,
+            Body=data_bytes,
+        )
+        return response
+    except botocore.exceptions.ClientError as e:
+        current_app.logger.exception(
+            "Unable to upload part %s in S3 bucket %s for file %s", part_number, bucket_name, filename
+        )
+        raise e
+
+
+def s3_multipart_upload_complete(bucket_name, filename, upload_id, parts):
+    s3 = client("s3")
+    try:
+        s3.complete_multipart_upload(
+            Bucket=bucket_name,
+            Key=filename,
+            UploadId=upload_id,
+            MultipartUpload={"Parts": parts},
+        )
+    except botocore.exceptions.ClientError as e:
+        current_app.logger.exception(
+            "Unable to complete multipart upload %s in S3 bucket %s for file %s", upload_id, bucket_name, filename
+        )
+        raise e
+
+
+def s3_multipart_upload_abort(bucket_name, filename, upload_id):
+    s3 = client("s3")
+
+    try:
+        s3.abort_multipart_upload(Bucket=bucket_name, Key=filename, UploadId=upload_id)
+    except botocore.exceptions.ClientError as e:
+        current_app.logger.exception(
+            "Unable to abort multipart upload %s in S3 bucket %s for file %s", upload_id, bucket_name, filename
+        )
+        raise e

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "99.1.2"  # af37fbfe92443682ed37eaddc33d46cc
+__version__ = "99.2.0"  # f57494ce591b31257402a54c2a11b8ae

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -3,13 +3,23 @@ from urllib.parse import parse_qs
 import botocore
 import pytest
 
-from notifications_utils.s3 import S3ObjectNotFound, s3download, s3upload
+from notifications_utils.s3 import (
+    S3ObjectNotFound,
+    s3_multipart_upload_abort,
+    s3_multipart_upload_complete,
+    s3_multipart_upload_create,
+    s3_multipart_upload_part,
+    s3download,
+    s3upload,
+)
 
 contents = "some file data"
 region = "eu-west-1"
 bucket = "some_bucket"
 location = "some_file_location"
 content_type = "binary/octet-stream"
+upload_id = "test-123-upload-id"
+part_number = 23
 
 
 def test_s3upload_save_file_to_bucket(mocker):
@@ -93,3 +103,133 @@ def test_s3download_raises_on_error(mocker):
 
     with pytest.raises(S3ObjectNotFound):
         s3download("bucket", "location.file")
+
+
+def test_s3_multipart_upload_create(mocker):
+    mocked_s3_client = mocker.patch("notifications_utils.s3.client")
+    mocked_create_multipart_upload = mocked_s3_client.return_value.create_multipart_upload
+
+    s3_multipart_upload_create(bucket_name=bucket, file_location=location)
+
+    mocked_create_multipart_upload.assert_called_once_with(
+        Bucket=bucket,
+        Key=location,
+        ServerSideEncryption="AES256",
+        ContentType=content_type,
+    )
+
+
+def test_s3_multipart_upload_create_with_content_type(mocker):
+    mocked_s3_client = mocker.patch("notifications_utils.s3.client")
+    mocked_create_multipart_upload = mocked_s3_client.return_value.create_multipart_upload
+
+    s3_multipart_upload_create(bucket_name=bucket, file_location=location, content_type="text/csv")
+
+    mocked_create_multipart_upload.assert_called_once_with(
+        Bucket=bucket,
+        Key=location,
+        ServerSideEncryption="AES256",
+        ContentType="text/csv",
+    )
+
+
+def test_s3_multipart_upload_create_failure(mocker, app_with_mocked_logger):
+    response = {"Error": {"Code": 500}}
+    exception = botocore.exceptions.ClientError(response, "Bad exception")
+
+    mocked_s3_client = mocker.patch("notifications_utils.s3.client")
+    mocked_instance = mocked_s3_client.return_value
+    mocked_instance.create_multipart_upload.side_effect = exception
+
+    with pytest.raises(botocore.exceptions.ClientError):
+        s3_multipart_upload_create(bucket_name=bucket, file_location=location)
+
+    mocked_instance.create_multipart_upload.assert_called_once()
+
+
+def test_s3_multipart_upload_part(mocker):
+    mocked_s3_client = mocker.patch("notifications_utils.s3.client")
+    mocked_upload_part = mocked_s3_client.return_value.upload_part
+
+    s3_multipart_upload_part(
+        part_number=part_number, bucket_name=bucket, filename=location, upload_id=upload_id, data_bytes=contents
+    )
+
+    mocked_upload_part.assert_called_once_with(
+        Bucket=bucket,
+        Key=location,
+        PartNumber=part_number,
+        UploadId=upload_id,
+        Body=contents,
+    )
+
+
+def test_s3_multipart_upload_part_failure(mocker, app_with_mocked_logger):
+    response = {"Error": {"Code": 500}}
+    exception = botocore.exceptions.ClientError(response, "Bad exception")
+
+    mocked_s3_client = mocker.patch("notifications_utils.s3.client")
+    mocked_instance = mocked_s3_client.return_value
+    mocked_instance.upload_part.side_effect = exception
+
+    with pytest.raises(botocore.exceptions.ClientError):
+        s3_multipart_upload_part(
+            part_number=part_number, bucket_name=bucket, filename=location, upload_id=upload_id, data_bytes=contents
+        )
+
+    mocked_instance.upload_part.assert_called_once()
+
+
+def test_s3_multipart_upload_complete(mocker):
+    mocked_s3_client = mocker.patch("notifications_utils.s3.client")
+    mocked_complete_multipart_upload = mocked_s3_client.return_value.complete_multipart_upload
+
+    s3_multipart_upload_complete(bucket_name=bucket, filename=location, upload_id=upload_id, parts=[])
+
+    mocked_complete_multipart_upload.assert_called_once_with(
+        Bucket=bucket,
+        Key=location,
+        MultipartUpload={"Parts": []},
+        UploadId=upload_id,
+    )
+
+
+def test_s3_multipart_upload_complete_failure(mocker, app_with_mocked_logger):
+    response = {"Error": {"Code": 500}}
+    exception = botocore.exceptions.ClientError(response, "Bad exception")
+
+    mocked_s3_client = mocker.patch("notifications_utils.s3.client")
+    mocked_instance = mocked_s3_client.return_value
+    mocked_instance.complete_multipart_upload.side_effect = exception
+
+    with pytest.raises(botocore.exceptions.ClientError):
+        s3_multipart_upload_complete(bucket_name=bucket, filename=location, upload_id=upload_id, parts=[])
+
+    mocked_instance.complete_multipart_upload.assert_called_once()
+
+
+def test_s3_multipart_upload_abort(mocker):
+    mocked_s3_client = mocker.patch("notifications_utils.s3.client")
+    mocked_abort_multipart_upload = mocked_s3_client.return_value.abort_multipart_upload
+
+    s3_multipart_upload_abort(bucket_name=bucket, filename=location, upload_id=upload_id)
+
+    mocked_abort_multipart_upload.assert_called_once_with(
+        Bucket=bucket,
+        Key=location,
+        UploadId=upload_id,
+    )
+
+
+def test_s3_multipart_upload_abort_failure(mocker, app_with_mocked_logger):
+    response = {"Error": {"Code": 500}}
+    exception = botocore.exceptions.ClientError(response, "Bad exception")
+
+    mocked_s3_client = mocker.patch("notifications_utils.s3.client")
+    mocked_instance = mocked_s3_client.return_value
+    mocked_instance.abort_multipart_upload.side_effect = exception
+
+    with pytest.raises(botocore.exceptions.ClientError):
+        s3_multipart_upload_abort(bucket_name=bucket, filename=location, upload_id=upload_id)
+
+    mocked_instance.abort_multipart_upload.assert_called_once()


### PR DESCRIPTION
Add multipart upload for large file handling. Implement full multipart upload lifecycle (create, upload, complete, abort).
Documentation here: https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-express-using-multipart-upload.html

This PR is part of the notifications request report data processing. Here is the [card](https://trello.com/c/sRiFZcNB/1197-function-report-data-processing) for more details.
