### PR TITLE
Print correct date on templated letters in summer and winter 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 115.0.2
+
+* Make date printed on templated letters aware of British Summer Time
+
 ## 115.0.1
 
 * Don’t set `require-hashes` to `true` when running `uv pip install` etc.

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -587,7 +587,7 @@ class BaseLetterTemplate(SubjectMixin, Template):
         )
         self.admin_base_url = admin_base_url
         self.logo_file_name = logo_file_name
-        self.date = date or datetime.now(UTC)
+        self.date = date
         self.language = language
         if language == "english":
             self.content = template["content"]
@@ -662,11 +662,15 @@ class BaseLetterTemplate(SubjectMixin, Template):
         )
 
     @property
-    def _date(self):
-        month = self.date.strftime("%B")
+    def date(self):
+        month = self._date.strftime("%B")
         if self.language == "welsh":
             month = ENGLISH_TO_WELSH_MONTHS[month]
-        return self.date.strftime(f"%-d {month} %Y")
+        return self._date.strftime(f"%-d {month} %Y")
+
+    @date.setter
+    def date(self, value):
+        self._date = value or datetime.now(UTC)
 
     @property
     def _personalised_content(self) -> Field:
@@ -704,7 +708,7 @@ class LetterPreviewTemplate(BaseLetterTemplate):
             "message": self._message,
             "address": self._address_block,
             "contact_block": self._contact_block,
-            "date": self._date,
+            "date": self.date,
             "language": self.language,
             "includes_first_page": self.includes_first_page,
         }

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -48,6 +48,7 @@ from notifications_utils.qr_code import QrCodeTooLong
 from notifications_utils.recipient_validation.postal_address import PostalAddress, address_lines_1_to_7_keys
 from notifications_utils.sanitise_text import SanitiseSMS
 from notifications_utils.take import Take
+from notifications_utils.timezones import utc_string_to_aware_gmt_datetime
 
 template_env = Environment(
     loader=FileSystemLoader(
@@ -670,7 +671,7 @@ class BaseLetterTemplate(SubjectMixin, Template):
 
     @date.setter
     def date(self, value):
-        self._date = value or datetime.now(UTC)
+        self._date = utc_string_to_aware_gmt_datetime(value or datetime.now(UTC)).date()
 
     @property
     def _personalised_content(self) -> Field:

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -578,7 +578,7 @@ class BaseLetterTemplate(SubjectMixin, Template):
         admin_base_url="http://localhost:6012",
         logo_file_name=None,
         redact_missing_personalisation=False,
-        date=None,
+        date: datetime | None = None,
         language="english",
         includes_first_page: bool = True,
     ):
@@ -663,14 +663,14 @@ class BaseLetterTemplate(SubjectMixin, Template):
         )
 
     @property
-    def date(self):
+    def date(self) -> str:
         month = self._date.strftime("%B")
         if self.language == "welsh":
             month = ENGLISH_TO_WELSH_MONTHS[month]
         return self._date.strftime(f"%-d {month} %Y")
 
     @date.setter
-    def date(self, value):
+    def date(self, value: datetime | None):
         self._date = utc_string_to_aware_gmt_datetime(value or datetime.now(UTC)).date()
 
     @property

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "115.0.1"  # 58cc0aa5a1c8d35716fdac3d1dba0e6e
+__version__ = "115.0.2"  # f2d560a20d45360f54975baf30b519ff

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -738,7 +738,9 @@ def test_phone_templates_normalise_whitespace(template_class):
     [
         ({}, "12 December 2012"),
         ({"date": None}, "12 December 2012"),
-        ({"date": datetime.date.fromtimestamp(0)}, "1 January 1970"),
+        ({"date": datetime.datetime.fromtimestamp(0)}, "1 January 1970"),
+        ({"date": datetime.datetime(2026, 1, 6, 23, 1)}, "6 January 2026"),  # GMT
+        ({"date": datetime.datetime(2026, 5, 6, 23, 1)}, "7 May 2026"),  # British Summer Time
     ],
 )
 def test_letter_preview_renderer(


### PR DESCRIPTION
The previous code was not timezone-aware so always assumed UTC.