### PR TITLE
Move `subject` handling into `BaseEmailTemplate` and `BaseLetterTemplate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 118.0.0
+
+* Removes `notifications_utils.template.SubjectMixin` (not used outside the repo)
+
 ## 117.1.0
 
 * Add `max_items_shown` and `word_for_items_not_shown` arguments to `formatted_list`

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -82,7 +82,6 @@ class Template(ABC):
         self.id = template.get("id", None)
         self.name = template.get("name", None)
         self.content = template["content"]
-        self.welsh_content = template.get("letter_welsh_content", None)
         self._template = template
         self.values = values
         self.redact_missing_personalisation = redact_missing_personalisation
@@ -125,12 +124,7 @@ class Template(ABC):
 
     @property
     def placeholders(self):
-        welsh = set()
-        if self.welsh_content:
-            welsh = get_placeholders(self.welsh_content)
-        english = get_placeholders(self.content)
-        all = welsh | english
-        return all
+        return get_placeholders(self.content)
 
     @property
     def missing_data(self):
@@ -599,6 +593,7 @@ class BaseLetterTemplate(Template):
     ):
         self.contact_block = (contact_block or "").strip()
         self._welsh_subject = template.get("letter_welsh_subject", "")
+        self.welsh_content = template.get("letter_welsh_content", None)
 
         if language == "english":
             self._subject = template["subject"]
@@ -633,13 +628,9 @@ class BaseLetterTemplate(Template):
 
     @property
     def placeholders(self):
-        welsh = set()
-        if self._welsh_subject:
-            welsh = get_placeholders(self._welsh_subject)
-        english = get_placeholders(self._subject)
-        all = welsh | english
-
-        return all | get_placeholders(self.contact_block) | super().placeholders
+        subject_placeholders = get_placeholders(self._welsh_subject) | get_placeholders(self._subject)
+        content_placeholders = get_placeholders(self.welsh_content) | super().placeholders
+        return get_placeholders(self.contact_block) | subject_placeholders | content_placeholders
 
     @property
     def too_many_pages(self):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -392,11 +392,7 @@ class SMSPreviewTemplate(BaseSMSTemplate):
         )
 
 
-class SubjectMixin:
-    pass
-
-
-class BaseEmailTemplate(SubjectMixin, Template):
+class BaseEmailTemplate(Template):
     template_type = "email"
 
     def __init__(self, template, values=None, unsubscribe_link=None, **kwargs):
@@ -582,7 +578,7 @@ class HTMLEmailTemplate(BaseEmailTemplate):
         )
 
 
-class BaseLetterTemplate(SubjectMixin, Template):
+class BaseLetterTemplate(Template):
     template_type = "letter"
     max_page_count = LETTER_MAX_PAGE_COUNT
     max_sheet_count = LETTER_MAX_PAGE_COUNT // 2

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -598,14 +598,12 @@ class BaseLetterTemplate(Template):
         includes_first_page: bool = True,
     ):
         self.contact_block = (contact_block or "").strip()
-        welsh_subject = template.get("letter_welsh_subject", "")
+        self._welsh_subject = template.get("letter_welsh_subject", "")
 
         if language == "english":
             self._subject = template["subject"]
         else:
-            self._subject = welsh_subject
-
-        self._welsh_subject = welsh_subject
+            self._subject = self._welsh_subject
 
         super().__init__(template, values, redact_missing_personalisation=redact_missing_personalisation)
         self.admin_base_url = admin_base_url
@@ -613,9 +611,7 @@ class BaseLetterTemplate(Template):
         self.date = date
         self.language = language
 
-        if language == "english":
-            self.content = template["content"]
-        else:
+        if language != "english":
             self.content = template.get("letter_welsh_content", "")
 
         self.includes_first_page = includes_first_page

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -625,9 +625,13 @@ class BaseLetterTemplate(Template):
 
     @property
     def placeholders(self):
-        subject_placeholders = get_placeholders(self._welsh_subject) | get_placeholders(self._subject)
-        content_placeholders = get_placeholders(self.welsh_content) | super().placeholders
-        return get_placeholders(self.contact_block) | subject_placeholders | content_placeholders
+        return (
+            get_placeholders(self.contact_block)
+            | get_placeholders(self._welsh_subject)
+            | get_placeholders(self.welsh_content)
+            | get_placeholders(self._subject)
+            | super().placeholders
+        )
 
     @property
     def too_many_pages(self):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -393,16 +393,15 @@ class SMSPreviewTemplate(BaseSMSTemplate):
 
 
 class SubjectMixin:
-    def __init__(self, template, values=None, language: Literal["english", "welsh"] = "english", **kwargs):
-        welsh_subject = template.get("letter_welsh_subject", "")
+    pass
 
-        if language == "english":
-            self._subject = template["subject"]
-        else:
-            self._subject = welsh_subject
 
-        self._welsh_subject = welsh_subject
+class BaseEmailTemplate(SubjectMixin, Template):
+    template_type = "email"
 
+    def __init__(self, template, values=None, unsubscribe_link=None, **kwargs):
+        self.unsubscribe_link = unsubscribe_link
+        self._subject = template["subject"]
         super().__init__(template, values, **kwargs)
 
     @property
@@ -422,21 +421,7 @@ class SubjectMixin:
 
     @property
     def placeholders(self):
-        welsh = set()
-        if self._welsh_subject:
-            welsh = get_placeholders(self._welsh_subject)
-        english = get_placeholders(self._subject)
-        all = welsh | english
-
-        return all | super().placeholders
-
-
-class BaseEmailTemplate(SubjectMixin, Template):
-    template_type = "email"
-
-    def __init__(self, template, values=None, unsubscribe_link=None, **kwargs):
-        self.unsubscribe_link = unsubscribe_link
-        super().__init__(template, values, **kwargs)
+        return get_placeholders(self._subject) | super().placeholders
 
     @property
     def content_with_unsubscribe_link(self):
@@ -613,21 +598,30 @@ class BaseLetterTemplate(SubjectMixin, Template):
         logo_file_name=None,
         redact_missing_personalisation=False,
         date: datetime | None = None,
-        language="english",
+        language: Literal["english", "welsh"] = "english",
         includes_first_page: bool = True,
     ):
         self.contact_block = (contact_block or "").strip()
-        super().__init__(
-            template, values, redact_missing_personalisation=redact_missing_personalisation, language=language
-        )
+        welsh_subject = template.get("letter_welsh_subject", "")
+
+        if language == "english":
+            self._subject = template["subject"]
+        else:
+            self._subject = welsh_subject
+
+        self._welsh_subject = welsh_subject
+
+        super().__init__(template, values, redact_missing_personalisation=redact_missing_personalisation)
         self.admin_base_url = admin_base_url
         self.logo_file_name = logo_file_name
         self.date = date
         self.language = language
+
         if language == "english":
             self.content = template["content"]
         else:
             self.content = template.get("letter_welsh_content", "")
+
         self.includes_first_page = includes_first_page
 
     @property
@@ -647,7 +641,13 @@ class BaseLetterTemplate(SubjectMixin, Template):
 
     @property
     def placeholders(self):
-        return get_placeholders(self.contact_block) | super().placeholders
+        welsh = set()
+        if self._welsh_subject:
+            welsh = get_placeholders(self._welsh_subject)
+        english = get_placeholders(self._subject)
+        all = welsh | english
+
+        return all | get_placeholders(self.contact_block) | super().placeholders
 
     @property
     def too_many_pages(self):

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -592,13 +592,9 @@ class BaseLetterTemplate(Template):
         includes_first_page: bool = True,
     ):
         self.contact_block = (contact_block or "").strip()
+        self._subject = template["subject"]
         self._welsh_subject = template.get("letter_welsh_subject", "")
         self.welsh_content = template.get("letter_welsh_content", None)
-
-        if language == "english":
-            self._subject = template["subject"]
-        else:
-            self._subject = self._welsh_subject
 
         super().__init__(template, values, redact_missing_personalisation=redact_missing_personalisation)
         self.admin_base_url = admin_base_url
@@ -606,8 +602,9 @@ class BaseLetterTemplate(Template):
         self.date = date
         self.language = language
 
-        if language != "english":
-            self.content = template.get("letter_welsh_content", "")
+        if language == "welsh":
+            self.content = self.welsh_content
+            self._subject = self._welsh_subject
 
         self.includes_first_page = includes_first_page
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "117.1.0"  # 48aa7ef33e8eb1bce45e93805239268f
+__version__ = "118.0.0"  # b479010551a3b03216911d36a30a3e3b

--- a/tests/test_base_template.py
+++ b/tests/test_base_template.py
@@ -1,6 +1,12 @@
 import pytest
 
-from notifications_utils.template import SubjectMixin, Template
+from notifications_utils.template import (
+    HTMLEmailTemplate,
+    LetterPreviewTemplate,
+    LetterPrintTemplate,
+    PlainTextEmailTemplate,
+    Template,
+)
 
 
 class ConcreteImplementation:
@@ -12,10 +18,6 @@ class ConcreteImplementation:
 
 
 class ConcreteTemplate(ConcreteImplementation, Template):
-    pass
-
-
-class ConcreteTemplateWithSubject(SubjectMixin, ConcreteTemplate):
     pass
 
 
@@ -31,8 +33,22 @@ def test_passes_through_template_attributes():
     assert ConcreteTemplate({"content": ""}).template_type is None
 
 
-def test_passes_through_subject():
-    assert ConcreteTemplateWithSubject({"content": "", "subject": "Your tax is due"}).subject == "Your tax is due"
+@pytest.mark.parametrize(
+    "template_class",
+    (
+        HTMLEmailTemplate,
+        PlainTextEmailTemplate,
+        LetterPreviewTemplate,
+        LetterPrintTemplate,
+    ),
+)
+def test_passes_through_subject(template_class):
+    assert (
+        template_class(
+            {"content": "", "subject": "Your tax is due", "template_type": template_class.template_type}
+        ).subject
+        == "Your tax is due"
+    )
 
 
 def test_errors_for_missing_template_content():
@@ -80,9 +96,21 @@ def test_matches_keys_to_placeholder_names():
         ("((warning? one question mark))", "", ["warning? one question mark"]),
     ],
 )
-def test_extracting_placeholders(template_content, template_subject, expected):
+@pytest.mark.parametrize(
+    "template_class",
+    (
+        HTMLEmailTemplate,
+        PlainTextEmailTemplate,
+        LetterPreviewTemplate,
+        LetterPrintTemplate,
+    ),
+)
+def test_extracting_placeholders(template_class, template_content, template_subject, expected):
     assert (
-        ConcreteTemplateWithSubject({"content": template_content, "subject": template_subject}).placeholders == expected
+        template_class(
+            {"content": template_content, "subject": template_subject, "template_type": template_class.template_type}
+        ).placeholders
+        == expected
     )
 
 

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -21,7 +21,6 @@ from notifications_utils.template import (
     SMSBodyPreviewTemplate,
     SMSMessageTemplate,
     SMSPreviewTemplate,
-    SubjectMixin,
     Template,
 )
 
@@ -940,13 +939,13 @@ def test_subject_line_gets_applied_to_correct_template_types():
         PlainTextEmailTemplate,
         LetterPreviewTemplate,
     ]:
-        assert issubclass(cls, SubjectMixin)
+        assert hasattr(cls, "subject")
     for cls in [
         SMSBodyPreviewTemplate,
         SMSMessageTemplate,
         SMSPreviewTemplate,
     ]:
-        assert not issubclass(cls, SubjectMixin)
+        assert not hasattr(cls, "subject")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -902,11 +902,16 @@ def test_letter_template_detects_all_placeholders_in_both_english_and_welsh_subj
             "subject": "Getting ((allowance_type))",
             "letter_welsh_subject": "Cael ((allowance_type_cy))",
             "template_type": "letter",
-        }
+        },
+        contact_block="((phone_number))",
     )
 
-    assert template.placeholders == OrderedSet(
-        ["allowance_type_cy", "allowance_type", "document_type_cy", "document_type"]
+    assert tuple(template.placeholders) == (
+        "phone_number",
+        "allowance_type_cy",
+        "document_type_cy",
+        "allowance_type",
+        "document_type",
     )
 
 


### PR DESCRIPTION
It’s not good factoring to have the stuff around bilingual letters shared between letter and email templates. I’d go as far as to say it’s a smell that code shared between both is looking at things like `letter_welsh_subject` and `letter_welsh_content`.

We can move the stuff around bilingual letters into `BaseLetterTemplate` for a better factoring.

This has the added bonus of removing `SubjectMixin`, which was difficult to add type hints for.