### PR TITLE
major version bump to 100.0.0

### DIFF
--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "99.8.0"  # 235b3e3580b24d464e4924064ac808f2
+__version__ = "100.0.0"  # 6e2957149e9f88e6a4a21d64d0dd7f43


### PR DESCRIPTION
We've made breaking changes since 99.8.0 that won't be correctly tagged (and so importable) until version.py is bumped as well