### PR TITLE
Specify version of dateutil

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "ordered-set>=4.1.0",
     "phonenumbers>=8.13.50",
     "pypdf>=3.13.0",
+    "python-dateutil>=2.9.0",
     "python-json-logger>=3.3.0",
     "pytz>=2024.2",
     "pyyaml>=6.0.2",

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -120,6 +120,7 @@ pytest-xdist==3.6.1
     # via -r requirements_for_test_common.in
 python-dateutil==2.9.0.post0
     # via
+    #   notifications-utils (pyproject.toml)
     #   botocore
     #   celery
     #   freezegun


### PR DESCRIPTION
Because this is one of our direct dependencies, we should specify it, rather than rely on being pressent because it’s a subdependency.

This also means we can specify the version, and we want the latest version for Python 3.12 compatibility – see https://github.com/dateutil/dateutil/issues/1284