### PR TITLE
Use non-deprecated format for specifying project license

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ name = "notifications-utils"
 dynamic = ["version"]
 description = "Shared python code for GOV.UK Notify."
 readme = "README.md"
-license = {text = "MIT License"}
+license = "MIT"
 authors = [
     { name = "Government Digital Service" },
 ]


### PR DESCRIPTION
`project.license` as a TOML table is deprecated

Seeing this warning locally:

> Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
>
> By 2026-Feb-18, you need to update your project and remove deprecated calls or your builds will no longer be supported.

https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license

New format taken from https://spdx.org/licenses/