### PR TITLE
`RedisClient`: add `redis_flakey` mechanism to avoid repeated timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 120.1.0
+
+* `RedisClient`: add `redis_flakey` mechanism to avoid repeated timeouts
+
 ## 120.0.0
 
 * Removes `BaseLetterTemplate.too_many_pages` (subclasses which define `page_count` should implement this themselves)

--- a/notifications_utils/clients/redis/redis_client.py
+++ b/notifications_utils/clients/redis/redis_client.py
@@ -10,13 +10,14 @@ from typing import (  # noqa: UP035
     final,
 )
 
-from flask import current_app
+from flask import current_app, g, has_app_context
 from flask_redis import FlaskRedis
 from redis.exceptions import ReadOnlyError, ResponseError
+from redis.exceptions import TimeoutError as redis_TimeoutError
 from redis.lock import Lock
 from redis.typing import Number
 
-from notifications_utils.eventlet import HardEventletTimeout
+from notifications_utils.eventlet import HardEventletTimeout, SoftEventletTimeout
 
 
 def prepare_value(val):
@@ -53,6 +54,12 @@ class RedisClient:
     active = False
     scripts = {}
     always_raise: tuple[type[BaseException], ...] = (HardEventletTimeout,)
+    # default flakey_exceptions are those that will have already wasted valuable time, where we'd
+    # rather not waste any more time waiting for redis requests in this app context
+    flakey_exceptions: tuple[type[BaseException], ...] = (
+        SoftEventletTimeout,
+        redis_TimeoutError,
+    )
 
     def init_app(self, app):
         self.active = app.config.get("REDIS_ENABLED")
@@ -221,15 +228,35 @@ class RedisClient:
             return False
 
     def set(
-        self, key, value, ex=None, px=None, nx=False, xx=False, raise_exception=False, always_raise=INSTANCE_DEFAULT
+        self,
+        key,
+        value,
+        ex=None,
+        px=None,
+        nx=False,
+        xx=False,
+        raise_exception=False,
+        always_raise=INSTANCE_DEFAULT,
+        skippable=False,
     ):
+        redis_operation = "set"
         key = prepare_value(key)
         value = prepare_value(value)
+
+        if skippable and self.__is_flakey():
+            current_app.logger.warning(
+                "Not performing redis %s on %s because redis is possibly flakey",
+                redis_operation,
+                key,
+                extra={"redis_operation": redis_operation, "redis_key": key},
+            )
+            return
+
         if self.active:
             try:
                 self.redis_store.set(key, value, ex, px, nx, xx)
             except Exception as e:
-                self.__handle_exception(e, raise_exception, always_raise, "set", key)
+                self.__handle_exception(e, raise_exception, always_raise, redis_operation, key)
 
     def incr(self, key, raise_exception=False, always_raise=INSTANCE_DEFAULT):
         key = prepare_value(key)
@@ -246,13 +273,24 @@ class RedisClient:
             except Exception as e:
                 self.__handle_exception(e, raise_exception, always_raise, "decrby", key)
 
-    def get(self, key, raise_exception=False, always_raise=INSTANCE_DEFAULT):
+    def get(self, key, raise_exception=False, always_raise=INSTANCE_DEFAULT, skippable=True):
+        redis_operation = "get"
         key = prepare_value(key)
+
+        if skippable and self.__is_flakey():
+            current_app.logger.warning(
+                "Not performing redis %s on %s because redis is possibly flakey",
+                redis_operation,
+                key,
+                extra={"redis_operation": redis_operation, "redis_key": key},
+            )
+            return
+
         if self.active:
             try:
                 return self.redis_store.get(key)
             except Exception as e:
-                self.__handle_exception(e, raise_exception, always_raise, "get", key)
+                self.__handle_exception(e, raise_exception, always_raise, redis_operation, key)
 
         return None
 
@@ -269,6 +307,9 @@ class RedisClient:
             return Lock(self.redis_store, key_name, **kwargs)
         else:
             return StubLock(redis=None, name="")
+
+    def __is_flakey(self):
+        return has_app_context() and g.get("redis_flakey")
 
     def __handle_exception(
         self,
@@ -292,6 +333,10 @@ class RedisClient:
             # "right" instance.
             current_app.logger.warning("Reacting to %r by disconnecting redis connection pool's idle connections", e)
             self.redis_store.connection_pool.disconnect()
+
+        if isinstance(e, self.flakey_exceptions) and has_app_context():
+            current_app.logger.warning("Marking redis as flakey for remainder of app context")
+            g.redis_flakey = True
 
         if always_raise is INSTANCE_DEFAULT:
             always_raise = self.always_raise

--- a/notifications_utils/clients/redis/request_cache.py
+++ b/notifications_utils/clients/redis/request_cache.py
@@ -104,7 +104,7 @@ class RequestCache:
             @wraps(client_method)
             def new_client_method(*args, **kwargs):
                 redis_key = RequestCache._make_key(key_format, client_method, args, kwargs)
-                cached = self.redis_client.get(redis_key)
+                cached = self.redis_client.get(redis_key, skippable=True)
                 if cached:
                     return json.loads(cached.decode("utf-8"))
 
@@ -121,6 +121,8 @@ class RequestCache:
                         redis_key,
                         json.dumps(value),
                         ex=int(final_ttl),
+                        # client_method was (hopefully) side-effect free so this should not be an invalidation
+                        skippable=True,
                     )
 
                 return value

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "120.0.0"  # 08b7f88cb3fa3e1f43040857a7ea7791
+__version__ = "120.1.0"  # da1deafe23d042588e7116fd3a4b110b

--- a/tests/clients/redis/test_redis_client.py
+++ b/tests/clients/redis/test_redis_client.py
@@ -3,12 +3,13 @@ import logging
 import uuid
 from datetime import UTC, datetime
 from functools import partial
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 
 import pytest
 import redis
 from filelock import FileLock, Timeout
 from freezegun import freeze_time
+from redis.exceptions import TimeoutError as redis_TimeoutError
 
 from notifications_utils.clients.redis.redis_client import (
     RedisClient,
@@ -396,3 +397,32 @@ def test_decrby(mocked_redis_client):
     key = "hash-key"
     mocked_redis_client.decrby(key, 10)
     mocked_redis_client.redis_store.decrby.assert_called_with(key, 10)
+
+
+def test_redis_flakey(caplog, app, mocked_redis_client):
+    mocked_redis_client.redis_store.get.side_effect = redis_TimeoutError
+
+    with app.app_context():
+        assert mocked_redis_client.get("foo", raise_exception=False, skippable=True) is None
+        mocked_redis_client.redis_store.get.side_effect = None
+        mocked_redis_client.redis_store.get.return_value = "1234"
+
+        assert mocked_redis_client.get("bar", raise_exception=False, skippable=True) is None
+        assert mocked_redis_client.set("baz", "qux", raise_exception=False, skippable=True) is None
+
+        assert mocked_redis_client.get("blah", raise_exception=False, skippable=False) == "1234"
+        assert mocked_redis_client.set("blaz", "qlux", raise_exception=False, skippable=False) is None
+
+    assert mocked_redis_client.redis_store.get.mock_calls == [
+        call("foo"),
+        # note no "bar"
+        call("blah"),
+    ]
+    assert mocked_redis_client.redis_store.set.mock_calls == [
+        # note no "baz"
+        call("blaz", "qlux", None, None, False, False),
+    ]
+
+    assert "Marking redis as flakey for remainder of app context" in caplog.messages
+    assert "Not performing redis get on bar because redis is possibly flakey" in caplog.messages
+    assert "Not performing redis set on baz because redis is possibly flakey" in caplog.messages

--- a/tests/clients/redis/test_request_cache.py
+++ b/tests/clients/redis/test_request_cache.py
@@ -66,12 +66,16 @@ def test_set(
 
     assert foo(*args, **kwargs) == "bar"
 
-    mock_redis_get.assert_called_once_with(expected_cache_key)
+    mock_redis_get.assert_called_once_with(
+        expected_cache_key,
+        skippable=True,
+    )
 
     mock_redis_set.assert_called_once_with(
         expected_cache_key,
         '"bar"',
         ex=2_419_200,
+        skippable=True,
     )
 
 
@@ -111,6 +115,7 @@ def test_set_with_custom_ttl(
         "foo",
         '"bar"',
         ex=expected_redis_client_ttl,
+        skippable=True,
     )
 
 
@@ -196,7 +201,7 @@ def test_set_result_custom_get_decision(mocked_redis_client, cache, mocker):
 
     assert ret2 == 80.0
 
-    assert mock_redis_set.mock_calls == [mocker.call("8-xyz", "80.0", ex=160)]
+    assert mock_redis_set.mock_calls == [mocker.call("8-xyz", "80.0", ex=160, skippable=True)]
 
 
 @pytest.mark.parametrize(
@@ -227,7 +232,10 @@ def test_get(mocked_redis_client, cache, args, expected_cache_key, mocker):
 
     assert foo(*args) == "bar"
 
-    mock_redis_get.assert_called_once_with(expected_cache_key)
+    mock_redis_get.assert_called_once_with(
+        expected_cache_key,
+        skippable=True,
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
https://trello.com/c/PEpdGAPE/1518-implement-solution-for-failed-writes-deletes-to-redis

When connections to redis are timing out, though we can reduce the timeout wait, many requests will attempt to access redis on multiple occasions. in these cases it will end up waiting the timeout period each time. These can add up to make a request fail (e.g. run into an `EventletTimeout`) where it could otherwise have passed if it had got the hint that redis was in bad shape the first time it got a timeout.

This adds an app-context-local flag `redis_flakey` that will prevent repeated attempts at accessing redis for calls that
are deemed `skippable`. `skippable` means that the consequences of omitting the redis request are not catastrophic and won't cause a consistency problem (just slightly poorer performance).

Call sites can themselves set the `skippable` argument, but by default `get`s are considered skippable and `set`s aren't.

`RequestCache.set` overrides this to set `skippable=True` for its `RedisClient.set` calls because the inner `client_method` call *should* be side-effect-free - i.e. nothing has just happened that requires us to invalidate an existing cache entry.