### PR TITLE
Disable gunicorn control socket by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 113.6.2
+
+* Configure gunicorn with `control_socket_disable` as `True` by default
+
 ## 113.6.1
 
 * Adds `requirements-parser` dependency to project (fix for issue introduced in 113.6.0)

--- a/notifications_utils/gunicorn/defaults.py
+++ b/notifications_utils/gunicorn/defaults.py
@@ -42,6 +42,7 @@ def worker_abort(worker):
 def set_gunicorn_defaults(globals_dict: dict):
     globals_dict.update(
         bind=f"0.0.0.0:{os.getenv('PORT', '8080')}",
+        control_socket_disable=True,
         disable_redirect_access_to_syslog=True,
         logconfig_dict={
             **LOGGING_CONFIG_DEFAULTS,

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "113.6.1"  # 917ca711600d85ded61fb2f4d02e335b
+__version__ = "113.6.2"  # 32605023abe439b58fa1b7e95b1d29b1


### PR DESCRIPTION
Since upgrading `gunicorn` from 25.1.0 to 25.3.0, we get `Control server error: [Errno 13] Permission denied: '/home/notify'` errors when running template preview in production.

Volume of errors since deploy:
<img width="853" height="390" alt="image" src="https://github.com/user-attachments/assets/640859d0-be2a-427b-8a80-d89f66955f00" />

***

Version 25.1.0 introduced a [control socket](https://gunicorn.org/reference/settings/#control) that is enabled by default. The control socket allows runtime management of `gunicorn` via the `gunicornc` command-line tool. Commands include viewing worker status, adjusting worker count, and graceful reload/shutdown.

The control socket needs to create a file at `/home/vcap/.gunicorn/gunicorn.ctl`, which it does not have permission to do.

We don’t use this new feature, so we can disable it. Hopefully this will silence the errors.

Weird things I can’t account for:
-  the admin app – [running the same version of gunicorn](https://github.com/alphagov/notifications-admin/blob/f90a324720d80b5b7c708a6ed261d940cab9d124/requirements.txt#L66) – doesn’t exhibit these errors (probably the difference between [`application.py`](https://github.com/alphagov/notifications-admin/blob/d565035bc5a908efc5b06eeb2d3af5b3718ad4bd/application.py) in the admin app and [`wsgi.py`](https://github.com/alphagov/notifications-template-preview/blob/96d81d7e8a3e5b7fc1ab75c1f462a8b1f37ddeeb/wsgi.py) in template preview)
- ~~it was [bumping to 25.3.0](https://github.com/alphagov/notifications-template-preview/pull/968/changes#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552R102) which introduced the errors, not 25.1.0, which introduced the feature~~ solved

***

This is what I get if I run template preview locally with `./scripts/run_with_docker.sh "./entrypoint.sh web"`
```json
{"name": "gunicorn.error", "levelname": "INFO", "message": "Control socket listening at /home/vcap/.gunicorn/gunicorn.ctl", "pathname": "/opt/venv/lib/python3.13/site-packages/gunicorn/glogging.py", "lineno": 277, "time": "2026-04-28T12:53:59.955149", "requestId": null, "application": null, "service_id": null, "logType": "application"}
```

If I add `control_socket_disable = True` to `gunicorn_config.py` I do not see this line when starting the app.

If I checkout [b821f3d2](https://github.com/alphagov/notifications-template-preview/commit/b821f3d27fb18629db293021d8a22e2d5ba69b68) (previous `main`) I see this in the `message` field:
```
Control socket listening at /home/vcap/app/gunicorn.ctl
```

So the change introduced in 25.3.0 is 
```
Control socket listening at /home/vcap/.gunicorn/gunicorn.ctl
```

This is the result of https://github.com/benoitc/gunicorn/commit/0ad47db800b70a3745e104708334faafe746cafa, and why we are seeing these permission errors from 25.3.0 onwards.