### PR TITLE
`RecipientCSV`: use `InterruptibleIterableList` for cached `rows` property 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 116.1.0
+
+* Add `interruptible_io` moodule.
+* `RecipientCSV`: use `InterruptibleIterableList` for cached rows property
+
 ## 116.0.0
 
 * Add `BaseSMSTemplate.count_of_characters_above_limit`

--- a/notifications_utils/interruptible_io.py
+++ b/notifications_utils/interruptible_io.py
@@ -1,0 +1,177 @@
+from collections.abc import Callable, Iterable, Iterator
+from functools import wraps
+from io import RawIOBase
+from itertools import repeat
+from time import sleep
+from zipfile import ZipFile
+
+
+def _allow_interruption(label: str) -> None:
+    """
+    Wrapping our `sleep(0)` calls in a wrapper makes them more instrumentable,
+    especially if a useful `label` is supplied. `sleep(0)` should yield to the
+    event loop on all greenthread libraries and at least release the GIL in
+    threading mode
+    """
+    sleep(0)
+
+
+class InterruptibleRawIOWrapper(RawIOBase):
+    """
+    A fileobj wrapper that will make itself "interruptible" by calling _allow_interruption
+    every time a reading or writing operation is performed, and will *attempt*
+    to reduce the size of reads performed to below the read_limit (and therefore
+    increase the frequency of read calls). The latter will of course not be
+    possible for e.g. .read(-1) calls which are expected to return everything
+    up to EOF in all cases.
+
+    This should allow a greenthread event loop to interrupt long processing
+    operations on this file, as long as the processing code is written in a
+    "memory efficient" way.
+    """
+
+    def __init__(self, wrapped, read_limit=4_096):
+        self._wrapped = wrapped
+        self._read_limit = read_limit
+
+    def close(self, *args, **kwargs):
+        return self._wrapped.close(*args, **kwargs)
+
+    @property
+    def closed(self):
+        return self._wrapped.closed
+
+    def fileno(self, *args, **kwargs):
+        return self._wrapped.fileno(*args, **kwargs)
+
+    def flush(self, *args, **kwargs):
+        return self._wrapped.flush(*args, **kwargs)
+
+    def isatty(self, *args, **kwargs):
+        return self._wrapped.isatty(*args, **kwargs)
+
+    def readable(self, *args, **kwargs):
+        return self._wrapped.readable(*args, **kwargs)
+
+    def readline(self, size=-1, /):
+        _allow_interruption(self.__class__.__name__)
+        if size >= 0:
+            size = min(self._read_limit, size)
+        return self._wrapped.readline(size)
+
+    def readlines(self, hint=-1, /):
+        _allow_interruption(self.__class__.__name__)
+        if hint >= 0:
+            hint = min(self._read_limit, hint)
+        return self._wrapped.readlines(hint)
+
+    def seek(self, *args, **kwargs):
+        return self._wrapped.seek(*args, **kwargs)
+
+    def seekable(self, *args, **kwargs):
+        return self._wrapped.seekable(*args, **kwargs)
+
+    def tell(self, *args, **kwargs):
+        return self._wrapped.tell(*args, **kwargs)
+
+    def truncate(self, *args, **kwargs):
+        return self._wrapped.truncate(*args, **kwargs)
+
+    def writable(self, *args, **kwargs):
+        return self._wrapped.writable(*args, **kwargs)
+
+    def writelines(self, *args, **kwargs):
+        _allow_interruption(self.__class__.__name__)
+        return self._wrapped.writelines(*args, **kwargs)
+
+    def __del__(self, *args, **kwargs):
+        return self._wrapped.__del__(*args, **kwargs)
+
+    def read(self, size=-1, /):
+        _allow_interruption(self.__class__.__name__)
+        if size >= 0:
+            size = min(self._read_limit, size)
+        return self._wrapped.read(size)
+
+    def readall(self, *args, **kwargs):
+        _allow_interruption(self.__class__.__name__)
+        return self._wrapped.readall(*args, **kwargs)
+
+    def readinto(self, *args, **kwargs):
+        _allow_interruption(self.__class__.__name__)
+        return self._wrapped.readinto(*args, **kwargs)
+
+    def write(self, *args, **kwargs):
+        _allow_interruption(self.__class__.__name__)
+        return self._wrapped.write(*args, **kwargs)
+
+
+class InterruptibleIOZipFile(ZipFile):
+    """
+    A ZipFile whose open method will return a InterruptibleRawIOWrapper-wrapped
+    fileobj
+    """
+
+    def open(self, *args, **kwargs) -> RawIOBase:
+        return InterruptibleRawIOWrapper(super().open(*args, **kwargs), read_limit=8_192)
+
+
+def interruptible_iter[T](
+    it: Iterable[T], interruptible_every: int, *, label: str = "interruptible_iter"
+) -> Iterable[T]:
+    """
+    Given an iterable `it`, will yield its contents, calling _allow_interruption before yielding each
+    `interruptible_every`'th iteration.
+    """
+    i = 0
+    for item in it:
+        if i >= interruptible_every:
+            _allow_interruption(label)
+            i = 0
+
+        yield item
+
+        i += 1
+
+
+class InterruptibleIterableMixin:
+    """
+    A mixin for an Iterable that will yield the GIL or greenthread every
+    INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY iterations when its iterator
+    is iterated through
+    """
+
+    INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY: int = 32
+    INTERRUPTIBLE_ITERABLE_LABEL_OVERRIDE: str | None = None
+
+    def __iter__(self) -> Iterator:
+        return interruptible_iter(
+            super().__iter__(),
+            self.INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY,
+            label=self.INTERRUPTIBLE_ITERABLE_LABEL_OVERRIDE or self.__class__.__name__,
+        )
+
+
+class InterruptibleIterableList(InterruptibleIterableMixin, list):
+    pass
+
+
+def interruptible_every[**A, R](
+    iterations: int, *, label: str = "interruptible_every"
+) -> Callable[[Callable[A, R]], Callable[A, R]]:
+    """
+    Returns a decorator that, applied to a function, will keep a global counter of invocations
+    and yield before every `iterations`'th call.
+    """
+
+    def interruptible_decorator(inner: Callable[A, R]) -> Callable[A, R]:
+        dummy_iterator = interruptible_iter(repeat(None), iterations, label=label)
+
+        @wraps(inner)
+        def interruptible_wrapper(*args, **kwargs):
+            next(dummy_iterator)
+            return inner(*args, **kwargs)
+
+        return interruptible_wrapper
+
+    return interruptible_decorator

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -4,7 +4,6 @@ from contextlib import suppress
 from functools import lru_cache
 from io import StringIO
 from itertools import islice
-from time import sleep
 from typing import cast
 
 from ordered_set import OrderedSet
@@ -15,6 +14,7 @@ from notifications_utils.formatters import (
     strip_and_remove_obscure_whitespace,
 )
 from notifications_utils.insensitive_dict import InsensitiveDict
+from notifications_utils.interruptible_io import InterruptibleIterableList, interruptible_iter
 from notifications_utils.recipient_validation import email_address
 from notifications_utils.recipient_validation.errors import InvalidEmailError, InvalidPhoneError, InvalidRecipientError
 from notifications_utils.recipient_validation.phone_number import PhoneNumber
@@ -39,6 +39,9 @@ address_columns = InsensitiveDict.from_keys(first_column_headings["letter"])
 class RecipientCSV:
     max_rows = 100_000
     get_rows_loop_interruptible_every = 128
+    # we're less certain a significant amount of work is going to be done on each iteration
+    # through the resultant row list
+    rows_list_iteration_interruptible_every = 512
 
     def __init__(
         self,
@@ -156,7 +159,8 @@ class RecipientCSV:
     @property
     def rows(self):
         if self.rows_as_list is None:
-            self.rows_as_list = list(self.get_rows())
+            self.rows_as_list = InterruptibleIterableList(self.get_rows())
+            self.rows_as_list.INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY = self.rows_list_iteration_interruptible_every
         return self.rows_as_list
 
     @property
@@ -187,15 +191,16 @@ class RecipientCSV:
 
         next(rows_as_lists_of_columns, None)  # skip the header row
 
-        for index, row in enumerate(rows_as_lists_of_columns):
+        for index, row in enumerate(
+            interruptible_iter(
+                rows_as_lists_of_columns,
+                self.get_rows_loop_interruptible_every,
+                label=f"{self.__class__.__name__}.get_rows",
+            )
+        ):
             if index >= self.max_rows:
                 yield None
                 continue
-
-            if not (index + 1) % self.get_rows_loop_interruptible_every:
-                # all green thread libraries will monkeypatch this to yield to the event loop
-                # and the real implementation should at least drop the GIL
-                sleep(0)
 
             output_dict = {}
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "116.0.0"  # 4710b80de01e36186b85fbe3397b8d67
+__version__ = "116.1.0"  # 98c61dbefde14673a865f647bb969f9a

--- a/tests/test_interruptible_io.py
+++ b/tests/test_interruptible_io.py
@@ -1,0 +1,62 @@
+from itertools import count, islice
+
+import pytest
+
+from notifications_utils.interruptible_io import interruptible_every, interruptible_iter
+
+
+def test_interruptible_every(mocker):
+    mock_sleep = mocker.patch("notifications_utils.interruptible_io.sleep")
+
+    c = count()
+
+    @interruptible_every(3)
+    def my_func(a):
+        return a + next(c)
+
+    assert len(mock_sleep.mock_calls) == 0
+    assert my_func(5) == 5
+    assert len(mock_sleep.mock_calls) == 0
+    assert my_func(5) == 6
+    assert len(mock_sleep.mock_calls) == 0
+    assert my_func(5) == 7
+    assert len(mock_sleep.mock_calls) == 0
+    assert my_func(5) == 8
+    assert len(mock_sleep.mock_calls) == 1
+    assert my_func(5) == 9
+    assert len(mock_sleep.mock_calls) == 1
+    assert my_func(5) == 10
+    assert len(mock_sleep.mock_calls) == 1
+    assert my_func(5) == 11
+    assert len(mock_sleep.mock_calls) == 2
+    assert my_func(5) == 12
+    assert len(mock_sleep.mock_calls) == 2
+
+
+def test_interruptible_iter(mocker):
+    mock_sleep = mocker.patch("notifications_utils.interruptible_io.sleep")
+    i = interruptible_iter(islice(count(), 0, 9), 3)
+
+    assert next(i) == 0
+    assert len(mock_sleep.mock_calls) == 0
+    assert next(i) == 1
+    assert len(mock_sleep.mock_calls) == 0
+    assert next(i) == 2
+    assert len(mock_sleep.mock_calls) == 0
+    assert next(i) == 3
+    assert len(mock_sleep.mock_calls) == 1
+    assert next(i) == 4
+    assert len(mock_sleep.mock_calls) == 1
+    assert next(i) == 5
+    assert len(mock_sleep.mock_calls) == 1
+    assert next(i) == 6
+    assert len(mock_sleep.mock_calls) == 2
+    assert next(i) == 7
+    assert len(mock_sleep.mock_calls) == 2
+    assert next(i) == 8
+    assert len(mock_sleep.mock_calls) == 2
+
+    with pytest.raises(StopIteration):
+        next(i)
+
+    assert len(mock_sleep.mock_calls) == 2


### PR DESCRIPTION
Incorporates #1356, and then uses the added tools to reimplement `get_rows` interruptibility and also return an `InterruptibleIterableList` from the `rows` property. This will cause operations iterating through the list to also allow interruption. This includes `RecipientCSV`'s own methods, some of which can be quite expensive.