### PR TITLE
Add dir attribute to sms view wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 115.4.1
+
+Add `dir="auto"` attribute to sms_preview_template message wrapper
+
 ## 115.4.0
 
 * `RedisClient`: allow configuration of `socket_timeout` and `socket_connect_timeout` parameters via flask config vars `REDIS_SOCKET_TIMEOUT` and `REDIS_SOCKET_CONNECT_TIMEOUT` respectively.

--- a/notifications_utils/jinja_templates/sms_preview_template.jinja2
+++ b/notifications_utils/jinja_templates/sms_preview_template.jinja2
@@ -8,6 +8,6 @@
     To: {{ recipient }}
   </p>
 {% endif %}
-<div class="sms-message-wrapper">
+<div class="sms-message-wrapper" dir="auto">
   {{ body }}
 </div>

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "115.4.0"  # 6ce69d1dbb0748c7b352ed3affa94ef4
+__version__ = "115.4.1"  # 6c470fd6729ac22727068864002809ae

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -2127,7 +2127,7 @@ def test_image_not_present_if_no_logo(template_class):
             SMSPreviewTemplate,
             (
                 "\n\n"
-                '<div class="sms-message-wrapper">\n'
+                '<div class="sms-message-wrapper" dir="auto">\n'
                 "  The quick brown fox.<br><br>Jumps over the lazy dog.<br>Single linebreak above.\n"
                 "</div>"
             ),


### PR DESCRIPTION
Adding `dir="auto"` attribute to `.sms-message-wrapper"`
Will be utilised by https://github.com/alphagov/notifications-admin/pull/5938