### PR TITLE
Refactor: Update economy transit date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 99.5.0
+
+* Update economy letter transit date to 5 days
+
 ## 99.4.1
 
 * Fix celery beat logging so that it will log in json

--- a/notifications_utils/letter_timings.py
+++ b/notifications_utils/letter_timings.py
@@ -109,7 +109,7 @@ def get_min_and_max_days_in_transit(postage):
         # day, so effectively spends no full days in transit
         Postage.FIRST: (0, 0),
         Postage.SECOND: (1, 2),
-        Postage.ECONOMY: (2, 6),
+        Postage.ECONOMY: (2, 5),
         Postage.EUROPE: (3, 5),
         Postage.REST_OF_WORLD: (5, 7),
     }[postage]

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "99.4.1"  # f95ac73dda4cce737c0b85a60fb3b020
+__version__ = "99.5.0"  # f86c863d04289d326900ebd16414e1cb


### PR DESCRIPTION
### Summary
- Update economy letter transit date to 5 days to be in line with expected delivery

### Ticket:
- [Update delivery estimates code to accomodate economy postage](https://trello.com/c/JngKcHSO/1272-update-delivery-estimates-code-to-accomodate-economy-postage)
