### PR TITLE
subclass _get_backend to return DisabledBackend object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 101.1.1
+
+* Override celery._get_backend to instantly return DisabledBackend object when result_backend is None.
+  This is to prevent expensive scans of importlib.metadata.entry_points for a result backend.
+
 ## 101.1.0
 
 * Added `tally-bucket-rate-limit` lua script to redis client and wrapper method: `get_remaining_bucket_tokens`

--- a/notifications_utils/celery.py
+++ b/notifications_utils/celery.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from os import getpid
 
 from celery import Celery, Task
+from celery.backends.base import DisabledBackend
 from flask import g, request
 from flask.ctx import has_app_context, has_request_context
 
@@ -157,3 +158,11 @@ class NotifyCelery(Celery):
             other_kwargs["headers"]["notify_request_id"] = g.request_id
 
         return super().send_task(name, args, kwargs, **other_kwargs)
+
+    def _get_backend(self):
+        # If we've explicitly set no backend, we want to return the DisabledBackend object immediately.
+        # This will prevent scanning of the importlib.metadata.entry_points for a result backend
+        if self.conf.get("result_backend") is None:
+            return DisabledBackend(app=self)
+
+        return super()._get_backend()

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "101.1.0"  # c57cd1fa6a6fa657e5867745484ef3a3
+__version__ = "101.1.1"  # 3443e9869d4f0d21df058ecd46cefb44

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -4,6 +4,7 @@ import uuid
 
 import pytest
 from celery import Task
+from celery.backends.base import DisabledBackend
 from flask import g
 from freezegun import freeze_time
 
@@ -256,3 +257,13 @@ def test_method_signatures(celery_app, async_task, method, _value):
     if method == "run":
         return
     assert inspect.signature(getattr(async_task.__class__, method)) == inspect.signature(getattr(Task, method))
+
+
+def test__get_backend_returns_DisabledBackground_object_when_result_backend_is_set_to_None(notify_celery):
+    notify_celery.conf.update({"result_backend": None})
+    assert isinstance(notify_celery._get_backend(), DisabledBackend)
+
+
+def test__get_backend_does_not_return_DisabledBackground_object_when_result_backend_has_a_value(notify_celery):
+    notify_celery.conf.update({"result_backend": "redis"})
+    assert not isinstance(notify_celery._get_backend(), DisabledBackend)


### PR DESCRIPTION
🚨 This is a test branch to investigate disabling the celery result backend and will not be merged into main.
It overrides `celery._get_backend` so that it simply returns the `DisabledBackend` object once `result_backend` is set to None. 🚨 
