### PR TITLE
add `interruptible_io` module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 115.5.0
+
+Add `interruptible_io` moodule.
+
 ## 115.4.1
 
 Add `dir="auto"` attribute to sms_preview_template message wrapper

--- a/notifications_utils/interruptible_io.py
+++ b/notifications_utils/interruptible_io.py
@@ -1,0 +1,177 @@
+from collections.abc import Callable, Iterable, Iterator
+from functools import wraps
+from io import RawIOBase
+from itertools import repeat
+from time import sleep
+from zipfile import ZipFile
+
+
+def _allow_interruption(label: str) -> None:
+    """
+    Wrapping our `sleep(0)` calls in a wrapper makes them more instrumentable,
+    especially if a useful `label` is supplied. `sleep(0)` should yield to the
+    event loop on all greenthread libraries and at least release the GIL in
+    threading mode
+    """
+    sleep(0)
+
+
+class InterruptibleRawIOWrapper(RawIOBase):
+    """
+    A fileobj wrapper that will make itself "interruptible" by calling _allow_interruption
+    every time a reading or writing operation is performed, and will *attempt*
+    to reduce the size of reads performed to below the read_limit (and therefore
+    increase the frequency of read calls). The latter will of course not be
+    possible for e.g. .read(-1) calls which are expected to return everything
+    up to EOF in all cases.
+
+    This should allow a greenthread event loop to interrupt long processing
+    operations on this file, as long as the processing code is written in a
+    "memory efficient" way.
+    """
+
+    def __init__(self, wrapped, read_limit=4_096):
+        self._wrapped = wrapped
+        self._read_limit = read_limit
+
+    def close(self, *args, **kwargs):
+        return self._wrapped.close(*args, **kwargs)
+
+    @property
+    def closed(self):
+        return self._wrapped.closed
+
+    def fileno(self, *args, **kwargs):
+        return self._wrapped.fileno(*args, **kwargs)
+
+    def flush(self, *args, **kwargs):
+        return self._wrapped.flush(*args, **kwargs)
+
+    def isatty(self, *args, **kwargs):
+        return self._wrapped.isatty(*args, **kwargs)
+
+    def readable(self, *args, **kwargs):
+        return self._wrapped.readable(*args, **kwargs)
+
+    def readline(self, size=-1, /):
+        _allow_interruption(self.__class__.__name__)
+        if size >= 0:
+            size = min(self._read_limit, size)
+        return self._wrapped.readline(size)
+
+    def readlines(self, hint=-1, /):
+        _allow_interruption(self.__class__.__name__)
+        if hint >= 0:
+            hint = min(self._read_limit, hint)
+        return self._wrapped.readlines(hint)
+
+    def seek(self, *args, **kwargs):
+        return self._wrapped.seek(*args, **kwargs)
+
+    def seekable(self, *args, **kwargs):
+        return self._wrapped.seekable(*args, **kwargs)
+
+    def tell(self, *args, **kwargs):
+        return self._wrapped.tell(*args, **kwargs)
+
+    def truncate(self, *args, **kwargs):
+        return self._wrapped.truncate(*args, **kwargs)
+
+    def writable(self, *args, **kwargs):
+        return self._wrapped.writable(*args, **kwargs)
+
+    def writelines(self, *args, **kwargs):
+        _allow_interruption(self.__class__.__name__)
+        return self._wrapped.writelines(*args, **kwargs)
+
+    def __del__(self, *args, **kwargs):
+        return self._wrapped.__del__(*args, **kwargs)
+
+    def read(self, size=-1, /):
+        _allow_interruption(self.__class__.__name__)
+        if size >= 0:
+            size = min(self._read_limit, size)
+        return self._wrapped.read(size)
+
+    def readall(self, *args, **kwargs):
+        _allow_interruption(self.__class__.__name__)
+        return self._wrapped.readall(*args, **kwargs)
+
+    def readinto(self, *args, **kwargs):
+        _allow_interruption(self.__class__.__name__)
+        return self._wrapped.readinto(*args, **kwargs)
+
+    def write(self, *args, **kwargs):
+        _allow_interruption(self.__class__.__name__)
+        return self._wrapped.write(*args, **kwargs)
+
+
+class InterruptibleIOZipFile(ZipFile):
+    """
+    A ZipFile whose open method will return a InterruptibleRawIOWrapper-wrapped
+    fileobj
+    """
+
+    def open(self, *args, **kwargs) -> RawIOBase:
+        return InterruptibleRawIOWrapper(super().open(*args, **kwargs), read_limit=8_192)
+
+
+def interruptible_iter[T](
+    it: Iterable[T], interruptible_every: int, *, label: str = "interruptible_iter"
+) -> Iterable[T]:
+    """
+    Given an iterable `it`, will yield its contents, calling _allow_interruption before yielding each
+    `interruptible_every`'th iteration.
+    """
+    i = 0
+    for item in it:
+        if i >= interruptible_every:
+            _allow_interruption(label)
+            i = 0
+
+        yield item
+
+        i += 1
+
+
+class InterruptibleIterableMixin:
+    """
+    A mixin for an Iterable that will yield the GIL or greenthread every
+    INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY iterations when its iterator
+    is iterated through
+    """
+
+    INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY: int = 32
+    INTERRUPTIBLE_ITERABLE_LABEL_OVERRIDE: str | None = None
+
+    def __iter__(self) -> Iterator:
+        return interruptible_iter(
+            super().__iter__(),
+            self.INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY,
+            label=self.INTERRUPTIBLE_ITERABLE_LABEL_OVERRIDE or self.__class__.__name__,
+        )
+
+
+class InterruptibleIterableList(InterruptibleIterableMixin, list):
+    pass
+
+
+def interruptible_every[**A, R](
+    iterations: int, *, label: str = "interruptible_every"
+) -> Callable[[Callable[A, R]], Callable[A, R]]:
+    """
+    Returns a decorator that, applied to a function, will keep a global counter of invocations
+    and yield before every `iterations`'th call.
+    """
+
+    def interruptible_decorator(inner: Callable[A, R]) -> Callable[A, R]:
+        dummy_iterator = interruptible_iter(repeat(None), iterations, label=label)
+
+        @wraps(inner)
+        def interruptible_wrapper(*args, **kwargs):
+            next(dummy_iterator)
+            return inner(*args, **kwargs)
+
+        return interruptible_wrapper
+
+    return interruptible_decorator

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "115.4.1"  # 6c470fd6729ac22727068864002809ae
+__version__ = "115.5.0"  # 7f5c471842f84ec593bcfc812852f072

--- a/tests/test_interruptible_io.py
+++ b/tests/test_interruptible_io.py
@@ -1,0 +1,62 @@
+from itertools import count, islice
+
+import pytest
+
+from notifications_utils.interruptible_io import interruptible_every, interruptible_iter
+
+
+def test_interruptible_every(mocker):
+    mock_sleep = mocker.patch("notifications_utils.interruptible_io.sleep")
+
+    c = count()
+
+    @interruptible_every(3)
+    def my_func(a):
+        return a + next(c)
+
+    assert len(mock_sleep.mock_calls) == 0
+    assert my_func(5) == 5
+    assert len(mock_sleep.mock_calls) == 0
+    assert my_func(5) == 6
+    assert len(mock_sleep.mock_calls) == 0
+    assert my_func(5) == 7
+    assert len(mock_sleep.mock_calls) == 0
+    assert my_func(5) == 8
+    assert len(mock_sleep.mock_calls) == 1
+    assert my_func(5) == 9
+    assert len(mock_sleep.mock_calls) == 1
+    assert my_func(5) == 10
+    assert len(mock_sleep.mock_calls) == 1
+    assert my_func(5) == 11
+    assert len(mock_sleep.mock_calls) == 2
+    assert my_func(5) == 12
+    assert len(mock_sleep.mock_calls) == 2
+
+
+def test_interruptible_iter(mocker):
+    mock_sleep = mocker.patch("notifications_utils.interruptible_io.sleep")
+    i = interruptible_iter(islice(count(), 0, 9), 3)
+
+    assert next(i) == 0
+    assert len(mock_sleep.mock_calls) == 0
+    assert next(i) == 1
+    assert len(mock_sleep.mock_calls) == 0
+    assert next(i) == 2
+    assert len(mock_sleep.mock_calls) == 0
+    assert next(i) == 3
+    assert len(mock_sleep.mock_calls) == 1
+    assert next(i) == 4
+    assert len(mock_sleep.mock_calls) == 1
+    assert next(i) == 5
+    assert len(mock_sleep.mock_calls) == 1
+    assert next(i) == 6
+    assert len(mock_sleep.mock_calls) == 2
+    assert next(i) == 7
+    assert len(mock_sleep.mock_calls) == 2
+    assert next(i) == 8
+    assert len(mock_sleep.mock_calls) == 2
+
+    with pytest.raises(StopIteration):
+        next(i)
+
+    assert len(mock_sleep.mock_calls) == 2


### PR DESCRIPTION
Largely a copy from module of the same name in admin, with some renaming and a better implementation of `interruptible_every` reusing `interruptible_iter`.

This will allow us to use it in other places - initially -api.