### PR TITLE
Add `max_items_shown` argument to `formatted_list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 117.1.0
+
+* Add `max_items_shown` and `word_for_items_not_shown` arguments to `formatted_list`
+* All arguments to `formatted_list` except for `items` are now keyword-only
+
 ## 117.0.2
 
 * Restrict Gunicorn to versions <= 26.0.0, since version 26.0.0 dropped Eventlet support

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -187,7 +187,14 @@ def url_encode_full_stops(value):
 
 
 def unescaped_formatted_list(
-    items, conjunction="and", before_each="‘", after_each="’", separator=", ", prefix="", prefix_plural=""
+    items,
+    *,
+    conjunction="and",
+    before_each="‘",
+    after_each="’",
+    separator=", ",
+    prefix="",
+    prefix_plural="",
 ):
     if prefix:
         prefix += " "
@@ -204,14 +211,8 @@ def unescaped_formatted_list(
         return f"{prefix_plural}{first_items} {conjunction} {last_item}"
 
 
-def formatted_list(
-    items, conjunction="and", before_each="‘", after_each="’", separator=", ", prefix="", prefix_plural=""
-):
-    return Markup(
-        unescaped_formatted_list(
-            [escape_html(x) for x in items], conjunction, before_each, after_each, separator, prefix, prefix_plural
-        )
-    )
+def formatted_list(items, **kwargs):
+    return Markup(unescaped_formatted_list([escape_html(x) for x in items], **kwargs))
 
 
 def remove_whitespace_before_punctuation(value):

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -1,3 +1,4 @@
+import math
 import re
 import string
 import urllib
@@ -195,17 +196,26 @@ def unescaped_formatted_list(
     separator=", ",
     prefix="",
     prefix_plural="",
+    max_items_shown=math.inf,
+    word_for_items_not_shown=None,
 ):
+    if max_items_shown < math.inf and not word_for_items_not_shown:
+        raise TypeError('`word_for_items_not_shown` must be provided, for example "more" or "others"')
+
     if prefix:
         prefix += " "
     if prefix_plural:
         prefix_plural += " "
 
-    if len(items) == 1:
-        return f"{prefix}{before_each}{items[0]}{after_each}"
-    elif items:
+    if len(items) > max_items_shown:
+        cutoff = max(max_items_shown - 1, 1)
+        formatted_items = [f"{before_each}{item}{after_each}" for item in items[:cutoff]] + [word_for_items_not_shown]
+    else:
         formatted_items = [f"{before_each}{item}{after_each}" for item in items]
 
+    if len(items) == 1:
+        return f"{prefix}{formatted_items[0]}"
+    elif items:
         first_items = separator.join(formatted_items[:-1])
         last_item = formatted_items[-1]
         return f"{prefix_plural}{first_items} {conjunction} {last_item}"

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -202,6 +202,9 @@ def unescaped_formatted_list(
     if max_items_shown < math.inf and not word_for_items_not_shown:
         raise TypeError('`word_for_items_not_shown` must be provided, for example "more" or "others"')
 
+    if not items:
+        return ""
+
     if prefix:
         prefix += " "
     if prefix_plural:
@@ -215,10 +218,10 @@ def unescaped_formatted_list(
 
     if len(items) == 1:
         return f"{prefix}{formatted_items[0]}"
-    elif items:
-        first_items = separator.join(formatted_items[:-1])
-        last_item = formatted_items[-1]
-        return f"{prefix_plural}{first_items} {conjunction} {last_item}"
+
+    first_items = separator.join(formatted_items[:-1])
+    last_item = formatted_items[-1]
+    return f"{prefix_plural}{first_items} {conjunction} {last_item}"
 
 
 def formatted_list(items, **kwargs):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "117.0.2"  # e827dd810f5cb6dbf99c7a67de4f99ad
+__version__ = "117.1.0"  # 48aa7ef33e8eb1bce45e93805239268f

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -158,6 +158,7 @@ def test_sms_encode(mocker):
 @pytest.mark.parametrize(
     "items, kwargs, expected_output",
     [
+        ([], {}, ""),
         ([1], {}, "‘1’"),
         ([1, 2], {}, "‘1’ and ‘2’"),
         ([1, 2, 3], {}, "‘1’, ‘2’ and ‘3’"),

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -167,6 +167,12 @@ def test_sms_encode(mocker):
         ([1, 2, 3], {"conjunction": "foo"}, "‘1’, ‘2’ foo ‘3’"),
         (["&"], {"before_each": "<i>", "after_each": "</i>"}, "<i>&amp;</i>"),
         ([1, 2, 3], {"before_each": "<i>", "after_each": "</i>"}, "<i>1</i>, <i>2</i> and <i>3</i>"),
+        pytest.param([], {"max_items_shown": 3}, "", marks=pytest.mark.xfail(raises=TypeError)),
+        ([1], {"max_items_shown": 1, "word_for_items_not_shown": "more"}, "‘1’"),
+        ([1, 2], {"max_items_shown": 1, "word_for_items_not_shown": "more"}, "‘1’ and more"),
+        ([1, 2, 3], {"max_items_shown": 2, "word_for_items_not_shown": "stuff"}, "‘1’ and stuff"),
+        ([1, 2, 3, 4], {"max_items_shown": 3, "word_for_items_not_shown": "others"}, "‘1’, ‘2’ and others"),
+        ([1, 2, 3], {"max_items_shown": 3, "word_for_items_not_shown": "foo"}, "‘1’, ‘2’ and ‘3’"),
     ],
 )
 def test_formatted_list(items, kwargs, expected_output):


### PR DESCRIPTION
This is useful when you want to display a list of things in prose, but don’t want that list getting too long.

It provides a way of truncating the output by specifying the maximum number of items to be shown and a word to use when there are more than this number of items.

***

Before:

> Avocado, banana, dragon fruit, mango, papaya and pineapple

After:

> Avocado, banana and more

***

Can replace what we are doing in Jinja here:
https://github.com/alphagov/notifications-admin/blob/1791ba2eb8f0dd45352ce0ded91d6e27d2fa1bfe/app/templates/partials/templates/content-count-message.html#L10-L14