### PR TITLE
Upgrade to python313

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 101.3.0
+
+* Upgrade Python version to 3.13
+* Adjust get_remote_version() to compensate for changes in locals() in Python 3.13
+
 ## 101.2.1
 
 - Remove `clients.redis.rate_limit_cache_key` (no longer used)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-bookworm AS test
+FROM python:3.13-bookworm AS test
 WORKDIR /home/vcap/app
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "101.2.1"  # 67bdb2db1d590d079d507ea9662cf6fb
+__version__ = "101.3.0"  # c6298a7a74b9758048d755d97673f55a

--- a/notifications_utils/version_tools/__init__.py
+++ b/notifications_utils/version_tools/__init__.py
@@ -50,8 +50,13 @@ def upgrade_version():
 
 
 def get_remote_version():
-    exec(get_file_contents_from_github("main", "notifications_utils/version.py"))
-    return locals()["__version__"]
+    # The functionality of locals() has been optimised starting in Python 3.12 and further
+    # in Python 3.13 due to PEP 667 https://github.com/python/cpython/issues/118888
+    # locals is no longer has insight into a functions state. We now have to explicitly define a local scope dict.
+    local_scope = {}
+    version_data = get_file_contents_from_github("main", "notifications_utils/version.py")
+    exec(version_data, {}, local_scope)
+    return local_scope["__version__"]
 
 
 def get_app_version():

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,8 +2,6 @@
 #    uv pip compile requirements_for_test.in pyproject.toml --output-file requirements_for_test.txt
 amqp==5.2.0
     # via kombu
-async-timeout==5.0.1
-    # via redis
 awscrt==0.22.0
     # via botocore
 beautifulsoup4==4.12.3


### PR DESCRIPTION
This PR upgrades notifications-utils to Python 3.13.

Python 3.13 brings changes to the behaviour of locals() which necessitated a compensatory change to get_remote_version()