### PR TITLE
Remove `clients.redis.rate_limit_cache_key`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # CHANGELOG
 
+## 101.2.1
+
+- Remove `clients.redis.rate_limit_cache_key` (no longer used)
+
 ## 101.2.0
 
-* Override celery's _get_backend() method to instantly return a DisabledBackend object if result_backend is None. 
+* Override celery's _get_backend() method to instantly return a DisabledBackend object if result_backend is None.
   This is to improve performance by preventing unnecessary calls to celery's backend.
 
 ## 101.1.1

--- a/notifications_utils/clients/redis/__init__.py
+++ b/notifications_utils/clients/redis/__init__.py
@@ -10,7 +10,3 @@ def daily_limit_cache_key(service_id, notification_type):
         raise TypeError("notification_type is required")
 
     return f"{service_id}-{notification_type}-{yyyy_mm_dd}-count"
-
-
-def rate_limit_cache_key(service_id, api_key_type):
-    return f"{service_id}-{api_key_type}"

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "101.2.0"  # 2e3a583163cff7c341fc57f65d463108
+__version__ = "101.2.1"  # 67bdb2db1d590d079d507ea9662cf6fb

--- a/tests/clients/test_redis.py
+++ b/tests/clients/test_redis.py
@@ -1,10 +1,7 @@
 import pytest
 from freezegun import freeze_time
 
-from notifications_utils.clients.redis import (
-    daily_limit_cache_key,
-    rate_limit_cache_key,
-)
+from notifications_utils.clients.redis import daily_limit_cache_key
 
 
 @pytest.mark.parametrize(
@@ -26,7 +23,3 @@ def test_daily_limit_cache_key(sample_service, kwargs, expected_cache_key):
         assert daily_limit_cache_key(sample_service.id, **kwargs) == expected_cache_key.format(
             sample_service=sample_service
         )
-
-
-def test_rate_limit_cache_key(sample_service):
-    assert rate_limit_cache_key(sample_service.id, "TEST") == f"{sample_service.id}-TEST"


### PR DESCRIPTION
Only use of this was removed in https://github.com/alphagov/notifications-api/commit/db704edabd2cf8ce98de93015c74f594f4b9d3b4

