### PR TITLE
Override celery get backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 101.2.0
+
+* Override celery's _get_backend() method to instantly return a DisabledBackend object if result_backend is None. 
+  This is to improve performance by preventing unnecessary calls to celery's backend.
+
 ## 101.1.1
 
 * Bump min version of `govuk-bank-holidays` to 0.17.0

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "101.1.1"  # d9aac1ae1bc8c3e3c773db8d6ed9a0b4
+__version__ = "101.2.0"  # 2e3a583163cff7c341fc57f65d463108

--- a/requirements_for_test.in
+++ b/requirements_for_test.in
@@ -1,6 +1,6 @@
 -r requirements_for_test_common.in
 
 build==1.2.2
-celery==5.3.6
+celery==5.4.0
 redis>=4.3.4  # Earlier versions of redis miss features the tests need
 filelock==3.12.4

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,6 +2,8 @@
 #    uv pip compile requirements_for_test.in pyproject.toml --output-file requirements_for_test.txt
 amqp==5.2.0
     # via kombu
+async-timeout==5.0.1
+    # via redis
 awscrt==0.22.0
     # via botocore
 beautifulsoup4==4.12.3
@@ -20,7 +22,7 @@ build==1.2.2
     # via -r requirements_for_test.in
 cachetools==5.5.0
     # via notifications-utils (pyproject.toml)
-celery==5.3.6
+celery==5.4.0
     # via -r requirements_for_test.in
 certifi==2024.8.30
     # via requests


### PR DESCRIPTION
This PR overrides celery's `_get_backend` method. This is is to help facilitate disabling celery's result backend as described in [this](https://trello.com/c/S1FTSLuT/346-disable-celery-result-backend-in-production) card.
Currently if `result_backend` is `None` celery.backend still calls `Celery._get_backend()` which scans for a result backend store. 
Profiling results have shown that this is a significant bottleneck as the scanning for a result backend occurs multiple times and uses significant resources.

In the PR `Celery._get_backend` is being overridden in `NotifyCelery` to prevent scanning for a result_backend if `result_backend` is None. Performance testing shows that this will lead to approximately 26% improvement in [performance](https://docs.google.com/document/d/1eQfwd-omuM9bIYLtVsEdGaiPcoGe82a7cBzaNSpFW9U/edit?tab=t.0).

Our current setup utilises a fire and forget approach and we are not currently do not use or need a `result_backend`.