### PR TITLE
Add OpenTelemetry semconv helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 113.2.0
+
+* Add `semconv.set_error_type`
+* Add `semconv.TASK_DURATION_HISTOGRAM_BUCKETS`
+* Add `semconv.HTTP_DURATION_HISTOGRAM_BUCKETS`
+
 ## 113.1.0
 
 Add `testing.comparisons.AnyInstanceOf`

--- a/notifications_utils/celery.py
+++ b/notifications_utils/celery.py
@@ -10,19 +10,14 @@ from flask.ctx import has_app_context, has_request_context
 from opentelemetry import metrics
 
 from notifications_utils.clients.statsd.statsd_client import StatsdClient
+from notifications_utils.semconv import TASK_DURATION_HISTOGRAM_BUCKETS
 
-# fmt: off
 duration_histogram = metrics.get_meter(__name__).create_histogram(
     "celery.task.duration",
     unit="s",
     description="The amount of time it took for the task to run.",
-    explicit_bucket_boundaries_advisory=[
-         0.01,  0.025, 0.05,  0.1,   0.25,   0.5,
-         1.0,   2.0,   4.0,   8.0,  15.0,   30.0,
-        60.0, 120.0, 240.0, 480.0, 900.0, 1800.0,
-    ],
+    explicit_bucket_boundaries_advisory=TASK_DURATION_HISTOGRAM_BUCKETS,
 )
-# fmt: on
 
 
 class NotifyTask(Task):

--- a/notifications_utils/semconv.py
+++ b/notifications_utils/semconv.py
@@ -1,0 +1,13 @@
+from collections.abc import MutableMapping
+from sys import exception
+
+from opentelemetry.util.types import AttributeValue
+
+
+def set_error_type(attributes: MutableMapping[str, AttributeValue]) -> None:
+    """
+    Sets key `"error.type"` in `attributes` to the fully-qualified name of the current exception, if any.
+    """
+    e = exception()
+    if e is not None:
+        attributes["error.type"] = type(e).__module__ + "." + type(e).__qualname__

--- a/notifications_utils/semconv.py
+++ b/notifications_utils/semconv.py
@@ -3,6 +3,29 @@ from sys import exception
 
 from opentelemetry.util.types import AttributeValue
 
+# Buckets ranging from milliseconds to 30 minutes,
+# suitable for e.g. Celery task durations
+TASK_DURATION_HISTOGRAM_BUCKETS = [
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.0,
+    4.0,
+    8.0,
+    15.0,
+    30.0,
+    60.0,
+    120.0,
+    240.0,
+    480.0,
+    900.0,
+    1800.0,
+]
+
 
 def set_error_type(attributes: MutableMapping[str, AttributeValue]) -> None:
     """

--- a/notifications_utils/semconv.py
+++ b/notifications_utils/semconv.py
@@ -26,6 +26,25 @@ TASK_DURATION_HISTOGRAM_BUCKETS = [
     1800.0,
 ]
 
+# Buckets suitable for HTTP request durations.
+# Copied from opentelemetry.instrumentation._semconv.HTTP_DURATION_HISTOGRAM_BUCKETS_NEW.
+HTTP_DURATION_HISTOGRAM_BUCKETS = [
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.075,
+    0.1,
+    0.25,
+    0.5,
+    0.75,
+    1,
+    2.5,
+    5,
+    7.5,
+    10,
+]
+
 
 def set_error_type(attributes: MutableMapping[str, AttributeValue]) -> None:
     """

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "113.1.0"  # f02c2d29d416cfaba8ef606c263f1d09
+__version__ = "113.2.0"  # 5c92920963b0b8dd8c5903f4f38deaa6

--- a/tests/test_semconv.py
+++ b/tests/test_semconv.py
@@ -1,0 +1,30 @@
+import pytest
+from opentelemetry.util.types import AttributeValue
+
+from notifications_utils.semconv import set_error_type
+
+
+class MyException(Exception):
+    pass
+
+
+def test_set_error_type_without_exception() -> None:
+    try:
+        pass
+    finally:
+        attributes: dict[str, AttributeValue] = {"foo.bar": "baz"}
+        set_error_type(attributes)
+        assert attributes == {"foo.bar": "baz"}
+
+
+def test_set_error_type_with_exception() -> None:
+    with pytest.raises(MyException):
+        try:
+            raise MyException
+        finally:
+            attributes: dict[str, AttributeValue] = {"foo.bar": "baz"}
+            set_error_type(attributes)
+            assert attributes == {
+                "foo.bar": "baz",
+                "error.type": "tests.test_semconv.MyException",
+            }


### PR DESCRIPTION
https://trello.com/c/25A3gpXh/1358-replace-statsd-instrumentation-across-notify-with-otel

Adds some constants and a helper function to a new module called `semconv` (i.e. semantic conventions):

* `set_error_type`: intended to be called from a `finally` block to conditionally set `error.type` on metric/log message/span attributes if an exception was raised
* `TASK_DURATION_HISTOGRAM_BUCKETS`: a set of histogram bucket boundaries suitable for background tasks
* `HTTP_DURATION_HISTOGRAM_BUCKETS`: a set of histogram bucket boundaries suitable for HTTP requests

The module is named `semconv` following the OpenTelemetry convention.