### PR TITLE
Remove `BaseLetterTemplate.too_many_pages`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 120.0.0
+
+* Removes `BaseLetterTemplate.too_many_pages` (subclasses which define `page_count` should implement this themselves)
+
 ## 119.0.0
 
 * Reimplement `InsensitiveSet` using standard python dicts and a more complete implementation of `MutableSet` & `Sequence`. Subtle (but hopefully unimportant) behaviour changes should be expected.

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -633,10 +633,6 @@ class BaseLetterTemplate(Template):
         )
 
     @property
-    def too_many_pages(self):
-        return self.page_count > self.max_page_count
-
-    @property
     def postal_address(self):
         return PostalAddress.from_personalisation(InsensitiveDict(self.values))
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "119.0.0"  # ec7671431faa48dda6ca81ab384771ec
+__version__ = "120.0.0"  # 08b7f88cb3fa3e1f43040857a7ea7791


### PR DESCRIPTION
This should only be implemented in subclasses which also implement `page_count`. Specifically it should move to
https://github.com/alphagov/notifications-admin/blob/06e6bece58a74132798233e65aad2d8a102e917e/app/utils/templates.py#L52-L54