### PR TITLE
Fix celery-beat logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 99.4.1
+
+* Fix celery beat logging so that it will log in json
+
 ## 99.4.0
 
 * Add celery logging configuration for json logging

--- a/notifications_utils/logging/celery.py
+++ b/notifications_utils/logging/celery.py
@@ -47,6 +47,7 @@ def setup_logging_connect(*args, **kwargs):
         },
         "loggers": {
             "celery.worker": {"handlers": ["default"], "level": log_level, "propagate": True},
+            "celery.beat": {"handlers": ["default"], "level": "INFO", "propagate": True},
         },
     }
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "99.4.0"  # c3c5c02b89ed5f03be6253d1e83eb1da
+__version__ = "99.4.1"  # f95ac73dda4cce737c0b85a60fb3b020


### PR DESCRIPTION
What
----

Fix celery beat logging so that it will log in json

Hard coded 'INFO' as we aren't concerned about leaking sensitive information from celery beat.

Why
----

The previous [celery logging pr](https://github.com/alphagov/notifications-utils/pull/1219) broke the celery beat unformatted logs we currently have.

This change will output these logs in json format. 