### PR TITLE
Celery Logging Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.venv
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 99.6.0
+
+* Improve celery json logging. Include beat with separate log level options and testing.
+
 ## 99.5.2
 
 * Make inheritence of annotations on SerialisedModel work on both the class and its instances

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "99.5.2"  # ab51164dad67bba11aa71960e75e033e
+__version__ = "99.6.0"  # 1f7738ff685ca1c60ba5172f9d88b628

--- a/tests/logging/dummy_celery_app.py
+++ b/tests/logging/dummy_celery_app.py
@@ -1,33 +1,44 @@
-import logging
 import os
 import signal
+import tempfile
+from datetime import timedelta
 
 from celery import Celery
-from pythonjsonlogger.json import JsonFormatter
 
 import notifications_utils.logging.celery as celery_logging
 
-logger = logging.getLogger()
 
-logHandler = logging.StreamHandler()
-formatter = JsonFormatter()
-logHandler.setFormatter(formatter)
-logger.addHandler(logHandler)
+class Config:
+    CELERY_WORKER_LOG_LEVEL = os.getenv("CELERY_WORKER_LOG_LEVEL", "CRITICAL").upper()
+    CELERY_BEAT_LOG_LEVEL = os.getenv("CELERY_BEAT_LOG_LEVEL", "INFO").upper()
 
-celery_logging.set_up_logging(logger)
+    def get(self, key, default=None):
+        return getattr(self, key, default)
 
 
+celery_logging.set_up_logging(Config())
+
+temp_dir = tempfile.mkdtemp()
 app = Celery("test_app")
 app.conf.update(
-    broker_url="memory://",  # deliberate celery failure
+    broker_url="filesystem://",
+    broker_transport_options={
+        "data_folder_in": temp_dir,
+        "data_folder_out": temp_dir,
+        "control_folder": os.path.join(temp_dir, "control"),
+    },
+    beat_schedule_filename=os.path.join(temp_dir, "celerybeat-schedule.db"),
+    beat_schedule={
+        "test-task": {
+            "task": "test_task",
+            "schedule": timedelta(seconds=1),  # Run every 1 seconds
+        }
+    },
 )
 
 WORKER_PID = os.getpid()
 
 
-@app.task
+@app.task(name="test_task")
 def test_task():
     os.kill(WORKER_PID, signal.SIGTERM)
-
-
-test_task.delay()


### PR DESCRIPTION
https://trello.com/c/btX99C0D/1085-celery-workers-not-logging-critical-errors

What
----

- Remove the warnings override. Feels a bit dodgy. It only means we miss a few items on startup
- Allow celery beat and celery worker log levels to be specified independently and from our normal config setup. 
- Update tests to include celery beat log tests
- Add test to ensure we do not print celery worker log messages if log level is CRITICAL.

Why
----

Previous implementation lacked beat testing and was using a non-standard configuration