### PR TITLE
Make basic `InsensitiveSet` test clear about format

### DIFF
--- a/tests/test_insensitive_dict.py
+++ b/tests/test_insensitive_dict.py
@@ -1,7 +1,6 @@
 from functools import partial
 
 import pytest
-from ordered_set import OrderedSet
 
 from notifications_utils.insensitive_dict import InsensitiveDict, InsensitiveSet
 from notifications_utils.recipients import Cell, Row
@@ -95,20 +94,21 @@ def test_maintains_insertion_order():
 
 
 def test_insensitive_set():
-    assert InsensitiveSet(
-        [
-            "foo",
-            "F o o ",
-            "F_O_O",
-            "B_A_R",
-            "B a r",
-            "bar",
-        ]
-    ) == OrderedSet(
-        [
-            "foo",
-            "B_A_R",
-        ]
+    assert tuple(
+        InsensitiveSet(
+            [
+                "foo",
+                "F o o ",
+                "F_O_O",
+                "B_A_R",
+                "B a r",
+                "bar",
+            ]
+        )
+    ) == (
+        # Items match their first-seen format
+        "foo",
+        "B_A_R",
     )
 
 


### PR DESCRIPTION
We want the format of the items to be as they are first-seen in the provided interable. This gives the expected behaviour for placeholders in templates, which should be displayed as per their first occurance.

This commit updates the test to make it clear that this is the intended behaviour.