### PR TITLE
Don’t encode parentheses as HTML entities in emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 101.3.1
+
+* Fix rendering of parentheses in some HTML email clients
+
 ## 101.3.0
 
 * Upgrade Python version to 3.13

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -40,8 +40,6 @@ multiple_newlines = re.compile(r"((\n)\2{2,})")
 HTML_ENTITY_MAPPING = (
     ("&nbsp;", "👾🐦🥴"),
     ("&amp;", "➕🐦🥴"),
-    ("&lpar;", "◀️🐦🥴"),
-    ("&rpar;", "▶️🐦🥴"),
 )
 
 url = re.compile(

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "101.3.0"  # c6298a7a74b9758048d755d97673f55a
+__version__ = "101.3.1"  # fc7201acc978af9531d07f5787448741

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -326,3 +326,9 @@ def test_PlainTextField():
     assert str(PlainTextField("((foo)) ((foo??bar))")) == "((foo)) ((foo??bar))"
     assert str(PlainTextField("((foo)) ((foo??bar))", redact_missing_personalisation=True)) == "[hidden] [hidden]"
     assert str(PlainTextField("((foo??bar??baz))")) == "((foo??bar??baz))"
+
+
+def test_handling_html_entities():
+    assert str(Field("&lsqb; &rsqb; &lpar; &rpar; &ast; &sol; &num; &amp; &Hat;")) == (
+        "[ ] &lpar; &rpar; * / # &amp; ^"
+    )

--- a/tests/test_field.py
+++ b/tests/test_field.py
@@ -329,6 +329,6 @@ def test_PlainTextField():
 
 
 def test_handling_html_entities():
-    assert str(Field("&lsqb; &rsqb; &lpar; &rpar; &ast; &sol; &num; &amp; &Hat;")) == (
-        "[ ] &lpar; &rpar; * / # &amp; ^"
+    assert str(Field("&lsqb; &rsqb; &lpar; &rpar; &ast; &sol; &num; &amp; &nbsp; &Hat;")) == (
+        "[ ] ( ) * / # &amp; &nbsp; ^"
     )

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -211,7 +211,7 @@ def test_bleach_doesnt_try_to_make_valid_html_before_cleaning():
         ("?a=1&amp;b=2", "?a=1&amp;b=2"),
         # We let users use &lpar; and &rpar; because otherwise it’s
         # impossible to put brackets in the body of conditional placeholders
-        ("((var??&lpar;in brackets&rpar;))", "((var??&lpar;in brackets&rpar;))"),
+        ("((var??&lpar;in brackets&rpar;))", "((var??(in brackets)))"),
     ),
 )
 def test_escaping_html_entities(

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -2307,3 +2307,27 @@ def test_unsubscribe_link_is_rendered(
             )
         )
     )
+
+
+def test_html_entities_in_html_email():
+    assert "[ ] &lpar; &rpar; * / # &amp; ^" in str(
+        HTMLEmailTemplate(
+            {
+                "content": "&lsqb; &rsqb; &lpar; &rpar; &ast; &sol; &num; &amp; &Hat;",
+                "subject": "subject",
+                "template_type": "email",
+            }
+        )
+    )
+
+
+def test_html_entities_in_plain_text_email():
+    assert "[ ] ( ) * / # & ^\n" == str(
+        PlainTextEmailTemplate(
+            {
+                "content": "&lsqb; &rsqb; &lpar; &rpar; &ast; &sol; &num; &amp; &Hat;",
+                "subject": "subject",
+                "template_type": "email",
+            }
+        )
+    )

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -2331,3 +2331,16 @@ def test_html_entities_in_plain_text_email():
             }
         )
     )
+
+
+def test_lpar_rpar_in_conditional_placeholder():
+    assert "(with brackets)" in str(
+        HTMLEmailTemplate(
+            {
+                "content": "((conditional?&lpar;with brackets&rpar;))",
+                "subject": "subject",
+                "template_type": "email",
+            },
+            values={"conditonal": "yes"},
+        )
+    )

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -2310,22 +2310,22 @@ def test_unsubscribe_link_is_rendered(
 
 
 def test_html_entities_in_html_email():
-    assert "[ ] &lpar; &rpar; * / # &amp; ^" in str(
+    assert "[ ] ( ) * / # &amp; &nbsp; ^" in str(
         HTMLEmailTemplate(
             {
-                "content": "&lsqb; &rsqb; &lpar; &rpar; &ast; &sol; &num; &amp; &Hat;",
+                "content": "&lsqb; &rsqb; &lpar; &rpar; &ast; &sol; &num; &amp; &nbsp; &Hat;",
                 "subject": "subject",
                 "template_type": "email",
-            }
+            },
         )
     )
 
 
 def test_html_entities_in_plain_text_email():
-    assert "[ ] ( ) * / # & ^\n" == str(
+    assert "[ ] ( ) * / # & \xa0 ^\n" == str(
         PlainTextEmailTemplate(
             {
-                "content": "&lsqb; &rsqb; &lpar; &rpar; &ast; &sol; &num; &amp; &Hat;",
+                "content": "&lsqb; &rsqb; &lpar; &rpar; &ast; &sol; &num; &amp; &nbsp; &Hat;",
                 "subject": "subject",
                 "template_type": "email",
             }


### PR DESCRIPTION
Looks like GMail and Outlook re-renders them literally as `&lpar;` rather than `(`.

This only happens when the user puts the entity in their content.

When we changed to support artibrary HTML entities in https://github.com/alphagov/notifications-utils/commit/e7886aa4e1daa8744262c8ee1469410543bff5c5 we kept parentheses as a special-case. This wasn’t necessary.

Probably still a good idea to special-case:
- ampersands (because URL query strings)
- non-breaking spaces (because maybe some clients might try to normalise unicode whitespace characters)

Before | After
---|---
<img width="337" height="122" alt="image" src="https://github.com/user-attachments/assets/43e95e3c-cb49-406f-a57b-8d86d607feaf" /> | <img width="312" height="116" alt="image" src="https://github.com/user-attachments/assets/39b0a699-fbb4-415e-b393-8473f39c79ca" />
