### PR TITLE
An idea to try and stop the notify tag ascii misconversion

### DIFF
--- a/notifications_utils/jinja_templates/letter_pdf/_print_only_add_tag_css.jinja2
+++ b/notifications_utils/jinja_templates/letter_pdf/_print_only_add_tag_css.jinja2
@@ -4,6 +4,9 @@
     @top-left-corner {
         content: 'NOTIFY';
         color: white;
+        font-variant: normal;
+        letter-spacing: 0px;
+        font-feature-settings: "liga" 0;
         font-family: 'arial';
         font-size: 6pt;
     }


### PR DESCRIPTION
In this incident https://docs.google.com/document/d/1mQP2pq2xKb8FQDKUOP0UZffSAPyOQoxUNXpXDO7MxCE/edit?tab=t.0

The Notify tag is being misconverted to 127,)<

This PR adds some CSS tags to avoid complex typography issues (it is just a guess).