### PR TITLE
Improve counting of fragments and characters in text message templates 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 116.0.0
+
+* Add `BaseSMSTemplate.count_of_characters_above_limit`
+* Add `BaseSMSTemplate.non_gsm_characters`
+* Add `BaseSMSTemplate.count_of_characters_above_previous_fragment_boundary`
+* Fix edge case where wrong fragment count would be shown with Welsh placeholder name
+* Removes `notifications_utils.template.get_sms_fragment_count` (not used outside this repo)
+* Removes `notifications_utils.template.non_gsm_characters` (not used outside this repo)
+* Removes `notifications_utils.template.count_extended_gsm_chars` (not used outside this repo)
+
 ## 115.4.1
 
 Add `dir="auto"` attribute to sms_preview_template message wrapper

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -254,6 +254,10 @@ class BaseSMSTemplate(Template):
         """
         return self.content_count_without_prefix > SMS_CHAR_COUNT_LIMIT
 
+    @property
+    def count_of_characters_above_limit(self):
+        return max(0, self.content_count_without_prefix - SMS_CHAR_COUNT_LIMIT)
+
     def is_message_empty(self):
         return self.content_count_without_prefix == 0
 

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -239,7 +239,7 @@ class BaseSMSTemplate(Template):
 
     @property
     def fragment_count(self):
-        content_with_placeholders = str(self)
+        content_with_placeholders = self._get_unsanitised_content()
 
         # Extended GSM characters count as 2 characters
         character_count = self.content_count + count_extended_gsm_chars(content_with_placeholders)
@@ -248,7 +248,7 @@ class BaseSMSTemplate(Template):
 
     @property
     def count_of_characters_above_previous_fragment_boundary(self):
-        content_with_placeholders = str(self)
+        content_with_placeholders = self._get_unsanitised_content()
         character_count = self.content_count + count_extended_gsm_chars(content_with_placeholders)
         boundary = get_sms_fragment_boundary(self.fragment_count, self.non_gsm_characters)
 
@@ -256,7 +256,7 @@ class BaseSMSTemplate(Template):
 
     @property
     def non_gsm_characters(self):
-        return non_gsm_characters(str(self))
+        return non_gsm_characters(self._get_unsanitised_content())
 
     def is_message_too_long(self):
         """

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -247,6 +247,14 @@ class BaseSMSTemplate(Template):
         return get_sms_fragment_count(character_count, non_gsm_characters(content_with_placeholders))
 
     @property
+    def count_of_characters_above_previous_fragment_boundary(self):
+        content_with_placeholders = str(self)
+        character_count = self.content_count + count_extended_gsm_chars(content_with_placeholders)
+        boundary = get_sms_fragment_boundary(self.fragment_count, self.non_gsm_characters)
+
+        return character_count - boundary
+
+    @property
     def non_gsm_characters(self):
         return non_gsm_characters(str(self))
 
@@ -764,6 +772,19 @@ def get_sms_fragment_count(character_count, non_gsm_characters):
         return 1 if character_count <= 70 else math.ceil(float(character_count) / 67)
     else:
         return 1 if character_count <= 160 else math.ceil(float(character_count) / 153)
+
+
+def get_sms_fragment_boundary(fragment_count, non_gsm_characters):
+    """
+    Returns the number of characters at which a message crosses into a given fragment count
+    """
+    if fragment_count == 1:
+        return 0
+
+    if fragment_count == 2:
+        return 70 if non_gsm_characters else 160
+
+    return (67 if non_gsm_characters else 153) * (fragment_count - 1)
 
 
 def non_gsm_characters(content):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -241,20 +241,34 @@ class BaseSMSTemplate(Template):
     @property
     def fragment_count(self):
         # Extended GSM characters count as 2 characters
-        character_count = self.content_count + count_extended_gsm_chars(self.unsanitised_content)
+        character_count = self.content_count + self.count_extended_gsm_chars
 
-        return get_sms_fragment_count(character_count, non_gsm_characters(self.unsanitised_content))
+        if self.non_gsm_characters:
+            return 1 if character_count <= 70 else math.ceil(float(character_count) / 67)
+
+        return 1 if character_count <= 160 else math.ceil(float(character_count) / 153)
 
     @property
     def count_of_characters_above_previous_fragment_boundary(self):
-        character_count = self.content_count + count_extended_gsm_chars(self.unsanitised_content)
-        boundary = get_sms_fragment_boundary(self.fragment_count, self.non_gsm_characters)
+        character_count = self.content_count + self.count_extended_gsm_chars
+
+        if self.fragment_count == 1:
+            boundary = 0
+        elif self.fragment_count == 2:
+            boundary = 70 if self.non_gsm_characters else 160
+        else:
+            boundary = (67 if self.non_gsm_characters else 153) * (self.fragment_count - 1)
 
         return character_count - boundary
 
     @property
     def non_gsm_characters(self):
-        return non_gsm_characters(self.unsanitised_content)
+        """
+        Returns a set of all the non gsm characters in a text. this doesn't include characters that we will
+        downgrade (eg emoji, ellipsis, ñ, etc). This only includes welsh non gsm characters that will force
+        the entire SMS to be encoded with UCS-2.
+        """
+        return OrderedSet(self.unsanitised_content) & SanitiseSMS.WELSH_NON_GSM_CHARACTERS
 
     def is_message_too_long(self):
         """
@@ -268,6 +282,10 @@ class BaseSMSTemplate(Template):
     @property
     def count_of_characters_above_limit(self):
         return max(0, self.content_count_without_prefix - SMS_CHAR_COUNT_LIMIT)
+
+    @property
+    def count_extended_gsm_chars(self):
+        return sum(map(self.unsanitised_content.count, SanitiseSMS.EXTENDED_GSM_CHARACTERS))
 
     def is_message_empty(self):
         return self.content_count_without_prefix == 0
@@ -764,39 +782,6 @@ class LetterPrintTemplate(LetterPreviewTemplate):
     @property
     def render_params(self):
         return super().render_params | {"includes_first_page": self.includes_first_page}
-
-
-def get_sms_fragment_count(character_count, non_gsm_characters):
-    if non_gsm_characters:
-        return 1 if character_count <= 70 else math.ceil(float(character_count) / 67)
-    else:
-        return 1 if character_count <= 160 else math.ceil(float(character_count) / 153)
-
-
-def get_sms_fragment_boundary(fragment_count, non_gsm_characters):
-    """
-    Returns the number of characters at which a message crosses into a given fragment count
-    """
-    if fragment_count == 1:
-        return 0
-
-    if fragment_count == 2:
-        return 70 if non_gsm_characters else 160
-
-    return (67 if non_gsm_characters else 153) * (fragment_count - 1)
-
-
-def non_gsm_characters(content):
-    """
-    Returns a set of all the non gsm characters in a text. this doesn't include characters that we will downgrade (eg
-    emoji, ellipsis, ñ, etc). This only includes welsh non gsm characters that will force the entire SMS to be encoded
-    with UCS-2.
-    """
-    return OrderedSet(content) & SanitiseSMS.WELSH_NON_GSM_CHARACTERS
-
-
-def count_extended_gsm_chars(content):
-    return sum(map(content.count, SanitiseSMS.EXTENDED_GSM_CHARACTERS))
 
 
 def do_nice_typography(value):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -245,6 +245,10 @@ class BaseSMSTemplate(Template):
 
         return get_sms_fragment_count(character_count, non_gsm_characters(content_with_placeholders))
 
+    @property
+    def non_gsm_characters(self):
+        return non_gsm_characters(str(self))
+
     def is_message_too_long(self):
         """
         Message is validated with out the prefix.

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from markupsafe import Markup
+from ordered_set import OrderedSet
 
 from notifications_utils import (
     ENGLISH_TO_WELSH_MONTHS,
@@ -771,7 +772,7 @@ def non_gsm_characters(content):
     emoji, ellipsis, ñ, etc). This only includes welsh non gsm characters that will force the entire SMS to be encoded
     with UCS-2.
     """
-    return set(content) & set(SanitiseSMS.WELSH_NON_GSM_CHARACTERS)
+    return OrderedSet(content) & SanitiseSMS.WELSH_NON_GSM_CHARACTERS
 
 
 def count_extended_gsm_chars(content):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -1,5 +1,6 @@
 import math
 from abc import ABC, abstractmethod
+from contextlib import suppress
 from datetime import UTC, datetime
 from functools import lru_cache
 from html import unescape
@@ -9,6 +10,7 @@ from typing import Literal
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from markupsafe import Markup
 from ordered_set import OrderedSet
+from werkzeug.utils import cached_property
 
 from notifications_utils import (
     ENGLISH_TO_WELSH_MONTHS,
@@ -175,8 +177,6 @@ class BaseSMSTemplate(Template):
         self.prefix = prefix
         self.show_prefix = show_prefix
         self.sender = sender
-        self._content_count = None
-        self._unsanitised_content = None
         super().__init__(template, values)
 
     @property
@@ -188,8 +188,10 @@ class BaseSMSTemplate(Template):
         # If we change the values of the template it’s possible the
         # content will have changed, so we need to reset the cached
         # count and content
-        self._content_count = None
-        self._unsanitised_content = None
+        with suppress(KeyError):  # Raised if value has not yet been cached
+            del self.content_count
+        with suppress(KeyError):  # Raised if value has not yet been cached
+            del self.unsanitised_content
 
         # Assigning to super().values doesn’t work here. We need to get
         # the property object instead, which has the special method
@@ -216,7 +218,7 @@ class BaseSMSTemplate(Template):
     def prefix(self, value):
         self._prefix = value
 
-    @property
+    @cached_property
     def content_count(self):
         """
         Return the number of characters in the message. Note that we don't distinguish between GSM and non-GSM
@@ -225,9 +227,7 @@ class BaseSMSTemplate(Template):
         Also note that if values aren't provided, will calculate the raw length of the unsubstituted placeholders,
         as in the message `foo ((placeholder))` has a length of 19.
         """
-        if self._content_count is None:
-            self._content_count = len(self.unsanitised_content)
-        return self._content_count
+        return len(self.unsanitised_content)
 
     @property
     def content_count_without_prefix(self):
@@ -272,25 +272,23 @@ class BaseSMSTemplate(Template):
     def is_message_empty(self):
         return self.content_count_without_prefix == 0
 
-    @property
+    @cached_property
     def unsanitised_content(self):
-        if self._unsanitised_content is None:
-            # This is faster to call than SMSMessageTemplate.__str__ if all
-            # you need to know is how many characters are in the message
-            if self.values:
-                values = self.values
-            else:
-                values = dict.fromkeys(self.placeholders, MAGIC_SEQUENCE)
-            self._unsanitised_content = (
-                Take(PlainTextField(self.content, values, html="passthrough"))
-                .then(add_prefix, self.prefix)
-                .then(remove_whitespace_before_punctuation)
-                .then(normalise_whitespace_and_newlines)
-                .then(normalise_multiple_newlines)
-                .then(str.strip)
-                .then(str.replace, MAGIC_SEQUENCE, "")
-            )
-        return self._unsanitised_content
+        # This is faster to call than SMSMessageTemplate.__str__ if all
+        # you need to know is how many characters are in the message
+        if self.values:
+            values = self.values
+        else:
+            values = dict.fromkeys(self.placeholders, MAGIC_SEQUENCE)
+        return (
+            Take(PlainTextField(self.content, values, html="passthrough"))
+            .then(add_prefix, self.prefix)
+            .then(remove_whitespace_before_punctuation)
+            .then(normalise_whitespace_and_newlines)
+            .then(normalise_multiple_newlines)
+            .then(str.strip)
+            .then(str.replace, MAGIC_SEQUENCE, "")
+        )
 
 
 class SMSMessageTemplate(BaseSMSTemplate):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -176,6 +176,7 @@ class BaseSMSTemplate(Template):
         self.show_prefix = show_prefix
         self.sender = sender
         self._content_count = None
+        self._unsanitised_content = None
         super().__init__(template, values)
 
     @property
@@ -185,10 +186,10 @@ class BaseSMSTemplate(Template):
     @values.setter
     def values(self, value):
         # If we change the values of the template it’s possible the
-        # content count will have changed, so we need to reset the
-        # cached count.
-        if self._content_count is not None:
-            self._content_count = None
+        # content will have changed, so we need to reset the cached
+        # count and content
+        self._content_count = None
+        self._unsanitised_content = None
 
         # Assigning to super().values doesn’t work here. We need to get
         # the property object instead, which has the special method
@@ -225,7 +226,7 @@ class BaseSMSTemplate(Template):
         as in the message `foo ((placeholder))` has a length of 19.
         """
         if self._content_count is None:
-            self._content_count = len(self._get_unsanitised_content())
+            self._content_count = len(self.unsanitised_content)
         return self._content_count
 
     @property
@@ -239,24 +240,21 @@ class BaseSMSTemplate(Template):
 
     @property
     def fragment_count(self):
-        content_with_placeholders = self._get_unsanitised_content()
-
         # Extended GSM characters count as 2 characters
-        character_count = self.content_count + count_extended_gsm_chars(content_with_placeholders)
+        character_count = self.content_count + count_extended_gsm_chars(self.unsanitised_content)
 
-        return get_sms_fragment_count(character_count, non_gsm_characters(content_with_placeholders))
+        return get_sms_fragment_count(character_count, non_gsm_characters(self.unsanitised_content))
 
     @property
     def count_of_characters_above_previous_fragment_boundary(self):
-        content_with_placeholders = self._get_unsanitised_content()
-        character_count = self.content_count + count_extended_gsm_chars(content_with_placeholders)
+        character_count = self.content_count + count_extended_gsm_chars(self.unsanitised_content)
         boundary = get_sms_fragment_boundary(self.fragment_count, self.non_gsm_characters)
 
         return character_count - boundary
 
     @property
     def non_gsm_characters(self):
-        return non_gsm_characters(self._get_unsanitised_content())
+        return non_gsm_characters(self.unsanitised_content)
 
     def is_message_too_long(self):
         """
@@ -274,27 +272,30 @@ class BaseSMSTemplate(Template):
     def is_message_empty(self):
         return self.content_count_without_prefix == 0
 
-    def _get_unsanitised_content(self):
-        # This is faster to call than SMSMessageTemplate.__str__ if all
-        # you need to know is how many characters are in the message
-        if self.values:
-            values = self.values
-        else:
-            values = dict.fromkeys(self.placeholders, MAGIC_SEQUENCE)
-        return (
-            Take(PlainTextField(self.content, values, html="passthrough"))
-            .then(add_prefix, self.prefix)
-            .then(remove_whitespace_before_punctuation)
-            .then(normalise_whitespace_and_newlines)
-            .then(normalise_multiple_newlines)
-            .then(str.strip)
-            .then(str.replace, MAGIC_SEQUENCE, "")
-        )
+    @property
+    def unsanitised_content(self):
+        if self._unsanitised_content is None:
+            # This is faster to call than SMSMessageTemplate.__str__ if all
+            # you need to know is how many characters are in the message
+            if self.values:
+                values = self.values
+            else:
+                values = dict.fromkeys(self.placeholders, MAGIC_SEQUENCE)
+            self._unsanitised_content = (
+                Take(PlainTextField(self.content, values, html="passthrough"))
+                .then(add_prefix, self.prefix)
+                .then(remove_whitespace_before_punctuation)
+                .then(normalise_whitespace_and_newlines)
+                .then(normalise_multiple_newlines)
+                .then(str.strip)
+                .then(str.replace, MAGIC_SEQUENCE, "")
+            )
+        return self._unsanitised_content
 
 
 class SMSMessageTemplate(BaseSMSTemplate):
     def __str__(self):
-        return sms_encode(self._get_unsanitised_content())
+        return sms_encode(self.unsanitised_content)
 
 
 class SMSBodyPreviewTemplate(BaseSMSTemplate):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "115.4.1"  # 6c470fd6729ac22727068864002809ae
+__version__ = "116.0.0"  # 4710b80de01e36186b85fbe3397b8d67

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1048,7 +1048,7 @@ def test_character_count_for_sms_templates(
 
 
 @pytest.mark.parametrize(
-    "msg, expected_sms_fragment_count, expected_count_of_characters_above_previous_fragment_boundary",
+    "template_content, expected_sms_fragment_count, expected_count_of_characters_above_previous_fragment_boundary",
     [
         ("à" * 71, 1, 71),  # welsh character in GSM
         ("à" * 160, 1, 160),
@@ -1083,11 +1083,11 @@ def test_character_count_for_sms_templates(
 )
 def test_sms_fragment_count_accounts_for_unicode_and_welsh_characters(
     template_class,
-    msg,
+    template_content,
     expected_sms_fragment_count,
     expected_count_of_characters_above_previous_fragment_boundary,
 ):
-    template = template_class({"content": msg, "template_type": "sms"})
+    template = template_class({"content": template_content, "template_type": "sms"})
     assert template.fragment_count == expected_sms_fragment_count
     assert template.count_of_characters_above_previous_fragment_boundary == (
         expected_count_of_characters_above_previous_fragment_boundary
@@ -1095,7 +1095,7 @@ def test_sms_fragment_count_accounts_for_unicode_and_welsh_characters(
 
 
 @pytest.mark.parametrize(
-    "msg, expected_sms_fragment_count, expected_count_of_characters_above_previous_fragment_boundary",
+    "template_content, expected_sms_fragment_count, expected_count_of_characters_above_previous_fragment_boundary",
     [
         # all extended GSM characters
         ("^" * 81, 2, 2),
@@ -1121,11 +1121,11 @@ def test_sms_fragment_count_accounts_for_unicode_and_welsh_characters(
 )
 def test_sms_fragment_count_accounts_for_extended_gsm_characters(
     template_class,
-    msg,
+    template_content,
     expected_sms_fragment_count,
     expected_count_of_characters_above_previous_fragment_boundary,
 ):
-    template = template_class({"content": msg, "template_type": "sms"})
+    template = template_class({"content": template_content, "template_type": "sms"})
     assert template.fragment_count == expected_sms_fragment_count
     assert template.count_of_characters_above_previous_fragment_boundary == (
         expected_count_of_characters_above_previous_fragment_boundary
@@ -1133,7 +1133,7 @@ def test_sms_fragment_count_accounts_for_extended_gsm_characters(
 
 
 @pytest.mark.parametrize(
-    "msg, expected_non_gsm_characters",
+    "template_content, expected_non_gsm_characters",
     [
         ("à", set()),  # Welsh character in GSM
         ("ÿ", {"ÿ"}),  # Welsh character not in GSM, so send as unicode
@@ -1153,13 +1153,13 @@ def test_sms_fragment_count_accounts_for_extended_gsm_characters(
 )
 def test_non_gsm_characters_in_sms(
     template_class,
-    msg,
+    template_content,
     expected_non_gsm_characters,
 ):
-    template = template_class({"content": msg, "template_type": "sms"})
+    template = template_class({"content": template_content, "template_type": "sms"})
     assert template.non_gsm_characters == expected_non_gsm_characters
 
-    template = template_class({"content": "GSM-7 only", "template_type": "sms"}, prefix=msg)
+    template = template_class({"content": "GSM-7 only", "template_type": "sms"}, prefix=template_content)
     assert template.non_gsm_characters == expected_non_gsm_characters
 
 
@@ -1813,11 +1813,13 @@ def test_lists_in_combination_with_other_elements_in_letters(markdown, expected)
     ),
 )
 def test_message_too_long_ignoring_prefix(template_class, repeat_character_count, expected_count_above_limit):
-    body = ("b" * repeat_character_count) + "((foo))"
+    template_content = ("b" * repeat_character_count) + "((foo))"
     template = template_class(
-        {"content": body, "template_type": template_class.template_type}, prefix="a" * 100, values={"foo": "cc"}
+        {"content": template_content, "template_type": template_class.template_type},
+        prefix="a" * 100,
+        values={"foo": "cc"},
     )
-    # content length is repeated characters plus personalisation (more than limit of 918)
+    # content length is length of template_content plus personalisation (more than limit of 918)
     assert template.is_message_too_long() is True
     assert template.count_of_characters_above_limit == expected_count_above_limit
 

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1048,29 +1048,30 @@ def test_character_count_for_sms_templates(
 
 
 @pytest.mark.parametrize(
-    "msg, expected_sms_fragment_count",
+    "msg, expected_sms_fragment_count, expected_count_of_characters_above_previous_fragment_boundary",
     [
-        ("à" * 71, 1),  # welsh character in GSM
-        ("à" * 160, 1),
-        ("à" * 161, 2),
-        ("à" * 306, 2),
-        ("à" * 307, 3),
-        ("à" * 612, 4),
-        ("à" * 613, 5),
-        ("à" * 765, 5),
-        ("à" * 766, 6),
-        ("à" * 918, 6),
-        ("à" * 919, 7),
-        ("ÿ" * 70, 1),  # welsh character not in GSM, so send as unicode
-        ("ÿ" * 71, 2),
-        ("ÿ" * 134, 2),
-        ("ÿ" * 135, 3),
-        ("ÿ" * 268, 4),
-        ("ÿ" * 269, 5),
-        ("ÿ" * 402, 6),
-        ("ÿ" * 403, 7),
-        ("à" * 70 + "ÿ", 2),  # just one non-gsm character means it's sent at unicode
-        ("🚀" * 160, 1),  # non-welsh unicode characters are downgraded to gsm, so are only one fragment long
+        ("à" * 71, 1, 71),  # welsh character in GSM
+        ("à" * 160, 1, 160),
+        ("à" * 161, 2, 1),
+        ("à" * 306, 2, 146),
+        ("à" * 307, 3, 1),
+        ("à" * 612, 4, 153),
+        ("à" * 613, 5, 1),
+        ("à" * 765, 5, 153),
+        ("à" * 766, 6, 1),
+        ("à" * 918, 6, 153),
+        ("à" * 919, 7, 1),
+        ("ÿ" * 70, 1, 70),  # welsh character not in GSM, so send as unicode
+        ("ÿ" * 71, 2, 1),
+        ("ÿ" * 134, 2, 64),
+        ("ÿ" * 135, 3, 1),
+        ("ÿ" * 268, 4, 67),
+        ("ÿ" * 269, 5, 1),
+        ("ÿ" * 402, 6, 67),
+        ("ÿ" * 403, 7, 1),
+        ("à" * 70 + "ÿ", 2, 1),  # just one non-gsm character means it's sent at unicode
+        ("🚀" * 160, 1, 160),  # non-welsh unicode characters are downgraded to gsm, so are only one fragment long
+        ("🚀" * 161, 2, 1),
     ],
 )
 @pytest.mark.parametrize(
@@ -1084,24 +1085,28 @@ def test_sms_fragment_count_accounts_for_unicode_and_welsh_characters(
     template_class,
     msg,
     expected_sms_fragment_count,
+    expected_count_of_characters_above_previous_fragment_boundary,
 ):
     template = template_class({"content": msg, "template_type": "sms"})
     assert template.fragment_count == expected_sms_fragment_count
+    assert template.count_of_characters_above_previous_fragment_boundary == (
+        expected_count_of_characters_above_previous_fragment_boundary
+    )
 
 
 @pytest.mark.parametrize(
-    "msg, expected_sms_fragment_count",
+    "msg, expected_sms_fragment_count, expected_count_of_characters_above_previous_fragment_boundary",
     [
         # all extended GSM characters
-        ("^" * 81, 2),
+        ("^" * 81, 2, 2),
         # GSM characters plus extended GSM
-        ("a" * 158 + "|", 1),
-        ("a" * 159 + "|", 2),
-        ("a" * 304 + "[", 2),
-        ("a" * 304 + "[]", 3),
+        ("a" * 158 + "|", 1, 160),
+        ("a" * 159 + "|", 2, 1),
+        ("a" * 304 + "[", 2, 146),
+        ("a" * 304 + "[]", 3, 2),
         # Welsh character plus extended GSM
-        ("â" * 132 + "{", 2),
-        ("â" * 133 + "}", 3),
+        ("â" * 132 + "{", 2, 64),
+        ("â" * 133 + "}", 3, 1),
     ],
 )
 @pytest.mark.parametrize(
@@ -1115,9 +1120,13 @@ def test_sms_fragment_count_accounts_for_extended_gsm_characters(
     template_class,
     msg,
     expected_sms_fragment_count,
+    expected_count_of_characters_above_previous_fragment_boundary,
 ):
     template = template_class({"content": msg, "template_type": "sms"})
     assert template.fragment_count == expected_sms_fragment_count
+    assert template.count_of_characters_above_previous_fragment_boundary == (
+        expected_count_of_characters_above_previous_fragment_boundary
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1107,6 +1107,9 @@ def test_sms_fragment_count_accounts_for_unicode_and_welsh_characters(
         # Welsh character plus extended GSM
         ("â" * 132 + "{", 2, 64),
         ("â" * 133 + "}", 3, 1),
+        # Non-GSM or extended characters in placeholder, not content
+        ("a" * 160 + "(( placeholder with â ))", 1, 160),
+        ("a" * 160 + "(( placeholder with | ))", 1, 160),
     ],
 )
 @pytest.mark.parametrize(
@@ -1158,6 +1161,20 @@ def test_non_gsm_characters_in_sms(
 
     template = template_class({"content": "GSM-7 only", "template_type": "sms"}, prefix=msg)
     assert template.non_gsm_characters == expected_non_gsm_characters
+
+
+@pytest.mark.parametrize(
+    "template_class",
+    (
+        SMSMessageTemplate,
+        SMSPreviewTemplate,
+    ),
+)
+def test_non_gsm_characters_in_placeholder(
+    template_class,
+):
+    template = template_class({"content": "((ÿ🚀))", "template_type": "sms"})
+    assert template.non_gsm_characters == set()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1732,13 +1732,21 @@ def test_lists_in_combination_with_other_elements_in_letters(markdown, expected)
         SMSPreviewTemplate,
     ],
 )
-def test_message_too_long_ignoring_prefix(template_class):
-    body = ("b" * 917) + "((foo))"
+@pytest.mark.parametrize(
+    "repeat_character_count, expected_count_above_limit",
+    (
+        (917, 1),
+        (1_000, 84),
+    ),
+)
+def test_message_too_long_ignoring_prefix(template_class, repeat_character_count, expected_count_above_limit):
+    body = ("b" * repeat_character_count) + "((foo))"
     template = template_class(
         {"content": body, "template_type": template_class.template_type}, prefix="a" * 100, values={"foo": "cc"}
     )
-    # content length is prefix + 919 characters (more than limit of 918)
+    # content length is repeated characters plus personalisation (more than limit of 918)
     assert template.is_message_too_long() is True
+    assert template.count_of_characters_above_limit == expected_count_above_limit
 
 
 @pytest.mark.parametrize(
@@ -1748,15 +1756,23 @@ def test_message_too_long_ignoring_prefix(template_class):
         SMSPreviewTemplate,
     ],
 )
-def test_message_is_not_too_long_ignoring_prefix(template_class):
-    body = ("b" * 917) + "((foo))"
+@pytest.mark.parametrize(
+    "repeat_character_count",
+    (
+        1,
+        917,
+    ),
+)
+def test_message_is_not_too_long_ignoring_prefix(template_class, repeat_character_count):
+    body = ("b" * repeat_character_count) + "((foo))"
     template = template_class(
         {"content": body, "template_type": template_class.template_type},
         prefix="a" * 100,
         values={"foo": "c"},
     )
-    # content length is prefix + 918 characters (not more than limit of 918)
+    # content length (ignoring prefix) is up to 918 characters (not more than limit of 918)
     assert template.is_message_too_long() is False
+    assert template.count_of_characters_above_limit == 0
 
 
 @pytest.mark.parametrize(
@@ -1771,6 +1787,8 @@ def test_message_too_long_limit_bigger_or_nonexistent_for_non_sms_templates(temp
     body = "a" * 1000
     template = template_class({"content": body, "subject": "foo", "template_type": template_type}, **kwargs)
     assert template.is_message_too_long() is False
+    with pytest.raises(AttributeError):
+        assert template.count_of_characters_above_limit
 
 
 @pytest.mark.parametrize(

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1105,6 +1105,28 @@ def test_sms_fragment_count_accounts_for_extended_gsm_characters(
 
 
 @pytest.mark.parametrize(
+    "msg, expected_non_gsm_characters",
+    [
+        ("à", set()),  # Welsh character in GSM
+        ("ÿ", {"ÿ"}),  # Welsh character not in GSM, so send as unicode
+        ("ÿŴ", {"ÿ", "Ŵ"}),  # Each character only returned once
+        ("àÿ", {"ÿ"}),  # Only non-GSM characters returned
+        ("🚀", set()),  # emoji downgraded to ?, which is in GSM
+        ("…", set()),  # HORIZONTAL ELLIPSIS (U+2026) downgraded to ..., which is 3 GSM characters
+    ],
+)
+def test_non_gsm_characters_in_sms(
+    msg,
+    expected_non_gsm_characters,
+):
+    template = SMSMessageTemplate({"content": msg, "template_type": "sms"})
+    assert template.non_gsm_characters == expected_non_gsm_characters
+
+    template = SMSMessageTemplate({"content": "GSM-7 only", "template_type": "sms"}, prefix=msg)
+    assert template.non_gsm_characters == expected_non_gsm_characters
+
+
+@pytest.mark.parametrize(
     "template_class",
     [
         SMSMessageTemplate,

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1073,11 +1073,19 @@ def test_character_count_for_sms_templates(
         ("🚀" * 160, 1),  # non-welsh unicode characters are downgraded to gsm, so are only one fragment long
     ],
 )
+@pytest.mark.parametrize(
+    "template_class",
+    (
+        SMSMessageTemplate,
+        SMSPreviewTemplate,
+    ),
+)
 def test_sms_fragment_count_accounts_for_unicode_and_welsh_characters(
+    template_class,
     msg,
     expected_sms_fragment_count,
 ):
-    template = SMSMessageTemplate({"content": msg, "template_type": "sms"})
+    template = template_class({"content": msg, "template_type": "sms"})
     assert template.fragment_count == expected_sms_fragment_count
 
 
@@ -1096,11 +1104,19 @@ def test_sms_fragment_count_accounts_for_unicode_and_welsh_characters(
         ("â" * 133 + "}", 3),
     ],
 )
+@pytest.mark.parametrize(
+    "template_class",
+    (
+        SMSMessageTemplate,
+        SMSPreviewTemplate,
+    ),
+)
 def test_sms_fragment_count_accounts_for_extended_gsm_characters(
+    template_class,
     msg,
     expected_sms_fragment_count,
 ):
-    template = SMSMessageTemplate({"content": msg, "template_type": "sms"})
+    template = template_class({"content": msg, "template_type": "sms"})
     assert template.fragment_count == expected_sms_fragment_count
 
 
@@ -1116,14 +1132,22 @@ def test_sms_fragment_count_accounts_for_extended_gsm_characters(
         ("ŸẄÜÖÏËÄ", OrderedSet("ŸẄÏË")),  # Content order is preserved
     ],
 )
+@pytest.mark.parametrize(
+    "template_class",
+    (
+        SMSMessageTemplate,
+        SMSPreviewTemplate,
+    ),
+)
 def test_non_gsm_characters_in_sms(
+    template_class,
     msg,
     expected_non_gsm_characters,
 ):
-    template = SMSMessageTemplate({"content": msg, "template_type": "sms"})
+    template = template_class({"content": msg, "template_type": "sms"})
     assert template.non_gsm_characters == expected_non_gsm_characters
 
-    template = SMSMessageTemplate({"content": "GSM-7 only", "template_type": "sms"}, prefix=msg)
+    template = template_class({"content": "GSM-7 only", "template_type": "sms"}, prefix=msg)
     assert template.non_gsm_characters == expected_non_gsm_characters
 
 

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1113,6 +1113,7 @@ def test_sms_fragment_count_accounts_for_extended_gsm_characters(
         ("àÿ", {"ÿ"}),  # Only non-GSM characters returned
         ("🚀", set()),  # emoji downgraded to ?, which is in GSM
         ("…", set()),  # HORIZONTAL ELLIPSIS (U+2026) downgraded to ..., which is 3 GSM characters
+        ("ŸẄÜÖÏËÄ", OrderedSet("ŸẄÏË")),  # Content order is preserved
     ],
 )
 def test_non_gsm_characters_in_sms(


### PR DESCRIPTION
# Add some useful extra properties to `BaseSMSTemplate`

## `count_of_characters_above_limit`

This is a useful property which can replace the mid-string-interpolation maths done here in the admin app:
https://github.com/alphagov/notifications-admin/blob/0b04123230f9586dc9e2ceecfac6b2df7812d39a/app/main/views/templates.py#L855

## `non_gsm_characters`

This is a useful property which returns the exact characters causing the message to not be sent as GSM-7, and therefore costing more.

## `count_of_characters_above_previous_fragment_boundary`
    
This is a useful property which we can use to tell users how many characters they need to remove to guarantee their message will be cheaper to send.

# Refactor helper functions into properties of `BaseSMSTemplate`

This makes it harder to introduce bugs where the wrong content or flags are given to these functions, because they are always looking at properties of the current instance, rather than arguments which could be any arbitrary value.

This means removing the following functions from `notifications_utils.template`:
- `get_sms_fragment_count`
- `non_gsm_characters`
- `count_extended_gsm_chars`

None of these functions were not imported by any of our apps. The corresponding properties on `BaseSMSTemplate` existed already.

# Ignore names of placeholders when determining non-GSM characters

Names of placeholders won’t end up in the final message – they will be replaced.

We shouldn’t include them when checking for:
- non-GSM characters which cause the message to change encoding
- extended GSM characters

Otherwise we could wrongly tell the user that their message will be charged as more fragments that is true.

## Before 

<img width="578" height="263" alt="image" src="https://github.com/user-attachments/assets/0818883f-0b67-401e-81bd-aa4a9fdd5fe7" />

## After 

<img width="573" height="256" alt="image" src="https://github.com/user-attachments/assets/5745b0d0-eeb6-40c2-aa5b-f7234f64ddc1" />

