### PR TITLE
celery.NotifyTask: add early-log messages, annotate end-of-task log messages with `celery_task_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 99.0.0
+
+* NOTABLE CHANGE: Celery tasks emit an "early" log message when starting, with a customisable log level to allow this to be disabled for high-volume tasks. When upgrading past this version you may want to pass the extra argument `early_log_level=logging.DEBUG` to the task decorator of your most heavily-called tasks to reduce the effect on log volume
+* Annotates automatic celery task log messages with `celery_task_id`
+
 ## 98.0.1
 
 * Moves from `setup.py` to `pyproject.toml` for package configuation

--- a/notifications_utils/celery.py
+++ b/notifications_utils/celery.py
@@ -42,6 +42,7 @@ def make_task(app):
                     elapsed_time,
                     extra={
                         "celery_task": self.name,
+                        "celery_task_id": self.request.id,
                         "queue_name": self.queue_name,
                         "time_taken": elapsed_time,
                         # avoid name collision with LogRecord's own `process` attribute
@@ -66,6 +67,7 @@ def make_task(app):
                     elapsed_time,
                     extra={
                         "celery_task": self.name,
+                        "celery_task_id": self.request.id,
                         "queue_name": self.queue_name,
                         "time_taken": elapsed_time,
                         # avoid name collision with LogRecord's own `process` attribute
@@ -90,6 +92,7 @@ def make_task(app):
                     elapsed_time,
                     extra={
                         "celery_task": self.name,
+                        "celery_task_id": self.request.id,
                         "queue_name": self.queue_name,
                         "time_taken": elapsed_time,
                         # avoid name collision with LogRecord's own `process` attribute

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "98.0.1"  # c390d5ad25c4ec71a4196a8651426c88
+__version__ = "99.0.0"  # deadbeef88719a01d01bf


### PR DESCRIPTION
This should partly address a some of the things I'm always moaning about - the lack of a logged identifier for a particular celery _task_ (the same request id is frequently applied en-masse to thousands of celery tasks) and the lack of a log message denoting the start of a celery task being processed (meaning if a worker dies we have no record of the task being partially executed).

This still isn't anywhere near as good as I'd like, where we'd extend span ids & parent span ids into celery task invocations, and any log message generated by a celery task would have this information annotated onto it.

Major bump to nudge people to mark their heavily called tasks with a reduced `early_log_level`

Tested a deployment on `-api`  via https://github.com/alphagov/notifications-api/pull/4425