### PR TITLE
Add the known email domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 115.2.0
+
+* Add file of known email domains and a function for checking the ending of an email address
+
 ## 115.1.0
 
 * `RedisClient`: detect "read-only" errors & drop idle connections. These errors are probably a sign of a failover event, and our connection pool probably has stale connections to the "wrong" redis instance.

--- a/notifications_utils/email_domains.txt
+++ b/notifications_utils/email_domains.txt
@@ -1,0 +1,12 @@
+gov.uk
+nhs.uk
+nhs.net
+nhs.scot
+police.uk
+cjsm.net
+sch.uk
+hscni.net
+llyw.cymru
+nhs.wales
+judiciary.uk
+kirkleeseducation.uk

--- a/notifications_utils/user.py
+++ b/notifications_utils/user.py
@@ -1,0 +1,16 @@
+import os
+
+with open(f"{os.path.dirname(os.path.realpath(__file__))}/email_domains.txt") as email_domains:
+    GOVERNMENT_EMAIL_DOMAIN_NAMES = [line.strip() for line in email_domains]
+
+
+def email_address_ends_with(email_address: str, known_domains: list[str]) -> bool:
+    return any(
+        email_address.lower().endswith(
+            (
+                f"@{known}",
+                f".{known}",
+            )
+        )
+        for known in known_domains
+    )

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "115.1.0"  # c0a9b1d1e92545f3acd4b31a56bca13a
+__version__ = "115.2.0"  # bb49babb42383a78ae81a0defb79a95d

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,0 +1,21 @@
+import pytest
+
+from notifications_utils.user import (
+    GOVERNMENT_EMAIL_DOMAIN_NAMES,
+    email_address_ends_with,
+)
+
+
+@pytest.mark.parametrize(
+    "email_address, expected_result",
+    [
+        ("example@gov.uk", True),
+        ("Example@GOV.uk", True),
+        ("Example@digital.GOV.uk", True),
+        ("Example@london.nhs.uk", True),
+        ("Example@nhs.wales", True),
+        ("user@example.com", False),
+    ],
+)
+def test_email_address_ends_with(email_address, expected_result):
+    assert email_address_ends_with(email_address, GOVERNMENT_EMAIL_DOMAIN_NAMES) is expected_result


### PR DESCRIPTION
We currently keep the list of known email domains (email domains that aren't linked to a particular org but that we allow to use Notify) [in admin](https://github.com/alphagov/notifications-admin/blob/5d3eccb540a67b636744872c13a37543ff9be0d1/app/utils/email_domains.txt), but we will need to start using these in the api too - we want to add checks about whether a user is a government user there too. 

This moves some of the list of email domains and a function that uses it here so that they can be used in multiple places.

[Trello card](https://trello.com/c/s1awvlJm/1779-error-for-removing-a-penultimate-user-with-manage-settings-permissions-public-sector-domains)