### PR TITLE
Rewrite `_parse_and_extract_bfpo` without lambda

### DIFF
--- a/notifications_utils/recipient_validation/postal_address.py
+++ b/notifications_utils/recipient_validation/postal_address.py
@@ -69,7 +69,7 @@ class PostalAddress:
     def __repr__(self):
         return f"{self.__class__.__name__}({repr(self.raw_address)})"
 
-    def _parse_and_extract_bfpo(self, lines):
+    def _parse_and_extract_bfpo(self, lines: list) -> tuple[int | None, list]:
         bfpo_matcher = re.compile(r"^\s*bfpo\s*(?:c\/o)?(?:\s*(\d+))?\s*$")
         matches = [bfpo_matcher.match(line.lower()) for line in lines]
 

--- a/notifications_utils/recipient_validation/postal_address.py
+++ b/notifications_utils/recipient_validation/postal_address.py
@@ -71,17 +71,13 @@ class PostalAddress:
 
     def _parse_and_extract_bfpo(self, lines):
         bfpo_matcher = re.compile(r"^\s*bfpo\s*(?:c\/o)?(?:\s*(\d+))?\s*$")
-        bfpo_number_line = next(
-            filter(lambda line: bfpo_matcher.match(line.lower()) and bfpo_matcher.match(line.lower()).group(1), lines),
-            None,
-        )
-        if not bfpo_number_line:
-            return None, lines
+        matches = [bfpo_matcher.match(line.lower()) for line in lines]
 
-        bfpo_number = bfpo_matcher.match(bfpo_number_line.lower()).group(1)
-        lines = [line for line in lines if not bfpo_matcher.match(line.lower())]
+        for match in matches:
+            if match and match.group(1):
+                return int(match.group(1)), [line for line, match in zip(lines, matches, strict=True) if not match]
 
-        return int(bfpo_number), lines
+        return None, lines
 
     @staticmethod
     def trailing_uk_countries(lines):


### PR DESCRIPTION
This:
- is fewer lines of code
- removes an icky `lambda`
- reduces the number of times we repeatedly call `bfpo_matcher`
- makes it possible for a type checker to figure out what’s going on

No functional changes.