### PR TITLE
refactor: Extend utils to support economy mail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 99.1.0
+
+* Adds support for economy mail in get_min_and_max_days_in_transit, with delivery estimated between 2 and 6 days
+
 ## 99.0.0
 
 * NOTABLE CHANGE: Celery tasks emit an "early" log message when starting, with a customisable log level to allow this to be disabled for high-volume tasks. When upgrading past this version you may want to pass the extra argument `early_log_level=logging.DEBUG` to the task decorator of your most heavily-called tasks to reduce the effect on log volume

--- a/notifications_utils/countries/data.py
+++ b/notifications_utils/countries/data.py
@@ -64,5 +64,6 @@ class Postage:
     UK = "united-kingdom"
     FIRST = "first"
     SECOND = "second"
+    ECONOMY = "economy"
     EUROPE = "europe"
     REST_OF_WORLD = "rest-of-world"

--- a/notifications_utils/letter_timings.py
+++ b/notifications_utils/letter_timings.py
@@ -109,6 +109,7 @@ def get_min_and_max_days_in_transit(postage):
         # day, so effectively spends no full days in transit
         "first": (0, 0),
         "second": (1, 2),
+        "economy": (2, 6),
         Postage.EUROPE: (3, 5),
         Postage.REST_OF_WORLD: (5, 7),
     }[postage]

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "99.0.0"  # deadbeef88719a01d01bf
+__version__ = "99.1.0"  # 8e1f1be9abd64cbfabbf3d237a54ee52


### PR DESCRIPTION
## PR Summary

- Extend `get_min_and_max_days_in_transit` to include economy transit 
- In [this Kick-off document](https://docs.google.com/document/d/12cZF-bnSk5TWgGi60Xf_qX3RZH1bEr-iGW56c8jIxjU/edit?tab=t.0#heading=h.emkr927lpq04), it says that the transit for Economy might take up to 6 days to be delivered and it is generally slower than 2nd Class. 
- Based on this, this function has been updated with a minimum of 2 days and max of 6 days for delivery

## Ticket
- [Allow postage to be economy in Notify](https://trello.com/c/Y95RhqNO/1244-allow-postage-to-be-economy-in-notify)


