### PR TITLE
Add a tool to check for outdated versions of pinned dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 113.6.0
+
+* Adds `version_tools.show_outdated_requirements`. Consumers should add a make command like `python -c "from notifications_utils.version_tools import show_outdated_requirements; show_outdated_requirements()`
+
 ## 113.5.1
 
 * `RecipientCSV`: Performance improvements for files with large numbers of columns

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "113.5.1"  # 5db9c3a03f089972345f6a37cce46c1f
+__version__ = "113.6.0"  # c06c738f1827b874ea08bb3b0759d97a

--- a/notifications_utils/version_tools/__init__.py
+++ b/notifications_utils/version_tools/__init__.py
@@ -1,9 +1,12 @@
 import pathlib
+import re
 from base64 import b64decode
 from importlib import resources as importlib_resources
 from importlib.metadata import version
+from itertools import zip_longest
 
 import requests
+import requirements
 
 requirements_file = pathlib.Path("requirements.in")
 frozen_requirements_file = pathlib.Path("requirements.txt")
@@ -113,3 +116,71 @@ def copy_config():
                 )
             )
             f.write(file_bytes)
+
+
+def get_semver_parts(version):
+    return dict(zip_longest(("major", "minor", "patch"), version.split(".")))
+
+
+def get_latest_version_from_pypi(requirement_name):
+    pypi_response = requests.get(
+        f"https://pypi.org/simple/{requirement_name}", headers={"Accept": "application/vnd.pypi.simple.v1+json"}
+    ).json()
+    versions = pypi_response["versions"]
+    versions = sorted(
+        # Matches 0.1 and 1.2.3 but not 3.2.1a
+        [version for version in versions if re.fullmatch(r"((\d+\.)+(\d+))", version)],
+        key=lambda version: [int(part) for part in version.split(".")],
+    )
+    return get_semver_parts(versions[-1])
+
+
+def check_version_difference(specified, available, *, specificity):
+    for part in specified.keys():
+        if specified[part] != available[part]:
+            available = ".".join(filter(None, available.values()))
+            print(  # noqa: T201
+                f"    🚨 {color.RED}{color.BOLD}{part.capitalize()} upgrade needed: {available} is latest{color.END}"
+            )
+            return
+        if part == specificity:
+            print(  # noqa: T201
+                f"    {color.GREEN}{specificity.capitalize()} version up to date{color.END}"
+            )
+            return
+
+
+def show_outdated_requirements():
+    for requirement in requirements.parse(requirements_file.open()):
+        print(  # noqa: T201
+            requirement.line.strip()
+        )
+
+        if not requirement.specs:
+            if requirement.vcs == "git":
+                print(  # noqa: T201
+                    f"{color.YELLOW}{color.BOLD}    ⚠️  Warning: not a PyPi package{color.END}"
+                )
+            else:
+                print(  # noqa: T201
+                    f"{color.BLUE}    No version specified{color.END}"
+                )
+            continue
+
+        specifier, version = requirement.specs[0]
+        latest_pypi_version = get_latest_version_from_pypi(requirement.name)
+        specified_version = get_semver_parts(version)
+
+        if specifier == "==":
+            specificity = "patch"
+        elif specifier == "~=" and specified_version["patch"]:
+            specificity = "minor"
+        elif specifier == "~=" and specified_version["minor"]:
+            specificity = "major"
+        else:
+            print(  # noqa: T201
+                f"{color.YELLOW}{color.BOLD}    ⚠️  Warning: unsupported specifier: {specifier}{color.END}"
+            )
+            continue
+
+        check_version_difference(specified_version, latest_pypi_version, specificity=specificity)

--- a/notifications_utils/version_tools/requirements_for_test_common.in
+++ b/notifications_utils/version_tools/requirements_for_test_common.in
@@ -8,3 +8,5 @@ requests-mock
 freezegun
 
 ruff==0.15.2  # Also update `.pre-commit-config.yaml` if this changes
+
+requirements-parser

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -104,6 +104,7 @@ packaging==26.0
     #   gunicorn
     #   kombu
     #   pytest
+    #   requirements-parser
 phonenumbers==9.0.25
     # via notifications-utils (pyproject.toml)
 pluggy==1.6.0
@@ -155,6 +156,8 @@ requests==2.32.5
     #   govuk-bank-holidays
     #   requests-mock
 requests-mock==1.12.1
+    # via -r requirements_for_test_common.in
+requirements-parser==0.13.0
     # via -r requirements_for_test_common.in
 ruff==0.15.2
     # via -r requirements_for_test_common.in


### PR DESCRIPTION
# Where we’d like to get to with Python dependency management

<img width="1225" height="687" alt="image" src="https://github.com/user-attachments/assets/c1b02c35-2729-461c-b74f-bba6f03516f6" />

The missing piece is working out when we update major versions of pinned dependencies.

# There is a problem upstream of this

How do we know when a pinned dependency is out of date and needs upgrading?

# The solution

This pull request adds a script which audits a project’s `requirements.in` file. It looks at:
- how strictly a dependency is pinned
- what the newest version of that dependency is on PyPi
- whether the pin would stop `make refreeze-requirements` from upgrading to the newest version 

Developers can use this tool to work out which dependencies either need:
- manually upgrading
- looser pinning

Example output:

<img width="949" height="654" alt="image" src="https://github.com/user-attachments/assets/3b71c860-8416-4996-b627-df178427d440" />

# Testing

I’ve run this against a combination of `requirements.in` files from admin, API, and template preview and checked that the output looks right.
