### PR TITLE
semconv: Add set_service_instance_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 113.3.0
+
+* Add `semconv.set_service_instance_id`
+* Remove `celery.task.retry_number` attribute from `celery.task.duration` histogram metric
+
 ## 113.2.0
 
 * Add `semconv.set_error_type`

--- a/notifications_utils/celery.py
+++ b/notifications_utils/celery.py
@@ -58,7 +58,6 @@ class NotifyTask(Task):
             duration,
             {
                 "celery.task.name": self.name,
-                "celery.task.retry_number": self.request.retries,
                 "celery.task.status": status,
                 "sqs.queue.name": self.queue_name,
             },

--- a/notifications_utils/semconv.py
+++ b/notifications_utils/semconv.py
@@ -1,5 +1,7 @@
+import os
 from collections.abc import MutableMapping
 from sys import exception
+from uuid import uuid4
 
 from opentelemetry.util.types import AttributeValue
 
@@ -53,3 +55,21 @@ def set_error_type(attributes: MutableMapping[str, AttributeValue]) -> None:
     e = exception()
     if e is not None:
         attributes["error.type"] = type(e).__module__ + "." + type(e).__qualname__
+
+
+def set_service_instance_id() -> None:
+    """Updates the `OTEL_RESOURCE_ATTRIBUTES` environment variable to set `service.instance.id` to a random UUIDv4.
+
+    For applications that use fork-based concurrency (which includes both Celery and Gunicorn), this should be called
+    in a post-fork hook, before the call to `opentelemetry.instrumentation.auto_instrumentation.initialize()`, to
+    ensure that each worker process gets a unique service instance ID.
+
+    Future versions of opentelemetry-python might do this automatically, in which case we can remove this.
+
+    See also:
+        https://github.com/open-telemetry/opentelemetry-python/issues/4390
+        https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/
+    """
+    old_value = os.environ.get("OTEL_RESOURCE_ATTRIBUTES")
+    new_value = f"service.instance.id={uuid4()}"
+    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = f"{old_value},{new_value}" if old_value is not None else new_value

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "113.2.0"  # 5c92920963b0b8dd8c5903f4f38deaa6
+__version__ = "113.3.0"  # e535033855c43194cca1b7e6851dd54f

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -75,7 +75,6 @@ def test_success_should_log_and_record_timing(celery_app, async_task, caplog, mo
         5.0,
         {
             "celery.task.name": async_task.name,
-            "celery.task.retry_number": 0,
             "celery.task.status": "success",
             "sqs.queue.name": "test-queue",
         },
@@ -99,7 +98,6 @@ def test_success_no_early_log(celery_app, async_task_early_debug, caplog, mocker
         5.0,
         {
             "celery.task.name": async_task_early_debug.name,
-            "celery.task.retry_number": 0,
             "celery.task.status": "success",
             "sqs.queue.name": "test-queue",
         },
@@ -123,7 +121,6 @@ def test_success_queue_when_applied_synchronously(celery_app, celery_task, caplo
         5.0,
         {
             "celery.task.name": celery_task.name,
-            "celery.task.retry_number": 0,
             "celery.task.status": "success",
             "sqs.queue.name": "none",
         },
@@ -147,7 +144,6 @@ def test_retry_should_log_and_call_statsd(celery_app, async_task, caplog, mocker
         5.0,
         {
             "celery.task.name": async_task.name,
-            "celery.task.retry_number": 0,
             "celery.task.status": "retry",
             "sqs.queue.name": "test-queue",
         },
@@ -171,7 +167,6 @@ def test_retry_queue_when_applied_synchronously(celery_app, celery_task, caplog,
         5.0,
         {
             "celery.task.name": celery_task.name,
-            "celery.task.retry_number": 0,
             "celery.task.status": "retry",
             "sqs.queue.name": "none",
         },
@@ -195,7 +190,6 @@ def test_failure_should_log_and_call_statsd(celery_app, async_task, caplog, mock
         5.0,
         {
             "celery.task.name": async_task.name,
-            "celery.task.retry_number": 0,
             "celery.task.status": "failure",
             "sqs.queue.name": "test-queue",
         },
@@ -219,7 +213,6 @@ def test_failure_queue_when_applied_synchronously(celery_app, celery_task, caplo
         5.0,
         {
             "celery.task.name": celery_task.name,
-            "celery.task.retry_number": 0,
             "celery.task.status": "failure",
             "sqs.queue.name": "none",
         },

--- a/tests/test_semconv.py
+++ b/tests/test_semconv.py
@@ -1,7 +1,10 @@
+import os
+
 import pytest
 from opentelemetry.util.types import AttributeValue
+from pytest_mock import MockerFixture
 
-from notifications_utils.semconv import set_error_type
+from notifications_utils.semconv import set_error_type, set_service_instance_id
 
 
 class MyException(Exception):
@@ -28,3 +31,16 @@ def test_set_error_type_with_exception() -> None:
                 "foo.bar": "baz",
                 "error.type": "tests.test_semconv.MyException",
             }
+
+
+def test_set_service_instance_id(mocker: MockerFixture) -> None:
+    mocker.patch("notifications_utils.semconv.uuid4", return_value="00000000-0000-0000-0000-000000000000")
+    set_service_instance_id()
+    assert os.environ["OTEL_RESOURCE_ATTRIBUTES"] == "service.instance.id=00000000-0000-0000-0000-000000000000"
+
+
+def test_set_service_instance_id_retains_existing_resource_attributes(mocker: MockerFixture) -> None:
+    mocker.patch("notifications_utils.semconv.uuid4", return_value="00000000-0000-0000-0000-000000000000")
+    os.environ["OTEL_RESOURCE_ATTRIBUTES"] = "foo=bar"
+    set_service_instance_id()
+    assert os.environ["OTEL_RESOURCE_ATTRIBUTES"] == "foo=bar,service.instance.id=00000000-0000-0000-0000-000000000000"


### PR DESCRIPTION
https://trello.com/c/25A3gpXh/1358-replace-statsd-instrumentation-across-notify-with-otel

- Adds helper function `semconv.set_service_instance_id` that sets the `OTEL_RESOURCE_ATTRIBUTES` environment variable to set `service.instance.id` to a random UUIDv4. This is currently the only way to configure the OTel resource that the auto-instrumentation sets up.

  - This is intended to be used by apps that use fork-based concurrency, to ensure that each child process annotates its metrics with a unique set of attributes. Otherwise each process ends up reporting time series with the same set of labels but with different values, which violates the single writer principle and means we end up with broken metrics in Prometheus.

  - Future versions of opentelemetry-python might do this automatically (see open-telemetry/opentelemetry-python#4390), in which case we can remove this.

  - See also https://opentelemetry.io/docs/specs/semconv/registry/attributes/service/

- Removes the `celery.task.retry_number` label from the `celery.task.duration` histogram metric. We retry tasks a lot more times than I'd realised, so this was potentially a very high cardinality label.
  - Technically this is a breaking change, but we don't actually collect this metric yet so :shrug: 