### PR TITLE
`celery.NotifyTask`: don't emit early log if called synchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 99.3.4
+
+* `celery.NotifyTask`: don't emit early log if called synchronously
+
 ## 99.3.3
 
 * Fix bug with non-SMS templates considering international SMS limits

--- a/notifications_utils/celery.py
+++ b/notifications_utils/celery.py
@@ -114,19 +114,21 @@ def make_task(app):
             with self.app_context():
                 self.start = time.monotonic()
 
-                app.logger.log(
-                    self.early_log_level,
-                    "Celery task %s (queue: %s) started",
-                    self.name,
-                    self.queue_name,
-                    extra={
-                        "celery_task": self.name,
-                        "celery_task_id": self.request.id,
-                        "queue_name": self.queue_name,
-                        # avoid name collision with LogRecord's own `process` attribute
-                        "process_": getpid(),
-                    },
-                )
+                if self.request.id is not None:
+                    # we're not being called synchronously
+                    app.logger.log(
+                        self.early_log_level,
+                        "Celery task %s (queue: %s) started",
+                        self.name,
+                        self.queue_name,
+                        extra={
+                            "celery_task": self.name,
+                            "celery_task_id": self.request.id,
+                            "queue_name": self.queue_name,
+                            # avoid name collision with LogRecord's own `process` attribute
+                            "process_": getpid(),
+                        },
+                    )
 
                 return super().__call__(*args, **kwargs)
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "99.3.3"  # 9d1156751da6fb09de66616008781252
+__version__ = "99.3.4"  # deadbeefb333dd40c3


### PR DESCRIPTION
Fixup for #1213. This is a misleading log message to emit as we're not an invocation of the stated celery task in this case.