### PR TITLE
Enforce strict undefined behaviour in Jinja templates

### DIFF
--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -6,7 +6,7 @@ from html import unescape
 from os import path
 from typing import Literal
 
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from markupsafe import Markup
 
 from notifications_utils import (
@@ -56,7 +56,8 @@ template_env = Environment(
             path.dirname(path.abspath(__file__)),
             "jinja_templates",
         )
-    )
+    ),
+    undefined=StrictUndefined,
 )
 
 


### PR DESCRIPTION
We use Jinja templates for things like rendering emails and letters to HTML.

These templates don’t use any third-party code like `govuk-frontend-jinja`.

By using [`StrictUndefined`](https://jinja.palletsprojects.com/en/stable/api/#jinja2.StrictUndefined) we have a better chance of catching typos in variable names etc