### PR TITLE
Make `RecipientCSV` better friends with the CPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 113.5.1
+
+* `RecipientCSV`: Performance improvements for files with large numbers of columns
+
 ## 113.5.0
 
 * RecipientCSV.get_rows: sleep every `get_rows_loop_interruptible_every` iterations. This should allow greenthread libraries to yield to another thread when processing large CSVs instead of blocking them.

--- a/notifications_utils/insensitive_dict.py
+++ b/notifications_utils/insensitive_dict.py
@@ -53,7 +53,7 @@ class InsensitiveDict(dict):
         return {key: self.get(key) for key in keys}
 
     @staticmethod
-    @lru_cache(maxsize=32, typed=False)
+    @lru_cache(maxsize=1_024, typed=False)  # Corresponds to 1,000 column limit when reading Excel files
     def make_key(original_key):
         if original_key is None:
             return None

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -489,8 +489,8 @@ class Cell:
 
     def __init__(self, key=None, value=None, error_fn=None, placeholders=None):
         self.data = value
-        self.error = error_fn(key, value) if error_fn else None
         self.ignore = InsensitiveDict.make_key(key) not in (placeholders or [])
+        self.error = error_fn(key, value) if error_fn and not self.ignore else None
 
     def __eq__(self, other):
         if not other.__class__ == self.__class__:

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "113.5.0"  # ca4cdd49c9ce42c281ea0564e3819816
+__version__ = "113.5.1"  # 5db9c3a03f089972345f6a37cce46c1f

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -3,7 +3,7 @@ import string
 import unicodedata
 from functools import partial
 from random import choice, randrange
-from unittest.mock import ANY, Mock, PropertyMock
+from unittest.mock import ANY, Mock, PropertyMock, call
 
 import pytest
 from ordered_set import OrderedSet
@@ -1513,4 +1513,35 @@ def test_duplicate_headers_are_cached(mocker):
         # 2 calls per loop, but cached after the first of 3 loops
         mocker.call(),
         mocker.call(),
+    ]
+
+
+def test_cell_ignore_and_error_checking(mocker):
+    mock_get_error_for_field = mocker.patch.object(
+        RecipientCSV,
+        "_get_error_for_field",
+    )
+    recipients = RecipientCSV(
+        """
+        Phone Number, Name, Foo, Bar
+        123,          A,    foo, bar
+        456,          B,    foo, bar
+        789,          C,    foo, bar
+        """,
+        template=_sample_template("sms", content="Hello ((name))"),
+    )
+
+    assert [[cell.ignore for _header, cell in row.items()] for row in recipients] == [
+        [False, False, True, True],
+        [False, False, True, True],
+        [False, False, True, True],
+    ]
+    assert mock_get_error_for_field.call_args_list == [
+        # Only fields which have a recipient or a placeholder from the template get checked
+        call("Phone Number", "123"),
+        call("Name", "A"),
+        call("Phone Number", "456"),
+        call("Name", "B"),
+        call("Phone Number", "789"),
+        call("Name", "C"),
     ]


### PR DESCRIPTION
# Problem

When parsing a CSV of recipient data we call `InsensitiveDict.make_key` a lot (there are 10 separate calls in `recipients.py`). This is to make sure the columns in the file match the placeholders in the template, even when their case and spacing don’t match.

Because `InsensitiveDict.make_key` is relatively slow (it does string manipulation) we cache it:
https://github.com/alphagov/notifications-utils/blob/a5be6d81422eab490ff3cf1d93a36b1c90826edb/notifications_utils/insensitive_dict.py#L56-L57

However a cache size of 32 items is quite small. If a CSV had more than 32 columns then the first column would get evicted from the cache by the time the code had looped through to the last column. And then repeat for the next row.

This thrashing of the cache means there’s a big performance hit for CSVs with a large number of columns.

# Fixes

## Increasing the cache size

The maximum number of columns we allow in an Excel file is 1,000. So that, rounded to the nearest power of 2, seems like a more sensible limit.

## Skipping error checking

There can be columns in a file which we don’t care about. These are columns which don’t correspond to recipient data or a placeholder in the file. We can get a small increase in efficiency by not running the function which checks each cell for errors against this column.

# How I tested this

I used this script to generate a CSV with 100 columns and 100 rows 

```python
from notifications_utils.recipients import RecipientCSV
from notifications_utils.template import SMSPreviewTemplate

template = SMSPreviewTemplate(
    {
        "template_type": "sms",
        "content": "Hello ((column-number-1))    this is a message for you",
    }
)

header = [",".join(["Phone Number"] + [f" Column Number {i}" for i in range(100)])]
rows = [",".join([f"07900900{j:03}"] + [f"Row {j} column {i}" for i in range(100)]) for j in range(100)]
contents = "\n".join(header + rows)


def r():
    instance = RecipientCSV(contents, template=template)
    assert not instance.has_errors
    assert len(list(instance.initial_rows)) == 10
```

I then ran this script from the shell with the `timeit` module:

```shell
python -m timeit -n 20 -s "from benchmark import r" "r()
```

# Results

Commit | Benchmarking results | Cumulative reduction in time
---|---|----
`origin/main` (baseline) | 20 loops, best of 5: 141 msec per loop | 0%
Increase cache size of `InsensitiveDict.make_key` | 20 loops, best of 5: 39.4 msec per loop | 72%
Don’t evaluate cells we don’t care about | 20 loops, best of 5: 37.2 msec per loop | 74%
