### PR TITLE
`remove_whitespace_before_punctuation`: fix redos vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 115.3.1
+
+* Fix easily-and-accidentally-exploited ReDoS vulnerabilities in `remove_whitespace_before_punctuation` and `replace_hyphens_with_en_dashes`.
+
 ## 115.3.0
 
 Add `file_types.mime_type_from_extension`

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -31,7 +31,7 @@ govuk_not_a_link = re.compile(r"(^|\s)(#|\*|\^)?(GOV)\.(UK)(?!\/|\?|#)", re.IGNO
 
 smartypants.tags_to_skip = smartypants.tags_to_skip + ["a"]
 
-whitespace_before_punctuation = re.compile(r"[ \t]+([,\.])")
+whitespace_before_punctuation = re.compile(r"(?<![ \t])[ \t]+([,\.])")
 
 hyphens_surrounded_by_spaces = re.compile(r"\s+[-–—]{1,3}\s+")  # check three different unicode hyphens
 

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -33,7 +33,7 @@ smartypants.tags_to_skip = smartypants.tags_to_skip + ["a"]
 
 whitespace_before_punctuation = re.compile(r"(?<![ \t])[ \t]+([,\.])")
 
-hyphens_surrounded_by_spaces = re.compile(r"\s+[-–—]{1,3}\s+")  # check three different unicode hyphens
+hyphens_surrounded_by_spaces = re.compile(r"(?<!\s)\s+[-–—]{1,3}\s+")  # check three different unicode hyphens
 
 multiple_newlines = re.compile(r"((\n)\2{2,})")
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "115.3.0"  # cca982cff0b733574a58526414d0cdb5
+__version__ = "115.3.1"  # 15b6d1720ecd46768fce966e17e3fb5f

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -231,6 +231,7 @@ def test_escaping_html_entities(
             "\n   \t    , word",
             "\n, word",
         ),
+        ("        \t    , 123", ", 123"),
     ],
 )
 def test_removing_whitespace_before_commas(dirty, clean):
@@ -246,10 +247,17 @@ def test_removing_whitespace_before_commas(dirty, clean):
             "\n   \t    . word",
             "\n. word",
         ),
+        ("        \t    . 123", ". 123"),
     ],
 )
 def test_removing_whitespace_before_full_stops(dirty, clean):
     assert remove_whitespace_before_punctuation(dirty) == clean
+
+
+def test_remove_whitespace_before_punctuation_scalability():
+    # this test would never complete if remove_whitespace_before_punctuation
+    # were still vulnerable to such a ReDoS
+    remove_whitespace_before_punctuation("a" + (" " * 1_000_000) + "a")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -315,6 +315,10 @@ def test_smart_quotes(dumb, smart):
             "em – dash",
         ),
         (
+            " \t\n   — dash",
+            " – dash",
+        ),
+        (
             "already\u0020–\u0020correct",  # \u0020 is a normal space character
             "already\u0020–\u0020correct",
         ),
@@ -326,6 +330,10 @@ def test_smart_quotes(dumb, smart):
 )
 def test_en_dashes(nasty, nice):
     assert replace_hyphens_with_en_dashes(nasty) == nice
+
+
+def test_en_dashes_scalability():
+    replace_hyphens_with_en_dashes("a" + (" " * 1_000_000) + "a")
 
 
 def test_unicode_dash_lookup():


### PR DESCRIPTION
Without an anchor of some sort at the beginning of the pattern, the regex will start trying making a match at every e.g. space in a long string of spaces, and then likely fail to find a punctuation mark and start again at the next position in the
long space string. This is polynomial and becomes unmanageable around string lengths of ~10,000 (which can happen because of people leaning on space bars or mis-pasting things).

Adding a negative lookbehind at the beginning of the pattern will stop early any attempts to make a match at positions other than the first whitespace character.