### PR TITLE
Register custom `slow` test mark

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ Homepage = "https://github.com/alphagov/notifications-utils"
 
 [tool.pytest.ini_options]
 xfail_strict = true
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
 
 [tool.setuptools.dynamic]
 version = {attr = "notifications_utils.version.__version__"}


### PR DESCRIPTION
Marks which aren’t registered will log a warning.

Follows https://docs.pytest.org/en/stable/how-to/mark.html#registering-marks