### PR TITLE
Fix links with non-http protocols in Markdown URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 97.0.5
+
+* Fix mailto: URLs in Markdown links
+
 ## 97.0.4
 
 * Fix inset text block styling

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -25,6 +25,8 @@ OBSCURE_FULL_WIDTH_WHITESPACE = "\u00a0\u202f"  # non breaking space  # narrow n
 
 ALL_WHITESPACE = string.whitespace + OBSCURE_ZERO_WIDTH_WHITESPACE + OBSCURE_FULL_WIDTH_WHITESPACE
 
+RECOGNISED_URL_PROTOCOLS = tuple(f"{protocol}:" for protocol in {"ftp", "file", "http", "https", "mailto", "tel"})
+
 govuk_not_a_link = re.compile(r"(^|\s)(#|\*|\^)?(GOV)\.(UK)(?!\/|\?|#)", re.IGNORECASE)
 
 smartypants.tags_to_skip = smartypants.tags_to_skip + ["a"]
@@ -129,7 +131,7 @@ def create_sanitised_html_for_url(link, *, classes="", style="", title="", link_
     if not link_text:
         link_text = link
 
-    if not link.lower().startswith("http"):
+    if not link.lower().startswith(RECOGNISED_URL_PROTOCOLS):
         link = f"http://{link}"
 
     class_attribute = f'class="{classes}" ' if classes else ""

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "97.0.4"  # 597ba88ca9820431248841288ca7d179
+__version__ = "97.0.5"  # 7fcfba793296f83df8fb90897aa2c3a8

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,4 +1,5 @@
 import pytest
+from bs4 import BeautifulSoup
 
 from notifications_utils.field import Field
 from notifications_utils.markdown import (
@@ -250,6 +251,39 @@ def test_external_link_without_http(markdown_function, expected):
 )
 def test_external_link_with_http(markdown_function, expected):
     assert markdown_function("Visit our [website](https://www.example.com/xyz).") == (expected)
+
+
+@pytest.mark.parametrize(
+    "url, expected_link_href",
+    (
+        (
+            "mailto:unsubscribe@example.com",
+            "mailto:unsubscribe%40example.com",
+        ),
+        (
+            "mailto:unsubscribe%40example.com",
+            "mailto:unsubscribe%40example.com",
+        ),
+        (
+            r"file:///C:\Windows\system32\mspaint.exe",
+            "file:///C:%5CWindows%5Csystem32%5Cmspaint.exe",
+        ),
+        (
+            "tel:+44123",
+            "tel:%2B44123",
+        ),
+        (
+            "ftp://username:password@ftp.example.com/folder/",
+            "ftp://username:password%40ftp.example.com/folder/",
+        ),
+    ),
+)
+def test_mailto_link_in_email_markdown_link(url, expected_link_href):
+    paragraph = BeautifulSoup(
+        notify_email_markdown(f"Unusual [link]({url})"),
+        features="html.parser",
+    )
+    assert paragraph.select_one("a")["href"] == expected_link_href
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
In https://github.com/alphagov/notifications-utils/pull/1204 we started prepending `http://` to any URLs which didn’t already have it, where those URLs were part of a Markdown link.

This didn’t account for URLs which use other protocols. Notably we have users who we’ve told to use `mailto:` links for managing unsubscriptions. This change broke those links by turning them into `http://mailto:…`

This commit fixes mailto links, and some other niche protocols which people may use.