### PR TITLE
Update phonenumbers 9.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 100.1.0
+
+* Updated `phonenumbers` to version 9.0.9 to keep phonenumber metadata uptodate
+
 ## 100.0.0
 
 * `notification_type` is now a required argument of `clients.redis.daily_limit_cache_key` (apps have already been updated)

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "100.0.0"  # 6e2957149e9f88e6a4a21d64d0dd7f43
+__version__ = "100.1.0"  # 2d3f218c067e9d233cd7091c9956b652

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "Jinja2>=3.1.6",
     "mistune<2.0.0",  # v2 is totally incompatible with unclear benefit
     "ordered-set>=4.1.0",
-    "phonenumbers>=8.13.50",
+    "phonenumbers>=9.0.9",
     "pypdf>=3.13.0",
     "python-dateutil>=2.9.0",
     "python-json-logger>=3.3.0",

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -93,7 +93,7 @@ packaging==24.1
     #   build
     #   gunicorn
     #   pytest
-phonenumbers==8.13.52
+phonenumbers==9.0.9
     # via notifications-utils (pyproject.toml)
 pluggy==1.5.0
     # via pytest


### PR DESCRIPTION
Major version bump from 8.13.52 to 9.0.9. Looking at the release notes, I'm confident that this is not technically a breaking change for python. The phonenumbers python port of libphonenumber repsects the semantic versioning of the original java codebase.

The [release notes for v9.0.0](https://github.com/google/libphonenumber/releases/tag/v9.0.0) tell us that the major version bump is due to an update to java 8 from 1.7. This is not a breaking change for the python port.