### PR TITLE
Remove +44 from set of country codes

### DIFF
--- a/notifications_utils/recipient_validation/phone_number.py
+++ b/notifications_utils/recipient_validation/phone_number.py
@@ -86,7 +86,7 @@ class PhoneNumber:
             raise InvalidPhoneError(code=InvalidPhoneError.Codes.NOT_A_UK_MOBILE)
 
     def _raise_if_unsupported_country(self):
-        if str(self.number.country_code) not in COUNTRY_PREFIXES | {f"+{UK_PREFIX}"}:
+        if str(self.number.country_code) not in COUNTRY_PREFIXES:
             raise InvalidPhoneError(code=InvalidPhoneError.Codes.UNSUPPORTED_COUNTRY_CODE)
 
     def validate(self, allow_international_number: bool = False, allow_uk_landline: bool = False) -> None:


### PR DESCRIPTION
Because:
- `self.number.country_code` returns `44` so would never match `+44`
- `44` is already in COUNTRY_PREFIXES from here: https://github.com/alphagov/notifications-utils/blob/73d5018cacd490863ca96544b059d63df07f2c3b/notifications_utils/international_billing_rates.yml#L240