### PR TITLE
Add x-forwarded-for information to log files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 100.2.0
+
+* add `x_forwarded_for_{0..3}` fields to pre/post request flask logs
+
 ## 100.1.0
 
 * Updated `phonenumbers` to version 9.0.9 to keep phonenumber metadata uptodate

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "100.1.0"  # 2d3f218c067e9d233cd7091c9956b652
+__version__ = "100.2.0"  # deadbeef964e16a7bb

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -127,6 +127,7 @@ def test_app_request_logs_level_by_status_code(
             "x-b3-parentspanid": "deadbeef",
             "x-b3-spanid": "abadcafe",
             "x-b3-traceid": "feedface",
+            "x-forwarded-for": "1.2.3.4, 5.6.7.8",
         },
     )
 
@@ -146,6 +147,8 @@ def test_app_request_logs_level_by_status_code(
                 "remote_addr": "127.0.0.1",
                 "parent_span_id": "deadbeef" if with_request_helper else None,
                 "process_": RestrictedAny(lambda value: isinstance(value, int)),
+                "x_forwarded_for_1": "1.2.3.4",
+                "x_forwarded_for_0": "5.6.7.8",
             },
             extra={
                 "url": "http://localhost/",
@@ -159,6 +162,8 @@ def test_app_request_logs_level_by_status_code(
                 "remote_addr": "127.0.0.1",
                 "parent_span_id": "deadbeef" if with_request_helper else None,
                 "process_": RestrictedAny(lambda value: isinstance(value, int)),
+                "x_forwarded_for_1": "1.2.3.4",
+                "x_forwarded_for_0": "5.6.7.8",
             },
         )
         in mock_req_logger.log.call_args_list
@@ -185,6 +190,8 @@ def test_app_request_logs_level_by_status_code(
                 "request_time": RestrictedAny(lambda value: isinstance(value, float) and 0.05 <= value),
                 "request_cpu_time": RestrictedAny(lambda value: isinstance(value, float)),
                 "process_": RestrictedAny(lambda value: isinstance(value, int)),
+                "x_forwarded_for_1": "1.2.3.4",
+                "x_forwarded_for_0": "5.6.7.8",
             },
             extra={
                 "url": "http://localhost/",
@@ -203,6 +210,8 @@ def test_app_request_logs_level_by_status_code(
                 "request_time": RestrictedAny(lambda value: isinstance(value, float) and 0.05 <= value),
                 "request_cpu_time": RestrictedAny(lambda value: isinstance(value, float)),
                 "process_": RestrictedAny(lambda value: isinstance(value, int)),
+                "x_forwarded_for_1": "1.2.3.4",
+                "x_forwarded_for_0": "5.6.7.8",
             },
         )
         in mock_req_logger.log.call_args_list
@@ -248,6 +257,8 @@ def test_app_request_logs_level_by_status_code(
                 "request_time": RestrictedAny(lambda value: isinstance(value, float) and 0.1 <= value),
                 "request_cpu_time": RestrictedAny(lambda value: isinstance(value, float)),
                 "process_": RestrictedAny(lambda value: isinstance(value, int)),
+                "x_forwarded_for_1": "1.2.3.4",
+                "x_forwarded_for_0": "5.6.7.8",
             },
             extra={
                 "url": "http://localhost/",
@@ -269,6 +280,8 @@ def test_app_request_logs_level_by_status_code(
                 "request_time": RestrictedAny(lambda value: isinstance(value, float) and 0.1 <= value),
                 "request_cpu_time": RestrictedAny(lambda value: isinstance(value, float)),
                 "process_": RestrictedAny(lambda value: isinstance(value, int)),
+                "x_forwarded_for_1": "1.2.3.4",
+                "x_forwarded_for_0": "5.6.7.8",
             },
         )
         in mock_req_logger.log.call_args_list


### PR DESCRIPTION
https://trello.com/c/CjPJrFAk/1160-notifications-api-recording-all-remoteaddr-as-internal-ips

What
----

Add x-forwarded-for info to log files.

Why
----

We want to log the ips we see at each stage of the request.