### PR TITLE
Restrict the maximum version of Gunicorn 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 117.0.2
+
+* Restrict Gunicorn to versions <= 26.0.0, since version 26.0.0 dropped Eventlet support
+
 ## 117.0.1
 
 * Small speed improvements to `validate_and_format_email_address`

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "117.0.1"  # 2ce45ffd0436b958243f91f8369f8aab
+__version__ = "117.0.2"  # e827dd810f5cb6dbf99c7a67de4f99ad

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "Flask-Redis>=0.4.0",
     "Flask>=3.1.1",
     "govuk-bank-holidays>=0.17",
-    "gunicorn[eventlet]>=23.0.0",
+    "gunicorn[eventlet]>=23.0.0,<26.0.0",  # v26.0.0 doesn't support eventlet
     "itsdangerous>=2.2.0",
     "Jinja2>=3.1.6",
     "mistune<2.0.0",  # v2 is totally incompatible with unclear benefit


### PR DESCRIPTION
Version 26.0.0 of Gunicorn is incompatable with our code since it [removes
support for Eventlet](https://gunicorn.org/2026-news/#2600-2026-05-05).

Running `make refreeze-requirements` in the apps currently brings in
version 26.0.0 because we're getting it from here, where there is no
maximum version. This would cause a breaking change which might not be
spotted when testing locally, where we use the Flask web server.