### PR TITLE
Dont double strip whitespace when formatting email addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 117.0.1
+
+* Small speed improvements to `validate_and_format_email_address`
+
 ## 117.0.0
 
 * Remove StatsD client

--- a/notifications_utils/recipient_validation/email_address.py
+++ b/notifications_utils/recipient_validation/email_address.py
@@ -63,4 +63,4 @@ def format_email_address(email_address):
 
 
 def validate_and_format_email_address(email_address):
-    return format_email_address(validate_email_address(email_address))
+    return validate_email_address(email_address).lower()

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "117.0.0"  # ff80800f96ddf93abceaacc340bd51bf
+__version__ = "117.0.1"  # 2ce45ffd0436b958243f91f8369f8aab


### PR DESCRIPTION
`validate_email_address` calls `strip_and_remove_obscure_whitespace`
here:
https://github.com/alphagov/notifications-utils/blob/64112420c90149d844c9aeaa224ea3914e695fd7/notifications_utils/recipient_validation/email_address.py#L18-L22

`format_email_address` calls it here:
https://github.com/alphagov/notifications-utils/blob/64112420c90149d844c9aeaa224ea3914e695fd7/notifications_utils/recipient_validation/email_address.py#L61-L62

`validate_and_format_email_address` calls both of these functions:
https://github.com/alphagov/notifications-utils/blob/64112420c90149d844c9aeaa224ea3914e695fd7/notifications_utils/recipient_validation/email_address.py#L65-L66

Therefore `strip_and_remove_obscure_whitespace` gets called twice, redundantly. Not as performant as it could be.

Making only the call to `str.lower()` is equivalent.

***

Benchmarking command:
```shell
python -m timeit -s "from notifications_utils.recipient_validation.email_address import validate_and_format_email_address" "validate_and_format_email_address('\tfoobar@Example.COM  \n')"
````

Before:
```
100000 loops, best of 5: 3.06 usec per loop
```

After:
```
100000 loops, best of 5: 2.59 usec per loop
```

15% improvement, or a 47ms saving over a 100,000 row CSV file.