### PR TITLE
Don’t count channel islands phone numbers against international rate limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 99.3.2
+
+* Stops counting Crown Dependency phone numbers in CSV file as international
+
 ## 99.3.1
 
 * Bump `python-json-logger` to version 3

--- a/notifications_utils/recipient_validation/phone_number.py
+++ b/notifications_utils/recipient_validation/phone_number.py
@@ -86,7 +86,7 @@ class PhoneNumber:
             raise InvalidPhoneError(code=InvalidPhoneError.Codes.NOT_A_UK_MOBILE)
 
     def _raise_if_unsupported_country(self):
-        if str(self.number.country_code) not in COUNTRY_PREFIXES | {"+44"}:
+        if str(self.number.country_code) not in COUNTRY_PREFIXES | {f"+{UK_PREFIX}"}:
             raise InvalidPhoneError(code=InvalidPhoneError.Codes.UNSUPPORTED_COUNTRY_CODE)
 
     def validate(self, allow_international_number: bool = False, allow_uk_landline: bool = False) -> None:
@@ -229,7 +229,7 @@ class PhoneNumber:
         # TODO: check if we still need this - looking at api, this might be able to be removed entirely since it's
         # always used in conjunction with should_use_numeric_sender
         """
-        return self.number.country_code == 44
+        return self.number.country_code == int(UK_PREFIX)
 
     def get_international_phone_info(self):
         if is_international := self.is_international_number():
@@ -294,8 +294,8 @@ class PhoneNumber:
         return phonenumbers.format_number(
             self.number,
             (
-                phonenumbers.PhoneNumberFormat.INTERNATIONAL
-                if self.number.country_code != 44
-                else phonenumbers.PhoneNumberFormat.NATIONAL
+                phonenumbers.PhoneNumberFormat.NATIONAL
+                if self.is_uk_phone_number()
+                else phonenumbers.PhoneNumberFormat.INTERNATIONAL
             ),
         )

--- a/notifications_utils/recipient_validation/phone_number.py
+++ b/notifications_utils/recipient_validation/phone_number.py
@@ -75,7 +75,7 @@ class PhoneNumber:
         self._phone_number = phone_number
 
     def _raise_if_service_cannot_send_to_international_but_tries_to(self, allow_international: bool = False):
-        if not allow_international and str(self.number.country_code) != UK_PREFIX:
+        if not (allow_international or self.is_uk_phone_number()):
             raise InvalidPhoneError(code=InvalidPhoneError.Codes.NOT_A_UK_MOBILE)
 
     def _raise_if_service_cannot_send_to_uk_landline_but_tries_to(self, allow_uk_landline: bool = False):

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -143,7 +143,7 @@ class RecipientCSV:
     def _international_sms_count_generator(self):
         for row in self.rows:
             with suppress(InvalidPhoneError):
-                yield get_phone_number_object(row.recipient).is_international_number()
+                yield not get_phone_number_object(row.recipient).is_uk_phone_number()
 
     @property
     def more_international_sms_than_can_send(self):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "99.3.1"  # f51500dd8b676ffd6ae724d500d6cca6
+__version__ = "99.3.2"  # c4725cffc444b459a8ef067f6caf72f5

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -770,6 +770,7 @@ def test_international_sms_limit(extra_args, too_many):
         +12025550104, 2
         +12025550104, 3
         07900 900 321, (UK with no country code)
+        +447797292290, Jersey (doesn’t count towards international limit)
         """,
         template=_sample_template("sms"),
         allow_international_sms=True,


### PR DESCRIPTION
We still let services who don’t send international text messages send to the channel islands.

The rate limiting code considers these numbers international.

This means these services are blocked from sending to these numbers.

Looking at the phone numbers there’s no easy way for services to say which numbers are Channel Islands numbers. So it’s not reasonable for us to ask services to remove them from their data.

Instead we should not count them towards the rate limit.