### PR TITLE
`RedisClient`: use `HardEventletTimeout` as default `always_raise` exception, allow configuration of `socket_timeout` and `socket_connect_timeout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 115.4.0
+
+* `RedisClient`: allow configuration of `socket_timeout` and `socket_connect_timeout` parameters via flask config vars `REDIS_SOCKET_TIMEOUT` and `REDIS_SOCKET_CONNECT_TIMEOUT` respectively.
+* `RedisClient`: use `HardEventletTimeout` as default `always_raise` exception.
+
 ## 115.3.1
 
 * Fix easily-and-accidentally-exploited ReDoS vulnerabilities in `remove_whitespace_before_punctuation` and `replace_hyphens_with_en_dashes`.

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -56,8 +56,10 @@ class RedisClient:
 
     def init_app(self, app):
         self.active = app.config.get("REDIS_ENABLED")
+        socket_timeout = app.config.get("REDIS_SOCKET_TIMEOUT")
+        socket_connect_timeout = app.config.get("REDIS_SOCKET_CONNECT_TIMEOUT")
         if self.active:
-            self.redis_store.init_app(app)
+            self.redis_store.init_app(app, socket_timeout=socket_timeout, socket_connect_timeout=socket_connect_timeout)
 
             self.register_scripts()
 

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -16,7 +16,7 @@ from redis.exceptions import ReadOnlyError, ResponseError
 from redis.lock import Lock
 from redis.typing import Number
 
-from notifications_utils.eventlet import EventletTimeout
+from notifications_utils.eventlet import HardEventletTimeout
 
 
 def prepare_value(val):
@@ -52,7 +52,7 @@ class RedisClient:
     redis_store = FlaskRedis()
     active = False
     scripts = {}
-    always_raise: tuple[type[BaseException], ...] = (EventletTimeout,)
+    always_raise: tuple[type[BaseException], ...] = (HardEventletTimeout,)
 
     def init_app(self, app):
         self.active = app.config.get("REDIS_ENABLED")

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "115.3.1"  # 15b6d1720ecd46768fce966e17e3fb5f
+__version__ = "115.4.0"  # 6ce69d1dbb0748c7b352ed3affa94ef4


### PR DESCRIPTION
https://trello.com/c/PEpdGAPE/1518-implement-solution-for-failed-writes-deletes-to-redis

See individual commits for remarks, these are vaguely-related `RedisClient` changes that should both make our use of redis a bit more reliable during e.g. a failover.

Tested on multiple dev envs, this does indeed have some effect on our robustness during a failover.