### PR TITLE
Remove `CROWN_DEPENDENCY_RANGES`

### DIFF
--- a/notifications_utils/recipient_validation/phone_number.py
+++ b/notifications_utils/recipient_validation/phone_number.py
@@ -49,8 +49,6 @@ international_phone_info = namedtuple(
     ],
 )
 
-CROWN_DEPENDENCY_RANGES = ["7781", "7839", "7911", "7509", "7797", "7937", "7700", "7829", "7624", "7524", "7924"]
-
 
 class PhoneNumber:
     """


### PR DESCRIPTION
These are not used anywhere: https://github.com/search?q=org%3Aalphagov+CROWN_DEPENDENCY_RANGES&type=code

Instead we use libphonenumber to determine if a phone number is from one of the Crown Dependencies