### PR TITLE
Extend Placeholder Syntax to include unsafe values

### DIFF
--- a/tests/test_placeholders.py
+++ b/tests/test_placeholders.py
@@ -10,6 +10,8 @@ from notifications_utils.field import Placeholder
     [
         ("((with-brackets))", "with-brackets"),
         ("without-brackets", "without-brackets"),
+        ("unsafe_placeholder::unsafe", "unsafe_placeholder"),
+        ("((name::notify_test_service))", "name::notify_test_service"),
     ],
 )
 def test_placeholder_returns_name(body, expected):


### PR DESCRIPTION
Best reviewed commit by commit.

Adds a placeholder of with the form `<my value>::unsafe>` that can be used to sanitise values that may contain vulnerable markdown syntax.

This will have the placeholder return a stub until later PRs can add the sanitisation logic. So, `str(Placeholder("((my name::unsafe)), {"my_name":"Richard"}))` is evaluated as `SANITISED` .