### PR TITLE
 `SerialisedModelCollection`: implement `__iter__` using `get_model_instance_from_item`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 114.0.0
+
+* **Breaking change**: Make `SerialisedModelCollection` a proper `Iterable`. To achieve this, model instance construction from "item" dicts has been moved to a new dedicated method `_get_model_instance_from_item`. Subclasses that previously customised model instance construction by overriding `__getitem__` will need to be updated to move this to `_get_model_instance_from_item` (and as a result may be able to remove their custom `__getitem__` implementation.
+
 ## 113.6.2
 
 * Configure gunicorn with `control_socket_disable` as `True` by default

--- a/notifications_utils/serialised_model.py
+++ b/notifications_utils/serialised_model.py
@@ -57,14 +57,20 @@ class SerialisedModelCollection(ABC):
     def model(self):
         pass
 
+    def _get_model_instance_from_item(self, item):
+        return self.model(item)
+
     def __init__(self, items):
         self.items = items
+
+    def __iter__(self):
+        return (self._get_model_instance_from_item(item) for item in self.items)
 
     def __bool__(self):
         return bool(self.items)
 
     def __getitem__(self, index):
-        return self.model(self.items[index])
+        return self._get_model_instance_from_item(self.items[index])
 
     def __len__(self):
         return len(self.items)

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "113.6.2"  # 32605023abe439b58fa1b7e95b1d29b1
+__version__ = "114.0.0"  # e18050d71f9d4269a60d0eb51324c609

--- a/tests/test_serialised_model.py
+++ b/tests/test_serialised_model.py
@@ -220,6 +220,14 @@ def test_serialised_model_collection_returns_models_from_list():
         "baz",
     ]
 
+    # check this actually works as an Iterable, not just a sequence
+    item_iter = iter(instance)
+    assert next(item_iter).x == "foo"
+    assert next(item_iter).x == "bar"
+    assert next(item_iter).x == "baz"
+    with pytest.raises(StopIteration):
+        next(item_iter)
+
     assert [type(item) for item in instance + [1, 2, 3]] == [
         Custom,
         Custom,


### PR DESCRIPTION
If we want to be able to use e.g. admin's [`InterruptibleIterableMixin`](https://github.com/alphagov/notifications-admin/blob/d565035bc5a908efc5b06eeb2d3af5b3718ad4bd/app/utils/interruptible_io.py#L161) with a `SerialisedModelCollection`, it needs to be an actual `Iterable` (i.e. implement `__iter__`). Up till now iteration through a `SerialisedModelCollection` has only been working through python's sequence-based iteration which is less flexible.

This is a potentially breaking change, details of which are included in the changelog entry here.