### PR TITLE
RecipientCSV.get_rows: sleep every 128 iterations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 113.5.0
+
+* RecipientCSV.get_rows: sleep every `get_rows_loop_interruptible_every` iterations. This should allow greenthread libraries to yield to another thread when processing large CSVs instead of blocking them.
+
 ## 113.4.0
 
 * Add option to check_token and generate_token to take encrypt_secret. If it is there it will attempt to decrypt in check_token first, before falling back to verifying signing.  It will encrypt the token in generate_token if encrypt_secret is there.

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -4,6 +4,7 @@ from contextlib import suppress
 from functools import lru_cache
 from io import StringIO
 from itertools import islice
+from time import sleep
 from typing import cast
 
 from ordered_set import OrderedSet
@@ -37,6 +38,7 @@ address_columns = InsensitiveDict.from_keys(first_column_headings["letter"])
 
 class RecipientCSV:
     max_rows = 100_000
+    get_rows_loop_interruptible_every = 128
 
     def __init__(
         self,
@@ -189,6 +191,11 @@ class RecipientCSV:
             if index >= self.max_rows:
                 yield None
                 continue
+
+            if not (index + 1) % self.get_rows_loop_interruptible_every:
+                # all green thread libraries will monkeypatch this to yield to the event loop
+                # and the real implementation should at least drop the GIL
+                sleep(0)
 
             output_dict = {}
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "113.4.0"  # 17502ffbb541e4be73ddcb33244e3dd4
+__version__ = "113.5.0"  # ca4cdd49c9ce42c281ea0564e3819816


### PR DESCRIPTION
This is so that we yield to other greenthreads when using eventlet.

Currently there are cases where the admin app gets its process blocked for 30s (and occasionally >30s which gets the process killed)