### PR TITLE
`RedisClient`: detect "read-only" errors & drop idle connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 115.1.0
+
+* `RedisClient`: detect "read-only" errors & drop idle connections. These errors are probably a sign of a failover event, and our connection pool probably has stale connections to the "wrong" redis instance.
+
 ## 115.0.2
 
 * Make date printed on templated letters aware of British Summer Time

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -12,6 +12,7 @@ from typing import (  # noqa: UP035
 
 from flask import current_app
 from flask_redis import FlaskRedis
+from redis.exceptions import ReadOnlyError, ResponseError
 from redis.lock import Lock
 from redis.typing import Number
 
@@ -281,6 +282,15 @@ class RedisClient:
             key_name,
             extra={"redis_operation": operation, "redis_key": key_name},
         )
+
+        if isinstance(e, ReadOnlyError) or (isinstance(e, ResponseError) and "READONLY" in str(e)):
+            # it's likely we're in the middle of a failover of some sort and it's possible
+            # that any number of our pooled connections are connected to the "wrong" redis
+            # instance. give these a chance to do a fresh dns lookup and connect to the
+            # "right" instance.
+            current_app.logger.warning("Reacting to %r by disconnecting redis connection pool's idle connections", e)
+            self.redis_store.connection_pool.disconnect()
+
         if always_raise is INSTANCE_DEFAULT:
             always_raise = self.always_raise
         if raise_exception or isinstance(e, always_raise or ()):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "115.0.2"  # f2d560a20d45360f54975baf30b519ff
+__version__ = "115.1.0"  # c0a9b1d1e92545f3acd4b31a56bca13a


### PR DESCRIPTION
The least wild part of https://trello.com/c/PEpdGAPE/1518-implement-solution-for-failed-writes-deletes-to-redis

When we have a failover we can end up with stale connection(s) to the wrong redis instance which, having now been switched over to being read-only, will throw these errors. In such a case we probably want to give all current connections we're holding a chance to pick up the new DNS record and connect to the correct redis instance.

This is "tested" on a dev env in that it operates normally and doesn't cause any extra trouble during a failover, but it's extremely hard to reproduce the unusual conditions where we get these exceptions, so that hasn't been possible (though we have definitely received these exceptions in production in the past).