### PR TITLE
Don’t double-count extended GSM characters if text message is not GSM encoded 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 118.0.2
+
+* Fix small bug in counting length of text messages with non-GSM and extended GSM characters
+
 ## 118.0.1
 
 * Improve performance of `Field.placeholders`

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -244,9 +244,7 @@ class BaseSMSTemplate(Template):
 
     @property
     def count_of_characters_above_previous_fragment_boundary(self):
-        if self.fragment_count == 1:
-            boundary = 0
-        elif self.fragment_count == 2:
+        if self.fragment_count == 2:
             boundary = 70 if self.non_gsm_characters else 160
         else:
             boundary = (67 if self.non_gsm_characters else 153) * (self.fragment_count - 1)

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -234,18 +234,16 @@ class BaseSMSTemplate(Template):
 
     @property
     def fragment_count(self):
-        # Extended GSM characters count as 2 characters
-        character_count = self.content_count + self.count_extended_gsm_chars
-
         if self.non_gsm_characters:
-            return 1 if character_count <= 70 else math.ceil(float(character_count) / 67)
+            return 1 if self.content_count <= 70 else math.ceil(float(self.content_count) / 67)
+
+        # Extended GSM characters count as 2 characters in GSM-7
+        character_count = self.content_count + self.count_extended_gsm_chars
 
         return 1 if character_count <= 160 else math.ceil(float(character_count) / 153)
 
     @property
     def count_of_characters_above_previous_fragment_boundary(self):
-        character_count = self.content_count + self.count_extended_gsm_chars
-
         if self.fragment_count == 1:
             boundary = 0
         elif self.fragment_count == 2:
@@ -253,7 +251,10 @@ class BaseSMSTemplate(Template):
         else:
             boundary = (67 if self.non_gsm_characters else 153) * (self.fragment_count - 1)
 
-        return character_count - boundary
+        if self.non_gsm_characters:
+            return self.content_count - boundary
+
+        return self.content_count + self.count_extended_gsm_chars - boundary
 
     @property
     def non_gsm_characters(self):

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "118.0.1"  # 25047862539d5613bcec377a6ff40354
+__version__ = "118.0.2"  # 75ca400e566fa067cf59d21e92107e23

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1102,6 +1102,7 @@ def test_sms_fragment_count_accounts_for_unicode_and_welsh_characters(
     "template_content, expected_sms_fragment_count, expected_count_of_characters_above_previous_fragment_boundary",
     [
         # all extended GSM characters
+        ("^" * 80, 1, 160),
         ("^" * 81, 2, 2),
         # GSM characters plus extended GSM
         ("a" * 158 + "|", 1, 160),
@@ -1109,8 +1110,10 @@ def test_sms_fragment_count_accounts_for_unicode_and_welsh_characters(
         ("a" * 304 + "[", 2, 146),
         ("a" * 304 + "[]", 3, 2),
         # Welsh character plus extended GSM
-        ("â" * 132 + "{", 2, 64),
-        ("â" * 133 + "}", 3, 1),
+        ("â" * 69 + "{", 1, 70),
+        ("â" * 70 + "{", 2, 1),
+        ("â" * 133 + "}", 2, 64),
+        ("â" * 134 + "}", 3, 1),
         # Non-GSM or extended characters in placeholder, not content
         ("a" * 160 + "(( placeholder with â ))", 1, 160),
         ("a" * 160 + "(( placeholder with | ))", 1, 160),


### PR DESCRIPTION
Characters like `{` only count as 2 characters if the message is GSM-encoded.

If characters like `Ŵ` have caused the message to be unicode-encoded then `{` counts as 1 character like any other.

This bug existed before https://github.com/alphagov/notifications-utils/pull/1362 but wasn’t spotted. It’s quite unlikely to make a real-life difference to billing given how infrequently these characters are used in messages.