### PR TITLE
Remove urls from unsafe placeholders

### DIFF
--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -8,6 +8,7 @@ from notifications_utils.formatters import (
     escape_html,
     strip_and_remove_obscure_whitespace,
     unescaped_formatted_list,
+    url,
 )
 from notifications_utils.insensitive_dict import InsensitiveDict
 
@@ -170,8 +171,11 @@ class Field:
 
         return replacement
 
-    # first draft, needs refactoring
     def sanitise_replacement_unsafe(self, replacement: str):
+        # if the replacement contains a link consider it all compromised
+        if re.search(url, replacement):
+            return ""
+        # escape markdown-specific characters
         markdown_characters = r"`*_(){}[]<>#+-.!|"
         for character in markdown_characters:
             replacement = replacement.replace(character, f"\\{character}")

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -99,7 +99,7 @@ class Field:
     conditional_placeholder_tag = "<span class='placeholder-conditional'>&#40;&#40;{}??</span>{}&#41;&#41;"
     placeholder_tag_no_brackets = "<span class='placeholder-no-brackets'>{}</span>"
     placeholder_tag_redacted = "<span class='placeholder-redacted'>hidden</span>"
-    placeholder_tag_unsafe = "<span class='placeholder'>&#40;&#40;{}</span>::unsafe&#41;&#41;"
+    placeholder_tag_unsafe = "<span class='placeholder-unsafe'>&#40;&#40;{}</span>::unsafe&#41;&#41;"
 
     def __init__(
         self,

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -20,7 +20,7 @@ class Placeholder:
 
     class Types(StrEnum):
         BASE = auto()
-        UNSAFE = auto()
+        MAKE_SAFE = auto()
         CONDITIONAL = auto()
 
     # order matters as the placeholder type will be the first type that returns a match
@@ -28,7 +28,7 @@ class Placeholder:
     # placeholders as they don't contain vulnerable input
     extended_type_pattern = {
         Types.CONDITIONAL: re.compile(r".*\?\?.*"),
-        Types.UNSAFE: re.compile(r".*::unsafe$"),
+        Types.MAKE_SAFE: re.compile(r".*::make_safe$"),
     }
 
     @property
@@ -45,8 +45,8 @@ class Placeholder:
     def is_conditional(self):
         return self.type == self.Types.CONDITIONAL
 
-    def is_unsafe(self):
-        return self.type == self.Types.UNSAFE
+    def is_make_safe(self):
+        return self.type == self.Types.MAKE_SAFE
 
     @property
     def name(self):
@@ -54,8 +54,8 @@ class Placeholder:
         match self.type:
             case self.Types.BASE:
                 return self.body
-            case self.Types.UNSAFE:
-                return self.body.split("::unsafe")[0]
+            case self.Types.MAKE_SAFE:
+                return self.body.split("::make_safe")[0]
             case self.Types.CONDITIONAL:
                 return self.body.split("??")[0]
 
@@ -100,7 +100,7 @@ class Field:
     conditional_placeholder_tag = "<span class='placeholder-conditional'>&#40;&#40;{}??</span>{}&#41;&#41;"
     placeholder_tag_no_brackets = "<span class='placeholder-no-brackets'>{}</span>"
     placeholder_tag_redacted = "<span class='placeholder-redacted'>hidden</span>"
-    placeholder_tag_unsafe = "<span class='placeholder-unsafe'>&#40;&#40;{}</span>::unsafe&#41;&#41;"
+    placeholder_tag_make_safe = "<span class='placeholder-unsafe'>&#40;&#40;{}</span>::make_safe&#41;&#41;"
 
     def __init__(
         self,
@@ -151,8 +151,8 @@ class Field:
         if placeholder.is_conditional():
             return self.conditional_placeholder_tag.format(placeholder.name, placeholder.conditional_text)
 
-        if placeholder.is_unsafe():
-            return self.placeholder_tag_unsafe.format(placeholder.name)
+        if placeholder.is_make_safe():
+            return self.placeholder_tag_make_safe.format(placeholder.name)
 
         return self.placeholder_tag.format(placeholder.name)
 
@@ -166,12 +166,12 @@ class Field:
         if placeholder.is_conditional():
             return placeholder.get_conditional_body(replacement)
 
-        if placeholder.is_unsafe():
-            return self.sanitise_replacement_unsafe(replacement)
+        if placeholder.is_make_safe():
+            return self.sanitise_replacement_make_safe(replacement)
 
         return replacement
 
-    def sanitise_replacement_unsafe(self, replacement: str):
+    def sanitise_replacement_make_safe(self, replacement: str):
         # if the replacement contains a link consider it all compromised
         if re.search(url, replacement):
             return ""
@@ -229,7 +229,7 @@ class PlainTextField(Field):
     conditional_placeholder_tag = "(({}??{}))"
     placeholder_tag_no_brackets = "{}"
     placeholder_tag_redacted = "[hidden]"
-    placeholder_tag_unsafe = "(({}::unsafe))"
+    placeholder_tag_make_safe = "(({}::make_safe))"
 
 
 def str2bool(value):

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -166,8 +166,15 @@ class Field:
             return placeholder.get_conditional_body(replacement)
 
         if placeholder.is_unsafe():
-            return "SANITISED"
+            return self.sanitise_replacement_unsafe(replacement)
 
+        return replacement
+
+    # first draft, needs refactoring
+    def sanitise_replacement_unsafe(self, replacement: str):
+        markdown_characters = r"`*_(){}[]<>#+-.!|"
+        for character in markdown_characters:
+            replacement = replacement.replace(character, f"\\{character}")
         return replacement
 
     def get_replacement(self, placeholder):

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -257,6 +257,11 @@ def test_handling_of_missing_values(content, values, expected):
             r"My name is Geoff\(\)\[\]\{\}",
         ),
         (
+            "Escaped link: ((link::unsafe))",
+            {"link": "https://www.google.com"},
+            "Escaped link: ",
+        ),
+        (
             "My name is ((name::unsafefoobar))",
             {"name::unsafefoobar": "Geoff"},
             "My name is Geoff",

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -211,7 +211,7 @@ def test_optional_redacting_of_missing_values(template_content, data, expected):
         ),
         (
             "Unsafe placeholder: ((name::unsafe))",
-            "Unsafe placeholder: <span class='placeholder'>&#40;&#40;name</span>::unsafe&#41;&#41;",
+            "Unsafe placeholder: <span class='placeholder-unsafe'>&#40;&#40;name</span>::unsafe&#41;&#41;",
         ),
     ],
 )

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -248,13 +248,13 @@ def test_handling_of_missing_values(content, values, expected):
     [
         (
             "My name is ((name))",
-            {"name": "Geoff"},
-            "My name is Geoff",
+            {"name": "Geoff()[]{}"},
+            "My name is Geoff()[]{}",
         ),
         (
             "My name is ((name::unsafe))",
-            {"name": "Geoff"},
-            "My name is SANITISED",
+            {"name": "Geoff()[]{}"},
+            r"My name is Geoff\(\)\[\]\{\}",
         ),
         (
             "My name is ((name::unsafefoobar))",

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -210,8 +210,8 @@ def test_optional_redacting_of_missing_values(template_content, data, expected):
             "<span class='placeholder-conditional'>&#40;&#40;warning??</span> This warning is ?? questionable&#41;&#41;",  # noqa
         ),
         (
-            "Unsafe placeholder: ((name::unsafe))",
-            "Unsafe placeholder: <span class='placeholder-unsafe'>&#40;&#40;name</span>::unsafe&#41;&#41;",
+            "Unsafe placeholder: ((name::make_safe))",
+            "Unsafe placeholder: <span class='placeholder-unsafe'>&#40;&#40;name</span>::make_safe&#41;&#41;",
         ),
     ],
 )
@@ -252,18 +252,18 @@ def test_handling_of_missing_values(content, values, expected):
             "My name is Geoff()[]{}",
         ),
         (
-            "My name is ((name::unsafe))",
+            "My name is ((name::make_safe))",
             {"name": "Geoff()[]{}"},
             r"My name is Geoff\(\)\[\]\{\}",
         ),
         (
-            "Escaped link: ((link::unsafe))",
+            "Escaped link: ((link::make_safe))",
             {"link": "https://www.google.com"},
             "Escaped link: ",
         ),
         (
-            "My name is ((name::unsafefoobar))",
-            {"name::unsafefoobar": "Geoff"},
+            "My name is ((name::make_safefoobar))",
+            {"name::make_safefoobar": "Geoff"},
             "My name is Geoff",
         ),
         (

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -915,7 +915,7 @@ def test_strikethrough(markdown_function, expected):
     "content, data, expected_html",
     [
         (
-            "This is an escaped heading: \n ((var::unsafe))",
+            "This is an escaped heading: \n ((var::make_safe))",
             {"var": "# This is heading 1"},
             '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">This is an escaped heading:<br> # This is heading 1</p>',  # noqa: E501
         ),

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -135,7 +135,10 @@ def test_URLs_get_escaped(url, expected_html, expected_html_in_template):
                 "</p>"
             ),
         ),
-        (notify_plain_text_email_markdown, ("\n\nhttps://example.com\n\nNext paragraph")),
+        (
+            notify_plain_text_email_markdown,
+            ("\n\nhttps://example.com\n\nNext paragraph"),
+        ),
     ],
 )
 def test_preserves_whitespace_when_making_links(markdown_function, expected_output):
@@ -214,7 +217,10 @@ def test_level_1_header(markdown_function, heading, expected):
 @pytest.mark.parametrize(
     "markdown_function, expected",
     (
-        [notify_letter_preview_markdown, "<p>Visit our [website](www.example.com/xyz).</p>"],
+        [
+            notify_letter_preview_markdown,
+            "<p>Visit our [website](www.example.com/xyz).</p>",
+        ],
         [
             notify_email_markdown,
             (
@@ -235,7 +241,10 @@ def test_external_link_without_http(markdown_function, expected):
 @pytest.mark.parametrize(
     "markdown_function, expected",
     (
-        [notify_letter_preview_markdown, "<p>Visit our [website](https://www.example.com/xyz).</p>"],
+        [
+            notify_letter_preview_markdown,
+            "<p>Visit our [website](https://www.example.com/xyz).</p>",
+        ],
         [
             notify_email_markdown,
             (
@@ -289,7 +298,10 @@ def test_mailto_link_in_email_markdown_link(url, expected_link_href):
 @pytest.mark.parametrize(
     "markdown_function, expected",
     (
-        [notify_letter_preview_markdown, '<p>Visit our [website](www.example.com/xyz "Link Title").</p>'],
+        [
+            notify_letter_preview_markdown,
+            '<p>Visit our [website](www.example.com/xyz "Link Title").</p>',
+        ],
         [
             notify_email_markdown,
             (
@@ -311,7 +323,10 @@ def test_external_title_link_without_http(markdown_function, expected):
 @pytest.mark.parametrize(
     "markdown_function, expected",
     (
-        [notify_letter_preview_markdown, '<p>Visit our [website](https://www.example.com/xyz "Link Title").</p>'],
+        [
+            notify_letter_preview_markdown,
+            '<p>Visit our [website](https://www.example.com/xyz "Link Title").</p>',
+        ],
         [
             notify_email_markdown,
             (
@@ -374,7 +389,10 @@ def test_level_3_header(markdown_function, expected):
 @pytest.mark.parametrize(
     "markdown_function, expected",
     (
-        [notify_letter_preview_markdown, ('<p>a</p><div class="page-break">&nbsp;</div><p>b</p>')],
+        [
+            notify_letter_preview_markdown,
+            ('<p>a</p><div class="page-break">&nbsp;</div><p>b</p>'),
+        ],
         [
             notify_email_markdown,
             (
@@ -397,7 +415,10 @@ def test_hrule(markdown_function, expected):
 @pytest.mark.parametrize(
     "markdown_function, expected",
     (
-        [notify_letter_preview_markdown, ("<ol>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ol>\n")],
+        [
+            notify_letter_preview_markdown,
+            ("<ol>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ol>\n"),
+        ],
         [
             notify_email_markdown,
             (
@@ -443,7 +464,10 @@ def test_ordered_list(markdown_function, expected):
 @pytest.mark.parametrize(
     "markdown_function, expected",
     (
-        [notify_letter_preview_markdown, ("<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n")],
+        [
+            notify_letter_preview_markdown,
+            ("<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n"),
+        ],
         [
             notify_email_markdown,
             (
@@ -501,7 +525,10 @@ def test_pluses_dont_render_as_lists(markdown_function, expected):
 @pytest.mark.parametrize(
     "markdown_function, expected",
     (
-        [notify_letter_preview_markdown, ("<p>line one<br>line two</p><p>new paragraph</p>")],
+        [
+            notify_letter_preview_markdown,
+            ("<p>line one<br>line two</p><p>new paragraph</p>"),
+        ],
         [
             notify_email_markdown,
             (
@@ -542,7 +569,12 @@ def test_multiple_newlines_get_truncated(markdown_function, expected):
 
 
 @pytest.mark.parametrize(
-    "markdown_function", (notify_letter_preview_markdown, notify_email_markdown, notify_plain_text_email_markdown)
+    "markdown_function",
+    (
+        notify_letter_preview_markdown,
+        notify_email_markdown,
+        notify_plain_text_email_markdown,
+    ),
 )
 def test_table(markdown_function):
     assert markdown_function("col | col\n----|----\nval | val\n") == ("")
@@ -635,7 +667,11 @@ def test_double_emphasis(markdown_function, expected):
 @pytest.mark.parametrize(
     "markdown_function, text, expected",
     (
-        [notify_letter_preview_markdown, "something *important*", "<p>something *important*</p>"],
+        [
+            notify_letter_preview_markdown,
+            "something *important*",
+            "<p>something *important*</p>",
+        ],
         [
             notify_email_markdown,
             "something *important*",
@@ -689,7 +725,12 @@ def test_nested_emphasis(markdown_function, expected):
 
 
 @pytest.mark.parametrize(
-    "markdown_function", (notify_letter_preview_markdown, notify_email_markdown, notify_plain_text_email_markdown)
+    "markdown_function",
+    (
+        notify_letter_preview_markdown,
+        notify_email_markdown,
+        notify_plain_text_email_markdown,
+    ),
 )
 def test_image(markdown_function):
     assert markdown_function("![alt text](http://example.com/image.png)") == ("")
@@ -821,10 +862,22 @@ def test_letter_qr_code_only_passes_through_url(
     "content, data, expected_data",
     (
         # This is the officially-supported syntax
-        ("qr: ((data))", {"data": "https://www.example.com"}, "https://www.example.com"),
+        (
+            "qr: ((data))",
+            {"data": "https://www.example.com"},
+            "https://www.example.com",
+        ),
         ("qr: static", {}, "static"),
-        ("qr: prefix https://www.google.com suffix", {}, "prefix https://www.google.com suffix"),
-        ("qr: prefix ((data))", {"data": "https://www.example.com"}, "prefix https://www.example.com"),
+        (
+            "qr: prefix https://www.google.com suffix",
+            {},
+            "prefix https://www.google.com suffix",
+        ),
+        (
+            "qr: prefix ((data))",
+            {"data": "https://www.example.com"},
+            "prefix https://www.example.com",
+        ),
         #
         # This is an old syntax which we don’t support, so we make sure it doesn't render broken QR codes
         ("[qr](((data)))", {"data": "https://www.example.com"}, None),

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -858,6 +858,25 @@ def test_strikethrough(markdown_function, expected):
     assert markdown_function("~~Strike~~") == expected
 
 
+@pytest.mark.parametrize(
+    "content, data, expected_html",
+    [
+        (
+            "This is an escaped heading: \n ((var::unsafe))",
+            {"var": "# This is heading 1"},
+            '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">This is an escaped heading:<br> # This is heading 1</p>',  # noqa: E501
+        ),
+        (
+            "This is an unescaped heading: \n ((var))",
+            {"var": "# This is heading 1"},
+            '<p style="Margin: 0 0 20px 0; font-size: 19px; line-height: 25px; color: #0B0C0C;">This is an unescaped heading: </p><h2 style="Margin: 0 0 15px 0; padding: 10px 0 0 0; font-size: 27px; line-height: 35px; font-weight: bold; color: #0B0C0C;">This is heading 1</h2>',  # noqa: E501
+        ),
+    ],
+)
+def test_unsafe_placeholders_are_escaped_correctly(content, data, expected_html):
+    assert notify_email_markdown(str(Field(content, data))) == expected_html
+
+
 def test_footnotes():
     # Can’t work out how to test this
     pass

--- a/tests/test_placeholders.py
+++ b/tests/test_placeholders.py
@@ -10,7 +10,7 @@ from notifications_utils.field import Placeholder
     [
         ("((with-brackets))", "with-brackets"),
         ("without-brackets", "without-brackets"),
-        ("unsafe_placeholder::unsafe", "unsafe_placeholder"),
+        ("make_safe_placeholder::make_safe", "make_safe_placeholder"),
         ("((name::notify_test_service))", "name::notify_test_service"),
     ],
 )


### PR DESCRIPTION
For the first iteration of sanitising placeholders we decide that if a replacement value contains a url, the entire value should be considered compromised and an empty string returned: