### PR TITLE
Fix pypdf vulnerabilities by updating to safe version

### DIFF
--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -727,9 +727,9 @@ pygments==2.19.2 \
     --hash=sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887 \
     --hash=sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b
     # via pytest
-pypdf==6.9.1 \
-    --hash=sha256:ae052407d33d34de0c86c5c729be6d51010bf36e03035a8f23ab449bca52377d \
-    --hash=sha256:f35a6a022348fae47e092a908339a8f3dc993510c026bb39a96718fc7185e89f
+pypdf==6.13.1 \
+    --hash=sha256:4841d8a4c1589e5833915dc0c7ddfacff80a2e0bcbeb5d1e681fecaa1674b03a \
+    --hash=sha256:e555e4ce3f561ef069307622f1374136ba964ca6ca24f24158701decaf83ed9b
     # via notifications-utils (pyproject.toml)
 pyproject-hooks==1.2.0 \
     --hash=sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8 \


### PR DESCRIPTION
We upgrade pypdf to 6.12.0 which fixes several vulnerabilities:

1) https://github.com/alphagov/notifications-utils/security/dependabot/40 - when we use the pdf reader we are vulnerable to an expansion attack with Manipulated XMP metadata entity declarations that exhausts memory and causes a denial of service.

2) https://github.com/alphagov/notifications-utils/security/dependabot/45 - when we use the PdfReader we are vulnerable to RAM exhaustion attack by manipulated FlateDecode image dimensions. This can cause resource overuse and denial of service.

3) https://github.com/alphagov/notifications-utils/security/dependabot/44 - when we use the PdfReader we are vulnerable to RAM exhaustion attack by manipulated FlateDecode predictor parameters. This can cause resource overuse and denial of service.

4) https://github.com/alphagov/notifications-utils/security/dependabot/55 - when we use the PdfReader we are vulnerable to artificially extended runtimes, leading to slower service / denial of service / larger use of resouces.

5) https://github.com/alphagov/notifications-utils/security/dependabot/42 - when we use the PdfReader we are vulnerable to artificially extended runtimes, leading to slower service / denial of service / larger use of resouces.

The risk of us being exploited by these vulnerabilities is fairly low (as only our service users provide PDFs vs general public) but it is not zero and could DoS any app components that are using pypdf to read pdfs

all tests in utils pass with the upgrade

All vulnerabilities also added to the spreadsheet: https://docs.google.com/spreadsheets/d/1g1Lji_1-jPx6MUT9kRZMM8riZhzkY-s0IlP-RKSoVlA/edit?usp=sharing