### PR TITLE
Only consider SMS CSVs when checking international SMS limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 99.3.3
+
+* Fix bug with non-SMS templates considering international SMS limits
+
 ## 99.3.2
 
 * Stops counting Crown Dependency phone numbers in CSV file as international

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -149,7 +149,7 @@ class RecipientCSV:
     def more_international_sms_than_can_send(self):
         if self.template_type != "sms":
             return False
-        return self.international_sms_count > self.remaining_international_sms_messages
+        return self.international_sms_count > max(self.remaining_international_sms_messages, 0)
 
     @property
     def rows(self):

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -147,6 +147,8 @@ class RecipientCSV:
 
     @property
     def more_international_sms_than_can_send(self):
+        if self.template_type != "sms":
+            return False
         return self.international_sms_count > self.remaining_international_sms_messages
 
     @property

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "99.3.2"  # c4725cffc444b459a8ef067f6caf72f5
+__version__ = "99.3.3"  # 9d1156751da6fb09de66616008781252

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -795,6 +795,7 @@ def test_international_sms_limit_doesnt_apply_for_email(allow_international, rem
     assert recipients.more_international_sms_than_can_send is False
     assert recipients.has_errors is False
 
+
 @pytest.mark.parametrize("allow_international_sms", (True, False))
 def test_international_sms_limit_handles_negative_limit(allow_international_sms):
     recipients = RecipientCSV(

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -780,6 +780,36 @@ def test_international_sms_limit(extra_args, too_many):
     assert recipients.has_errors is too_many
 
 
+@pytest.mark.parametrize("allow_international", [True, False])
+@pytest.mark.parametrize("remaining_international_sms_messages", [1, 0, -1])
+def test_international_sms_limit_doesnt_apply_for_email(allow_international, remaining_international_sms_messages):
+    recipients = RecipientCSV(
+        """
+        email_address,
+        example@gmail.com
+        """,
+        template=_sample_template("email"),
+        allow_international_sms=allow_international,
+        remaining_international_sms_messages=remaining_international_sms_messages,
+    )
+    assert recipients.more_international_sms_than_can_send is False
+    assert recipients.has_errors is False
+
+
+def test_international_sms_limit_is_ok_with_uk_number_if_no_international_remaining():
+    recipients = RecipientCSV(
+        """
+        phone_number,
+        07790 000 123
+        """,
+        template=_sample_template("sms"),
+        allow_international_sms=True,
+        remaining_international_sms_messages=0,
+    )
+    assert recipients.more_international_sms_than_can_send is False
+    assert recipients.has_errors is False
+
+
 @pytest.mark.parametrize(
     "file_contents,rows_with_bad_recipients",
     [

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -795,6 +795,20 @@ def test_international_sms_limit_doesnt_apply_for_email(allow_international, rem
     assert recipients.more_international_sms_than_can_send is False
     assert recipients.has_errors is False
 
+@pytest.mark.parametrize("allow_international_sms", (True, False))
+def test_international_sms_limit_handles_negative_limit(allow_international_sms):
+    recipients = RecipientCSV(
+        """
+        phone number
+        +447900900123
+        """,
+        template=_sample_template("sms"),
+        allow_international_sms=allow_international_sms,
+        remaining_international_sms_messages=-1,
+    )
+    assert not recipients.more_international_sms_than_can_send
+    assert not recipients.has_errors
+
 
 def test_international_sms_limit_is_ok_with_uk_number_if_no_international_remaining():
     recipients = RecipientCSV(


### PR DESCRIPTION
resolves an issue where if you had run out of international SMS for the day (or indeed, if we accidentally added to the cache limit for international SMS when you'd been sending other things like emails), we wouldn't let you send anything even if it wasn't an international SMS itself