### PR TITLE
Move requirements-parser to project dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 113.6.1
+
+* Adds `requirements-parser` dependency to project (fix for issue introduced in 113.6.0)
+
 ## 113.6.0
 
 * Adds `version_tools.show_outdated_requirements`. Consumers should add a make command like `python -c "from notifications_utils.version_tools import show_outdated_requirements; show_outdated_requirements()`

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "113.6.0"  # c06c738f1827b874ea08bb3b0759d97a
+__version__ = "113.6.1"  # 917ca711600d85ded61fb2f4d02e335b

--- a/notifications_utils/version_tools/requirements_for_test_common.in
+++ b/notifications_utils/version_tools/requirements_for_test_common.in
@@ -8,5 +8,3 @@ requests-mock
 freezegun
 
 ruff==0.15.2  # Also update `.pre-commit-config.yaml` if this changes
-
-requirements-parser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "smartypants>=2.0.1",
     "statsd>=4.0.1",
     "opentelemetry-api>=1.40.0",
+    "requirements-parser",
 ]
 
 [project.urls]

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -158,7 +158,7 @@ requests==2.32.5
 requests-mock==1.12.1
     # via -r requirements_for_test_common.in
 requirements-parser==0.13.0
-    # via -r requirements_for_test_common.in
+    # via notifications-utils (pyproject.toml)
 ruff==0.15.2
     # via -r requirements_for_test_common.in
 s3transfer==0.16.0


### PR DESCRIPTION
If we don’t do this then running `make bump-utils` in an app has a chicken/egg problem where it needs the dependency before it is installed.