### PR TITLE
Add `testing.comparisons.AnyInstanceOf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 113.1.0
+
+Add `testing.comparisons.AnyInstanceOf`
+
 ## 113.0.0
 
 * Update Celery duration metric to follow OpenTelemetry semantic conventions

--- a/notifications_utils/testing/comparisons.py
+++ b/notifications_utils/testing/comparisons.py
@@ -31,6 +31,16 @@ class RestrictedAny:
         return None
 
 
+class AnyInstanceOf(RestrictedAny):
+    """
+    Instance will appear to "equal" any object whose class matches, or is a subclass of, the constructor-supplied
+    ``class_``
+    """
+
+    def __init__(self, *classes):
+        self._condition = lambda instance: isinstance(instance, tuple(classes))
+
+
 class AnySupersetOf(RestrictedAny):
     """
     Instance will appear to "equal" any dictionary-like object that is a "superset" of the the constructor-supplied

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "113.0.0"  # dd380f7de9ced126783e40bd4d2d3666
+__version__ = "113.1.0"  # f02c2d29d416cfaba8ef606c263f1d09

--- a/tests/testing/test_comparisons.py
+++ b/tests/testing/test_comparisons.py
@@ -1,6 +1,7 @@
 import re
 
 from notifications_utils.testing.comparisons import (
+    AnyInstanceOf,
     AnyStringMatching,
     AnySupersetOf,
     ExactIdentity,
@@ -109,3 +110,28 @@ class TestExactIdentity:
             7,
             [],
         )
+
+
+class TestAnyInstanceOf:
+    class Parent:
+        pass
+
+    class Child(Parent):
+        pass
+
+    class Stranger:
+        pass
+
+    def test_compares_against_one_class(self):
+        assert self.Parent() == AnyInstanceOf(self.Parent)
+        assert self.Child() == AnyInstanceOf(self.Parent)
+        assert self.Child() == AnyInstanceOf(self.Child)
+        assert self.Parent() != AnyInstanceOf(self.Child)
+        assert self.Stranger() != AnyInstanceOf(self.Parent)
+
+    def test_compares_against_multiple_classes(self):
+        assert self.Stranger() != AnyInstanceOf(self.Parent, self.Child)
+        assert self.Stranger() == AnyInstanceOf(self.Parent, self.Stranger)
+
+    def test_does_not_match_if_left_side_is_not_instance(self):
+        assert self.Stranger != AnyInstanceOf(self.Stranger)


### PR DESCRIPTION
This is useful if you want to assert a function call’s argument is of the right type, but don’t care about its exact value