### PR TITLE
Update international SMS rate multipliers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 98.0.0
+
+* Update rate multipliers for international SMS to have values for 1 April 2025 onwards. When used in notifications-api and
+  notifications-admin this change will affect the billing of text messages the pricing shown.
+
 ## 97.0.5
 
 * Fix mailto: URLs in Markdown links

--- a/notifications_utils/international_billing_rates.yml
+++ b/notifications_utils/international_billing_rates.yml
@@ -55,7 +55,6 @@
   names:
   - Canada
   - United States
-  - Dominican Republic
 '7':
   attributes:
     alpha: REG
@@ -2930,6 +2929,45 @@
   rate_multiplier: 7
   names:
   - Saint Vincent and The Grenadines
+'1809':
+  attributes:
+    alpha: 'NO'
+    comment: null
+    dlr: Carrier DLR
+    generic_sender: ''
+    numeric: LIMITED
+    sc: 'NO'
+    sender_and_registration_info: All senders CONVERTED into random long numeric senders
+    text_restrictions: Bulk/marketing traffic NOT allowed
+  rate_multiplier: 3
+  names:
+  - Dominican Republic
+'1829':
+  attributes:
+    alpha: 'NO'
+    comment: null
+    dlr: Carrier DLR
+    generic_sender: ''
+    numeric: LIMITED
+    sc: 'NO'
+    sender_and_registration_info: All senders CONVERTED into random long numeric senders
+    text_restrictions: Bulk/marketing traffic NOT allowed
+  rate_multiplier: 3
+  names:
+  - Dominican Republic
+'1849':
+  attributes:
+    alpha: 'NO'
+    comment: null
+    dlr: Carrier DLR
+    generic_sender: ''
+    numeric: LIMITED
+    sc: 'NO'
+    sender_and_registration_info: All senders CONVERTED into random long numeric senders
+    text_restrictions: Bulk/marketing traffic NOT allowed
+  rate_multiplier: 3
+  names:
+  - Dominican Republic
 '1868':
   attributes:
     alpha: null

--- a/notifications_utils/international_billing_rates.yml
+++ b/notifications_utils/international_billing_rates.yml
@@ -66,7 +66,7 @@
     sc: 'NO'
     sender_and_registration_info: ''
     text_restrictions: Transactional traffic ONLY
-  rate_multiplier: 4
+  rate_multiplier: 10
   names:
   - South Ossetia
   - Kazakhstan
@@ -82,7 +82,7 @@
     sc: REG
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 7
   names:
   - Egypt
 '27':
@@ -95,7 +95,7 @@
     sc: 'NO'
     sender_and_registration_info: All senders CONVERTED into long numeric sender
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 3
   names:
   - South Africa
 '30':
@@ -179,7 +179,7 @@
     sc: 'NO'
     sender_and_registration_info: All senders CONVERTED to one national long numeric
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 2
   names:
   - Hungary
 '39':
@@ -235,7 +235,7 @@
       one long numeric sender allowed
     text_restrictions: Bulk traffic NOT allowed. NO political content and other text
       restrictions
-  rate_multiplier: 3
+  rate_multiplier: 2
   names:
   - Austria
 '44':
@@ -248,7 +248,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 1
+  rate_multiplier: 2
   names:
   - Guernsey
   - Isle of Man
@@ -289,7 +289,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 2
   names:
   - Norway
 '48':
@@ -302,7 +302,7 @@
     sc: 'NO'
     sender_and_registration_info: ''
     text_restrictions: ''
-  rate_multiplier: 2
+  rate_multiplier: 1
   names:
   - Poland
 '49':
@@ -315,7 +315,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 4
+  rate_multiplier: 5
   names:
   - Germany
 '51':
@@ -328,7 +328,7 @@
     sc: LIMITED
     sender_and_registration_info: All senders CONVERTED into one SC
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 5
   names:
   - Peru
 '52':
@@ -341,7 +341,7 @@
     sc: 'NO'
     sender_and_registration_info: All senders CONVERTED into random long numeric senders
     text_restrictions: Bulk/marketing traffic NOT allowed
-  rate_multiplier: 2
+  rate_multiplier: 3
   names:
   - Mexico
 '53':
@@ -395,7 +395,7 @@
     sc: 'NO'
     sender_and_registration_info: All senders CONVERTED into random long numeric senders
     text_restrictions: Bulk/marketing traffic NOT allowed
-  rate_multiplier: 1
+  rate_multiplier: 2
   names:
   - Chile
 '57':
@@ -408,7 +408,7 @@
     sc: LIMITED
     sender_and_registration_info: LIMITED amount of SCs available
     text_restrictions: null
-  rate_multiplier: 1
+  rate_multiplier: 2
   names:
   - Colombia
 '58':
@@ -435,7 +435,7 @@
     sender_and_registration_info: LIMITED amount of registered shared SCs available.
       HIGH one time and monthly FEEs for each additional dedicated SC
     text_restrictions: null
-  rate_multiplier: 1
+  rate_multiplier: 7
   names:
   - Malaysia
 '61':
@@ -461,7 +461,7 @@
     sc: 'NO'
     sender_and_registration_info: ''
     text_restrictions: ''
-  rate_multiplier: 2
+  rate_multiplier: 12
   names:
   - Indonesia
 '63':
@@ -475,7 +475,7 @@
     sender_and_registration_info: All numeric senders are converted to InfoText
     text_restrictions: Adult, alcohol, drugs, gambling, election and tobacco contents
       are strictly forbidden
-  rate_multiplier: 1
+  rate_multiplier: 5
   names:
   - Philippines
 '64':
@@ -488,7 +488,7 @@
     sc: 'YES'
     sender_and_registration_info: All alpha senders converted to a random UK longnumber
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 2
   names:
   - New Zealand
 '65':
@@ -504,7 +504,7 @@
       LIMITED amount of free senders, MONTHLY FEE for additional Alpha and numeric
       senders. Only national long numeric senders ara available
     text_restrictions: ''
-  rate_multiplier: 1
+  rate_multiplier: 2
   names:
   - Singapore
 '66':
@@ -521,7 +521,7 @@
       of the sender. Numeric sender up to 11 digits in length. Dynamic sender available
       over Offnet connection.
     text_restrictions: NO political nor erotic content and other text restrictions
-  rate_multiplier: 2
+  rate_multiplier: 1
   names:
   - Thailand
 '81':
@@ -534,7 +534,7 @@
     sc: 'YES'
     sender_and_registration_info: 11-digit long short code.
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 2
   names:
   - Japan
 '82':
@@ -549,7 +549,7 @@
       "00" is ADDED in front of international long numeric sender ids. '
     text_restrictions: "[\uAD6D\uC81C\uBC1C\uC2E0] is added in front of SMS text for\
       \ every inbound P2P and A2P coming from overseas countries."
-  rate_multiplier: 2
+  rate_multiplier: 1
   names:
   - Korea, Republic of
 '84':
@@ -563,7 +563,7 @@
     sender_and_registration_info: One time and monthly FEEs for each sender. All not
       registered senders CONVERTED into "InfoSMS" sender
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 4
   names:
   - Vietnam
 '86':
@@ -578,7 +578,7 @@
       numeric sender
     text_restrictions: Content template MUST be approved by the MNO. Transactional
       traffic ONLY. Sufix added in the message text
-  rate_multiplier: 2
+  rate_multiplier: 1
   names:
   - China
 '90':
@@ -592,7 +592,7 @@
     sender_and_registration_info: LIMITED amount of numeric senders are allowed (just
       some ranges)
     text_restrictions: NO lottery, gambling nor erotic content and other text restrictions
-  rate_multiplier: 2
+  rate_multiplier: 1
   names:
   - Turkey
   - Northern Cyprus
@@ -606,7 +606,7 @@
     sc: 'NO'
     sender_and_registration_info: Alpha senders with exactly 6 characters ONLY
     text_restrictions: Transactional traffic ONLY
-  rate_multiplier: 3
+  rate_multiplier: 2
   names:
   - India
 '92':
@@ -619,7 +619,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 12
   names:
   - Pakistan
 '93':
@@ -634,7 +634,7 @@
       Sender and text example required prior to registration. Registration ETA: up
       to 10 days.'
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 10
   names:
   - Afghanistan
 '94':
@@ -647,7 +647,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 12
   names:
   - Sri Lanka
 '95':
@@ -661,7 +661,7 @@
     sender_and_registration_info: There is monthly FEE for renting a SC. No generic
       senders available. WEB page and description for each sender needed.
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 9
   names:
   - Myanmar
 '98':
@@ -674,7 +674,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 6
   names:
   - Iran
 '211':
@@ -687,7 +687,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 8
   names:
   - South Sudan
 '212':
@@ -700,7 +700,7 @@
     sc: 'NO'
     sender_and_registration_info: Case sensitive senders
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 6
   names:
   - Morocco
 '213':
@@ -713,7 +713,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 6
   names:
   - Algeria
 '216':
@@ -726,7 +726,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 9
   names:
   - Tunisia
 '218':
@@ -739,7 +739,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 9
   names:
   - Libya
 '220':
@@ -752,7 +752,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 4
   names:
   - Gambia
 '221':
@@ -765,7 +765,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 7
   names:
   - Senegal
 '222':
@@ -778,7 +778,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 6
   names:
   - Mauritania
 '223':
@@ -791,7 +791,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 7
   names:
   - Mali
 '224':
@@ -804,7 +804,7 @@
     sc: 'YES'
     sender_and_registration_info: 00 added in front of destination
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 6
   names:
   - Guinea
 '225':
@@ -817,7 +817,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 10
   names:
   - Cote d'Ivoire
 '226':
@@ -830,7 +830,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 4
   names:
   - Burkina Faso
 '227':
@@ -843,7 +843,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 8
   names:
   - Niger
 '228':
@@ -856,7 +856,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 7
   names:
   - Togo
 '229':
@@ -869,7 +869,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 7
   names:
   - Benin
 '230':
@@ -882,7 +882,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 4
   names:
   - Mauritius
 '231':
@@ -895,7 +895,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 6
   names:
   - Liberia
 '232':
@@ -908,7 +908,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 5
   names:
   - Sierra Leone
 '233':
@@ -921,7 +921,7 @@
     sc: REG
     sender_and_registration_info: One time and monthly FEEs for each SC
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 8
   names:
   - Ghana
 '234':
@@ -934,7 +934,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 4
+  rate_multiplier: 8
   names:
   - Nigeria
 '235':
@@ -947,7 +947,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 6
   names:
   - Chad
 '236':
@@ -960,7 +960,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 7
   names:
   - Central African Republic
 '237':
@@ -973,7 +973,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 5
   names:
   - Cameroon
 '238':
@@ -986,7 +986,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 5
   names:
   - Cape Verde
 '239':
@@ -999,7 +999,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 1
   names:
   - Sao Tome and Principe
 '240':
@@ -1012,7 +1012,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 6
   names:
   - Equatorial Guinea
 '241':
@@ -1025,7 +1025,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 8
   names:
   - Gabon
 '242':
@@ -1038,7 +1038,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 7
   names:
   - Congo
 '243':
@@ -1051,7 +1051,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 5
   names:
   - Congo, Democratic Republic of
 '244':
@@ -1077,7 +1077,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 8
   names:
   - Guinea-Bissau
 '246':
@@ -1103,7 +1103,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 4
   names:
   - Seychelles
 '249':
@@ -1116,7 +1116,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 8
   names:
   - Sudan
 '250':
@@ -1129,7 +1129,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 8
   names:
   - Rwanda, Republic of
 '251':
@@ -1142,7 +1142,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 9
   names:
   - Ethiopia
 '252':
@@ -1155,7 +1155,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 5
   names:
   - Somalia
 '253':
@@ -1168,7 +1168,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 4
   names:
   - Djibouti, Republic of
 '254':
@@ -1183,7 +1183,7 @@
       monthly FEEs for each additional sender. Only local entities can register senders
       for Safaricom.
     text_restrictions: null
-  rate_multiplier: 1
+  rate_multiplier: 3
   names:
   - Kenya
 '255':
@@ -1196,7 +1196,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 1
+  rate_multiplier: 7
   names:
   - Tanzania
 '256':
@@ -1211,7 +1211,7 @@
       Only local entities can register the sender (requires Authorization letter).
     text_restrictions: As per regulation, 'DND*196#' is being added at the end of
       each message.
-  rate_multiplier: 2
+  rate_multiplier: 7
   names:
   - Uganda
 '257':
@@ -1224,7 +1224,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 8
   names:
   - Burundi
 '258':
@@ -1237,7 +1237,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 4
   names:
   - Mozambique
 '260':
@@ -1250,7 +1250,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 8
   names:
   - Zambia
 '261':
@@ -1263,7 +1263,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 12
   names:
   - Madagascar
 '262':
@@ -1276,8 +1276,9 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 3
   names:
+  - Mayotte
   - Reunion
 '263':
   attributes:
@@ -1289,7 +1290,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 1
+  rate_multiplier: 5
   names:
   - Zimbabwe
 '264':
@@ -1303,7 +1304,7 @@
     sender_and_registration_info: Long registration procedure, up to 30 days. Monthly
       FEE for each sender
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 1
   names:
   - Namibia
 '265':
@@ -1316,7 +1317,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 8
   names:
   - Malawi
 '266':
@@ -1329,7 +1330,7 @@
     sc: null  # should be 'NO'
     sender_and_registration_info: null  # should be "Sender names can only be 3-11 chars, no spaces"
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 3
   names:
   - Lesotho
 '267':
@@ -1342,7 +1343,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 3
   names:
   - Botswana
 '268':
@@ -1355,7 +1356,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 7
   names:
   - Eswatini
 '269':
@@ -1368,7 +1369,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 7
   names:
   - Comoros
 '291':
@@ -1381,7 +1382,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 4
+  rate_multiplier: 3
   names:
   - Eritrea
 '297':
@@ -1420,7 +1421,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 1
   names:
   - Greenland
 '350':
@@ -1473,7 +1474,7 @@
     sender_and_registration_info: Numeric sender up to 12 digits in length. SC available
       upon registration
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 2
   names:
   - Ireland
 '354':
@@ -1499,7 +1500,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 3
   names:
   - Albania
 '356':
@@ -1540,7 +1541,7 @@
     sender_and_registration_info: $ INSERTED in front of each Alpha sender, "00" in
       front of long numeric senders
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 2
   names:
   - Finland
 '359':
@@ -1605,7 +1606,7 @@
     sc: 'YES'
     sender_and_registration_info: All senders CONVERTED into one SC
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 2
   names:
   - Moldova
 '374':
@@ -1618,7 +1619,7 @@
     sc: REG
     sender_and_registration_info: NO long numeric senders
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 5
   names:
   - Armenia
 '375':
@@ -1631,7 +1632,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 1
+  rate_multiplier: 6
   names:
   - Belarus
 '376':
@@ -1644,7 +1645,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 3
   names:
   - Andorra
 '377':
@@ -1657,7 +1658,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 4
   names:
   - Monaco
 '378':
@@ -1670,7 +1671,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 8
   names:
   - San Marino, Republic of
 '380':
@@ -1683,7 +1684,7 @@
     sc: 'NO'
     sender_and_registration_info: Alpha senders are case sensitive
     text_restrictions: null
-  rate_multiplier: 4
+  rate_multiplier: 5
   names:
   - Ukraine
 '381':
@@ -1696,7 +1697,7 @@
     sc: REG
     sender_and_registration_info: Monthly FEE for each SC
     text_restrictions: Transactional traffic ONLY
-  rate_multiplier: 1
+  rate_multiplier: 7
   names:
   - Serbia
 '382':
@@ -1709,7 +1710,7 @@
     sc: REG
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 4
   names:
   - Montenegro
 '383':
@@ -1723,7 +1724,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 4
+  rate_multiplier: 5
   names:
   - Kosovo
 '385':
@@ -1751,7 +1752,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 4
   names:
   - Slovenia
 '387':
@@ -1765,7 +1766,7 @@
     sender_and_registration_info: Numeric sender available for the FEE upon registration.
       SC registration CHARGED - one time and monthly FEEs per each sender.
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 3
   names:
   - Bosnia and Herzegovina
 '389':
@@ -1795,8 +1796,7 @@
     text_restrictions: Traffic allowed ONLY between 8am and 6pm (CET) on working days.
       Content promoting lottery, betting, gambling nor consumer loans NOT allowed.
       NO political, violent, erotic nor abusive content and other text restrictions
-  # not specified in MMG multiplier sheet so set to default of 4
-  rate_multiplier: 4
+  rate_multiplier: 2
   names:
   - Czech Republic
 '421':
@@ -1837,7 +1837,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 3
   names:
   - Falkland Islands
 '501':
@@ -1850,7 +1850,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 5
   names:
   - Belize
 '502':
@@ -1863,7 +1863,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 5
   names:
   - Guatemala
 '503':
@@ -1889,7 +1889,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 5
   names:
   - Honduras
 '505':
@@ -1902,7 +1902,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 4
   names:
   - Nicaragua
 '506':
@@ -1915,7 +1915,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 1
   names:
   - Costa Rica
 '507':
@@ -1928,7 +1928,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 4
   names:
   - Panama
 '508':
@@ -1941,7 +1941,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 4
   names:
   - Saint Pierre and Miquelon
 '509':
@@ -1954,7 +1954,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 8
   names:
   - Haiti
 '590':
@@ -1967,7 +1967,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 4
   names:
   - Guadeloupe
 '591':
@@ -1980,7 +1980,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 4
   names:
   - Bolivia
 '592':
@@ -1993,7 +1993,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 6
   names:
   - Guyana
 '593':
@@ -2006,7 +2006,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 1
+  rate_multiplier: 4
   names:
   - Ecuador
 '594':
@@ -2019,7 +2019,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 4
   names:
   - French Guiana
 '595':
@@ -2032,7 +2032,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 3
   names:
   - Paraguay
 '596':
@@ -2045,7 +2045,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 4
   names:
   - Martinique
 '597':
@@ -2058,7 +2058,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 4
+  rate_multiplier: 6
   names:
   - Suriname
 '598':
@@ -2071,7 +2071,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 1
+  rate_multiplier: 2
   names:
   - Uruguay
 '599':
@@ -2084,7 +2084,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 7
   names:
   - Curacao (former Netherlands Antilles)
 '670':
@@ -2097,7 +2097,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 5
   names:
   - Timor L'este
 '672':
@@ -2110,7 +2110,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 2
   names:
   - Norfolk Island
 '673':
@@ -2123,7 +2123,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 1
+  rate_multiplier: 2
   names:
   - Brunei Darussalam
 '674':
@@ -2136,7 +2136,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 6
   names:
   - Nauru
 '675':
@@ -2149,7 +2149,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 6
   names:
   - Papua New Guinea
 '676':
@@ -2162,7 +2162,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 4
   names:
   - Tonga
 '677':
@@ -2175,7 +2175,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 1
+  rate_multiplier: 2
   names:
   - Solomon Islands
 '678':
@@ -2188,7 +2188,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 4
   names:
   - Vanuatu
 '679':
@@ -2201,7 +2201,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 5
   names:
   - Fiji
 '680':
@@ -2214,7 +2214,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 2
   names:
   - Palau
 '681':
@@ -2227,7 +2227,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 4
+  rate_multiplier: 2
   names:
   - Wallis and Futuna
 '682':
@@ -2240,7 +2240,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 4
   names:
   - Cook Islands
 '683':
@@ -2253,7 +2253,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 4
+  rate_multiplier: 8
   names:
   - Niue
 '685':
@@ -2266,7 +2266,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 5
   names:
   - Samoa
 '686':
@@ -2279,7 +2279,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 4
+  rate_multiplier: 1
   names:
   - Kiribati
 '687':
@@ -2305,7 +2305,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 3
   names:
   - French Polynesia
 '690':
@@ -2318,7 +2318,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 4
+  rate_multiplier: 8
   names:
   - Tokelau
 '691':
@@ -2344,7 +2344,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 1
+  rate_multiplier: 2
   names:
   - Marshall Islands
 '852':
@@ -2358,7 +2358,7 @@
     sender_and_registration_info: ''
     text_restrictions: OPT-IN required for promotional traffic. NO violent, discriminatory
       nor erotic content
-  rate_multiplier: 3
+  rate_multiplier: 2
   names:
   - Hong Kong
 '853':
@@ -2384,7 +2384,7 @@
     sc: 'NO'
     sender_and_registration_info: All senders CONVERTED into random long numeric senders
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 8
   names:
   - Cambodia
 '856':
@@ -2397,7 +2397,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 8
   names:
   - Laos
 '880':
@@ -2410,7 +2410,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 9
   names:
   - Bangladesh
 '886':
@@ -2436,7 +2436,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 6
   names:
   - Maldives
 '961':
@@ -2449,7 +2449,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 9
   names:
   - Lebanon
 '962':
@@ -2462,7 +2462,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 8
   names:
   - Jordan
 '963':
@@ -2475,7 +2475,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 9
   names:
   - Syria
 '964':
@@ -2488,7 +2488,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 9
   names:
   - Iraq
 '965':
@@ -2502,7 +2502,7 @@
     sender_and_registration_info: No new senders available at the moment. Registration
       ETA 1-5 days.
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 7
   names:
   - Kuwait
 '966':
@@ -2515,7 +2515,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 5
   names:
   - Saudi Arabia
 '967':
@@ -2528,7 +2528,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 6
   names:
   - Yemen
 '968':
@@ -2542,7 +2542,7 @@
     sender_and_registration_info: Only local entities can register senders. NOC and
       Trace Licence required.
     text_restrictions: null
-  rate_multiplier: 1
+  rate_multiplier: 4
   names:
   - Oman
 '970':
@@ -2555,7 +2555,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 4
+  rate_multiplier: 9
   names:
   - Palestinian Territory
 '971':
@@ -2570,7 +2570,7 @@
       process. One time and monthly FEEs for each additional SC
     text_restrictions: 'No marketing traffic between 8pm and 8am (GMT +4). International
       traffic is allowed. '
-  rate_multiplier: 2
+  rate_multiplier: 3
   names:
   - United Arab Emirates
 '972':
@@ -2583,7 +2583,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 6
   names:
   - Israel
 '973':
@@ -2610,7 +2610,7 @@
     sender_and_registration_info: Case sensitive senders. SCs and numeric senders
       MUST have more than 5 digits. All not registered senders are CONVERTED to "INFOSMSI"
     text_restrictions: null
-  rate_multiplier: 1
+  rate_multiplier: 6
   names:
   - Qatar
 '975':
@@ -2623,7 +2623,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 10
   names:
   - Bhutan
 '976':
@@ -2636,7 +2636,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 7
   names:
   - Mongolia
 '977':
@@ -2649,7 +2649,7 @@
     sc: 'NO'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 8
   names:
   - Nepal
 '992':
@@ -2663,7 +2663,7 @@
     sender_and_registration_info: Numeric sender available upon registration. Numeric
       sender MUST begin with "992" or "0" (zero)
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 10
   names:
   - Tajikistan
 '993':
@@ -2676,7 +2676,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 7
   names:
   - Turkmenistan
 '994':
@@ -2691,7 +2691,7 @@
     text_restrictions: NO political, erotic, religious, alcoholic or tobacco products,
       premium services related info. APPROVAL required for food add., medical, non-govern.
       organizations or minor individuals related messages
-  rate_multiplier: 2
+  rate_multiplier: 9
   names:
   - Azerbaijan
 '995':
@@ -2704,7 +2704,7 @@
     sc: 'NO'
     sender_and_registration_info: ''
     text_restrictions: Few GSM 7 characters are not supported
-  rate_multiplier: 2
+  rate_multiplier: 4
   names:
   - Georgia
 '996':
@@ -2718,7 +2718,7 @@
     sender_and_registration_info: ONLY two shared numeric senders available. Long
       numeric usage MUST be approved by MNO
     text_restrictions: null
-  rate_multiplier: 2
+  rate_multiplier: 8
   names:
   - Kyrgyzstan
 '998':
@@ -2732,7 +2732,7 @@
     sender_and_registration_info: Numeric and all non registered senders are converted
       to InfoSMS
     text_restrictions: ''
-  rate_multiplier: 2
+  rate_multiplier: 12
   names:
   - Uzbekistan
 '1242':
@@ -2745,7 +2745,7 @@
     sc: 'NO'
     sender_and_registration_info: All senders CONVERTED into random long numeric senders
     text_restrictions: Bulk/marketing traffic NOT allowed
-  rate_multiplier: 2
+  rate_multiplier: 3
   names:
   - Bahamas
 '1246':
@@ -2758,7 +2758,7 @@
     sc: 'NO'
     sender_and_registration_info: All senders CONVERTED into random long numeric senders
     text_restrictions: Bulk/marketing traffic NOT allowed
-  rate_multiplier: 3
+  rate_multiplier: 7
   names:
   - Barbados
 '1264':
@@ -2771,7 +2771,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 6
   names:
   - Anguilla
 '1268':
@@ -2784,7 +2784,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 5
   names:
   - Antigua and Barbuda
 '1284':
@@ -2797,7 +2797,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 5
   names:
   - Virgin Islands, British
 '1345':
@@ -2810,7 +2810,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 6
   names:
   - Cayman Islands
 '1441':
@@ -2823,7 +2823,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 7
   names:
   - Bermuda
 '1473':
@@ -2836,7 +2836,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 6
   names:
   - Grenada
 '1649':
@@ -2849,7 +2849,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 6
   names:
   - Turks and Caicos Islands
 '1664':
@@ -2862,7 +2862,7 @@
     sc: 'NO'
     sender_and_registration_info: All senders CONVERTED into random long numeric senders
     text_restrictions: Bulk/marketing traffic NOT allowed
-  rate_multiplier: 3
+  rate_multiplier: 6
   names:
   - Montserrat
 '1684':
@@ -2875,7 +2875,7 @@
     sc: 'NO'
     sender_and_registration_info: All senders CONVERTED into random long numeric senders
     text_restrictions: Bulk/marketing traffic NOT allowed
-  rate_multiplier: 3
+  rate_multiplier: 2
   names:
   - American Samoa
 '1721':
@@ -2888,7 +2888,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 1
+  rate_multiplier: 2
   names:
   - Sint Maarten
 '1758':
@@ -2901,7 +2901,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 7
   names:
   - Saint Lucia
 '1767':
@@ -2914,7 +2914,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 7
   names:
   - Dominica, Commonwealth of
 '1784':
@@ -2927,7 +2927,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 7
   names:
   - Saint Vincent and The Grenadines
 '1868':
@@ -2940,7 +2940,7 @@
     sc: null
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 7
   names:
   - Trinidad and Tobago
 '1869':
@@ -2953,7 +2953,7 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 6
   names:
   - Saint Kitts and Nevis
 '1876':
@@ -2966,6 +2966,6 @@
     sc: 'YES'
     sender_and_registration_info: null
     text_restrictions: null
-  rate_multiplier: 3
+  rate_multiplier: 7
   names:
   - Jamaica

--- a/notifications_utils/recipient_validation/phone_number.py
+++ b/notifications_utils/recipient_validation/phone_number.py
@@ -231,11 +231,16 @@ class PhoneNumber:
         return self.number.country_code == 44
 
     def get_international_phone_info(self):
+        if is_international := self.is_international_number():
+            rate_multiplier = INTERNATIONAL_BILLING_RATES[self.prefix]["rate_multiplier"]
+        else:
+            rate_multiplier = 1
+
         return international_phone_info(
-            international=self.is_international_number(),
+            international=is_international,
             crown_dependency=self.is_a_crown_dependency_number(),
             country_prefix=self.prefix,
-            rate_multiplier=INTERNATIONAL_BILLING_RATES[self.prefix]["rate_multiplier"],
+            rate_multiplier=rate_multiplier,
         )
 
     def is_international_number(self):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "97.0.5"  # 7fcfba793296f83df8fb90897aa2c3a8
+__version__ = "98.0.0"  # 9c541149787a6524aa37885957e4f2fa

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -180,7 +180,7 @@ international_phone_info_fixtures = [
             international=True,
             crown_dependency=True,
             country_prefix="44",  # UK Crown dependency, so prefix same as UK
-            rate_multiplier=1,
+            rate_multiplier=2,
         ),
     ),
     (
@@ -189,7 +189,7 @@ international_phone_info_fixtures = [
             international=True,
             crown_dependency=False,
             country_prefix="20",  # Egypt
-            rate_multiplier=3,
+            rate_multiplier=7,
         ),
     ),
     (
@@ -198,7 +198,7 @@ international_phone_info_fixtures = [
             international=True,
             crown_dependency=False,
             country_prefix="20",  # Egypt
-            rate_multiplier=3,
+            rate_multiplier=7,
         ),
     ),
     (
@@ -207,7 +207,7 @@ international_phone_info_fixtures = [
             international=True,
             crown_dependency=False,
             country_prefix="1664",  # Montserrat
-            rate_multiplier=3,
+            rate_multiplier=6,
         ),
     ),
     (
@@ -216,7 +216,7 @@ international_phone_info_fixtures = [
             international=True,
             crown_dependency=False,
             country_prefix="7",  # Russia
-            rate_multiplier=4,
+            rate_multiplier=10,
         ),
     ),
     (
@@ -234,7 +234,7 @@ international_phone_info_fixtures = [
             international=True,
             crown_dependency=False,
             country_prefix="230",  # Mauritius
-            rate_multiplier=2,
+            rate_multiplier=4,
         ),
     ),
 ]

--- a/tests/test_international_billing_rates.py
+++ b/tests/test_international_billing_rates.py
@@ -20,7 +20,7 @@ def test_international_billing_rates_are_in_correct_format(country_prefix, value
     assert set(values.keys()) == {"attributes", "rate_multiplier", "names"}
 
     assert isinstance(values["rate_multiplier"], int)
-    assert 1 <= values["rate_multiplier"] <= 4
+    assert 1 <= values["rate_multiplier"] <= 12
 
     assert isinstance(values["names"], list)
     assert all(isinstance(country, str) for country in values["names"])

--- a/tests/test_international_billing_rates.py
+++ b/tests/test_international_billing_rates.py
@@ -30,7 +30,7 @@ def test_international_billing_rates_are_in_correct_format(country_prefix, value
 
 
 def test_country_codes():
-    assert len(COUNTRY_PREFIXES) == 220
+    assert len(COUNTRY_PREFIXES) == 223
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The rate multipliers for international SMS are changing from 1 April
2025, so this change updates the yml file. The `+44` prefix has a rate
multiplier of 2 for Guersey, Jersey and the Isle of Man and 1 for
mainland UK, which requires a change in logic.