### PR TITLE
For `RecipientCSV` class, count international text messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 99.3.0
+
+* Adds `RecipientCSV.international_sms_count`
+* Adds `RecipientCSV.more_international_sms_than_can_send` (initialise per `RecipientCSV(remaining_international_sms_messages=123)` to enable this check)
+
 ## 99.2.0
 
 * Add s3 multipart upload lifecycle (create, upload, complete, abort)

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -122,6 +122,7 @@ class RecipientCSV:
             or self.too_many_rows
             or (not self.allowed_to_send_to)
             or any(self.rows_with_errors)
+            or self.more_international_sms_than_can_send
         )  # `or` is 3x faster than using `any()` here
 
     @property

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -63,6 +63,8 @@ class RecipientCSV:
         self.rows_as_list = None
         self.should_validate = should_validate
         self.should_validate_phone_number = should_validate_phone_number
+        # use the international_sms_count property to get this.
+        self._international_sms_count = 0
 
     def __len__(self):
         if not hasattr(self, "_len"):
@@ -129,6 +131,12 @@ class RecipientCSV:
         if not self.guestlist:
             return True
         return all(allowed_to_send_to(row.recipient, self.guestlist) for row in self.rows)
+
+    @property
+    def international_sms_count(self):
+        if self._international_sms_count == 0:
+            self.rows
+        return self._international_sms_count
 
     @property
     def rows(self):
@@ -327,6 +335,8 @@ class RecipientCSV:
                             allow_international_number=self.allow_international_sms,
                             allow_uk_landline=self.allow_sms_to_uk_landline,
                         )
+                        if number.is_international_number():
+                            self._international_sms_count += 1
             except InvalidRecipientError as error:
                 return str(error)
 

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -143,7 +143,7 @@ class RecipientCSV:
     def _international_sms_count_generator(self):
         for row in self.rows:
             with suppress(InvalidPhoneError):
-                yield PhoneNumber(row.recipient).is_international_number()
+                yield get_phone_number_object(row.recipient).is_international_number()
 
     @property
     def more_international_sms_than_can_send(self):
@@ -341,7 +341,7 @@ class RecipientCSV:
                     email_address.validate_email_address(value)
                 if self.template_type == "sms":
                     if self.should_validate_phone_number:
-                        number = PhoneNumber(value)
+                        number = get_phone_number_object(value)
                         number.validate(
                             allow_international_number=self.allow_international_sms,
                             allow_uk_landline=self.allow_sms_to_uk_landline,
@@ -496,6 +496,11 @@ def format_recipient(recipient):
     with suppress(InvalidEmailError):
         return email_address.validate_and_format_email_address(recipient)
     return recipient
+
+
+@lru_cache(maxsize=RecipientCSV.max_rows, typed=False)
+def get_phone_number_object(phone_number):
+    return PhoneNumber(phone_number)
 
 
 def allowed_to_send_to(recipient, allowlist):

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -45,6 +45,7 @@ class RecipientCSV:
         max_initial_rows_shown=10,
         guestlist=None,
         remaining_messages=sys.maxsize,
+        remaining_international_sms_messages=sys.maxsize,
         allow_international_sms=False,
         allow_international_letters=False,
         allow_sms_to_uk_landline=False,
@@ -60,6 +61,7 @@ class RecipientCSV:
         self.allow_international_letters = allow_international_letters
         self.allow_sms_to_uk_landline = allow_sms_to_uk_landline
         self.remaining_messages = remaining_messages
+        self.remaining_international_sms_messages = remaining_international_sms_messages
         self.rows_as_list = None
         self.should_validate = should_validate
         self.should_validate_phone_number = should_validate_phone_number
@@ -140,6 +142,10 @@ class RecipientCSV:
         for row in self.rows:
             with suppress(InvalidPhoneError):
                 yield PhoneNumber(row.recipient).is_international_number()
+
+    @property
+    def more_international_sms_than_can_send(self):
+        return self.international_sms_count > self.remaining_international_sms_messages
 
     @property
     def rows(self):

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -63,8 +63,6 @@ class RecipientCSV:
         self.rows_as_list = None
         self.should_validate = should_validate
         self.should_validate_phone_number = should_validate_phone_number
-        # use the international_sms_count property to get this.
-        self._international_sms_count = 0
 
     def __len__(self):
         if not hasattr(self, "_len"):
@@ -134,9 +132,14 @@ class RecipientCSV:
 
     @property
     def international_sms_count(self):
-        if self._international_sms_count == 0:
-            self.rows
-        return self._international_sms_count
+        if self.template_type != "sms":
+            return 0
+        return sum(self._international_sms_count_generator())
+
+    def _international_sms_count_generator(self):
+        for row in self.rows:
+            with suppress(InvalidPhoneError):
+                yield PhoneNumber(row.recipient).is_international_number()
 
     @property
     def rows(self):
@@ -335,8 +338,6 @@ class RecipientCSV:
                             allow_international_number=self.allow_international_sms,
                             allow_uk_landline=self.allow_sms_to_uk_landline,
                         )
-                        if number.is_international_number():
-                            self._international_sms_count += 1
             except InvalidRecipientError as error:
                 return str(error)
 

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -7,6 +7,7 @@ from itertools import islice
 from typing import cast
 
 from ordered_set import OrderedSet
+from werkzeug.utils import cached_property
 
 from notifications_utils.formatters import (
     strip_all_whitespace,
@@ -133,7 +134,7 @@ class RecipientCSV:
             return True
         return all(allowed_to_send_to(row.recipient, self.guestlist) for row in self.rows)
 
-    @property
+    @cached_property
     def international_sms_count(self):
         if self.template_type != "sms":
             return 0

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "99.2.0"  # f57494ce591b31257402a54c2a11b8ae
+__version__ = "99.3.0"  # a08a87a22c416220bbda5cc4262ff24f

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -754,6 +754,31 @@ def test_international_recipients(file_contents, rows_with_bad_recipients, expec
 
 
 @pytest.mark.parametrize(
+    "extra_args, too_many",
+    (
+        ({"remaining_international_sms_messages": 2}, True),
+        ({"remaining_international_sms_messages": 3}, False),
+        ({}, False),
+    ),
+)
+def test_international_sms_limit(extra_args, too_many):
+    recipients = RecipientCSV(
+        """
+        phone number, count international
+        +12025550104, 1
+        +447900900123, (UK)
+        +12025550104, 2
+        +12025550104, 3
+        07900 900 321, (UK with no country code)
+        """,
+        template=_sample_template("sms"),
+        allow_international_sms=True,
+        **extra_args,
+    )
+    assert recipients.more_international_sms_than_can_send is too_many
+
+
+@pytest.mark.parametrize(
     "file_contents,rows_with_bad_recipients",
     [
         (

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -719,7 +719,7 @@ def test_bad_or_missing_data(
 
 
 @pytest.mark.parametrize(
-    "file_contents,rows_with_bad_recipients",
+    "file_contents,rows_with_bad_recipients,expectected_count",
     [
         (
             """
@@ -729,6 +729,7 @@ def test_bad_or_missing_data(
             +447900123
         """,
             {0, 1, 2},
+            0,
         ),
         (
             """
@@ -738,15 +739,17 @@ def test_bad_or_missing_data(
             +2304031000, Mauritius
         """,
             set(),
+            3,
         ),
     ],
 )
-def test_international_recipients(file_contents, rows_with_bad_recipients):
+def test_international_recipients(file_contents, rows_with_bad_recipients, expectected_count):
     recipients = RecipientCSV(
         file_contents,
         template=_sample_template("sms"),
         allow_international_sms=True,
     )
+    assert recipients.international_sms_count == expectected_count
     assert _index_rows(recipients.rows_with_bad_recipients) == rows_with_bad_recipients
 
 

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -776,6 +776,7 @@ def test_international_sms_limit(extra_args, too_many):
         **extra_args,
     )
     assert recipients.more_international_sms_than_can_send is too_many
+    assert recipients.has_errors is too_many
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is so that we can effectively check international sms message limit for jobs.