### PR TITLE
Add `file_types.mime_type_from_extension`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 115.3.0
+
+Add `file_types.mime_type_from_extension`
+
 ## 115.2.0
 
 * Add file of known email domains and a function for checking the ending of an email address

--- a/notifications_utils/file_types.py
+++ b/notifications_utils/file_types.py
@@ -15,6 +15,7 @@ EXTENSIONS_MIMETYPES_AND_PRETTY_NAMES = (
 )
 EXTENSIONS = {ext for ext, _mime, _pretty in EXTENSIONS_MIMETYPES_AND_PRETTY_NAMES}
 MIME_TYPES_TO_EXTENSIONS = {mime: ext for ext, mime, _pretty in EXTENSIONS_MIMETYPES_AND_PRETTY_NAMES}
+EXTENSIONS_TO_MIME_TYPES = {ext: mime for ext, mime, _pretty in EXTENSIONS_MIMETYPES_AND_PRETTY_NAMES}
 
 
 def is_allowed_file_extension(extension):
@@ -27,6 +28,10 @@ def is_allowed_mime_type(mime_type):
 
 def extension_from_mime_type(mime_type):
     return MIME_TYPES_TO_EXTENSIONS[mime_type]
+
+
+def mime_type_from_extension(extension):
+    return EXTENSIONS_TO_MIME_TYPES[extension.lower()]
 
 
 def format_file_type(extension):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "115.2.0"  # bb49babb42383a78ae81a0defb79a95d
+__version__ = "115.3.0"  # cca982cff0b733574a58526414d0cdb5

--- a/tests/test_file_types.py
+++ b/tests/test_file_types.py
@@ -5,6 +5,7 @@ from notifications_utils.file_types import (
     format_file_type,
     is_allowed_file_extension,
     is_allowed_mime_type,
+    mime_type_from_extension,
 )
 
 
@@ -76,6 +77,29 @@ def test_is_allowed_mime_type(mime_type, allowed):
 )
 def test_extension_from_mime_type(mime_type, extension):
     assert extension_from_mime_type(mime_type) == extension
+
+
+@pytest.mark.parametrize(
+    "extension, mime_type",
+    (
+        ("pdf", "application/pdf"),
+        ("PDF", "application/pdf"),
+        ("csv", "text/csv"),
+        ("txt", "text/plain"),
+        ("json", "application/json"),
+        ("doc", "application/msword"),
+        ("docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+        ("xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+        ("odt", "application/vnd.oasis.opendocument.text"),
+        ("rtf", "application/rtf"),
+        ("jpg", "image/jpeg"),
+        ("jpeg", "image/jpeg"),
+        ("png", "image/png"),
+        pytest.param("exe", "application/octet-stream", marks=pytest.mark.xfail(raises=KeyError)),
+    ),
+)
+def test_mime_type_from_extension(extension, mime_type):
+    assert mime_type_from_extension(extension) == mime_type
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Python’s built in `mimetypes` module doesn’t have mappings for `docx`<sup>*</sup> by default. It can enable some extra extensions by calling `mimetypes.init()` but this is platform dependent.

There’s only a limited and known set of mime types we need to support. So that we consistently serve the right mime type for `.docx` files – both in the admin app and in document download API – let’s make our own mapping.

***

<sup>*</sup>It will from 3.14 onwards: https://github.com/python/cpython/commit/1cf9b6d9b8fbb5ebc3e9b42a3682684a983c78bc