### PR TITLE
Optimise searching for placeholders 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 118.0.1
+
+* Improve performance of `Field.placeholders`
+
 ## 118.0.0
 
 * Removes `notifications_utils.template.SubjectMixin` (not used outside the repo)

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -161,7 +161,7 @@ class Field:
 
     @property
     def placeholders(self):
-        if not getattr(self, "content", ""):
+        if not self.content or "(" not in self.content:
             return InsensitiveSet()
         return InsensitiveSet(Placeholder(body).name for body in re.findall(self.placeholder_pattern, self.content))
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "118.0.0"  # b479010551a3b03216911d36a30a3e3b
+__version__ = "118.0.1"  # 25047862539d5613bcec377a6ff40354

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1312,8 +1312,7 @@ def test_is_message_empty_email_and_letter_templates_tries_not_to_count_chars(
             "sms",
             {},
             [
-                mock.call("content"),  # This is to get the placeholders
-                mock.call("content", {}, html="passthrough"),
+                mock.call("content"),
             ],
         ),
         (
@@ -1392,11 +1391,9 @@ def test_is_message_empty_email_and_letter_templates_tries_not_to_count_chars(
         ),
     ],
 )
-@mock.patch("notifications_utils.template.Field.__init__", return_value=None)
-@mock.patch("notifications_utils.template.Field.__str__", return_value="1\n2\n3\n4\n5\n6\n7\n8")
+@mock.patch("notifications_utils.template.Field")
 def test_templates_handle_html_and_redacting(
-    mock_field_str,
-    mock_field_init,
+    mock_field,
     template_class,
     template_type,
     extra_args,
@@ -1405,7 +1402,7 @@ def test_templates_handle_html_and_redacting(
     assert str(
         template_class({"content": "content", "subject": "subject", "template_type": template_type}, **extra_args)
     )
-    assert mock_field_init.call_args_list == expected_field_calls
+    assert mock_field.call_args_list == expected_field_calls
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
If a string doesn’t have an opening parentheses then we can guarantee it doesn’t have any placeholders in it.

We can take advantage of this to skip the expensive regex search.

## Benchmark for string with no placeholders
```shell
python -m timeit -s "import random; import string; from notifications_utils.field import Field; s = ''.join(random.choices(string.ascii_uppercase + string.digits + string.whitespace, k=1000))" "Field(s).placeholders"
```

### Before
> 50000 loops, best of 5: 7.68 usec per loop

### After
> 500000 loops, best of 5: 536 nsec per loop

14× faster

## Benchmark for same string with one placeholder right at the end
```shell
python -m timeit -s "import random; import string; from notifications_utils.field import Field; s = ''.join(random.choices(string.ascii_uppercase + string.digits + string.whitespace, k=1000)) + '((name))'" "Field(s).placeholders"
```

### Before
> 50000 loops, best of 5: 9.06 usec per loop

### After
> 50000 loops, best of 5: 9.06 usec per loop

No change.