### PR TITLE
Bump minimum Gunicorn version to 23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "Flask-Redis>=0.4.0",
     "Flask>=3.1.0",
     "govuk-bank-holidays>=0.15",
-    "gunicorn[eventlet]>=20.1.0",
+    "gunicorn[eventlet]>=23.0.0",
     "itsdangerous>=2.2.0",
     "Jinja2>=3.1.6",
     "mistune<2.0.0",  # v2 is totally incompatible with unclear benefit


### PR DESCRIPTION
All our apps are using at least this version now, so that’s what we should test against in this repo.

The `requirements.txt` file already has this version:
https://github.com/alphagov/notifications-utils/blob/9154f4b5d0ff5d9ad212cb6f08b31297bdeeb63a/requirements_for_test.txt#L62

But changing it in `pyproject.toml` prevents backsliding.