### PR TITLE
Don’t declare `start` on NotifyTask

### DIFF
--- a/notifications_utils/celery.py
+++ b/notifications_utils/celery.py
@@ -21,7 +21,6 @@ duration_histogram = metrics.get_meter(__name__).create_histogram(
 
 class NotifyTask(Task):
     abstract = True
-    start = None
 
     def __init__(self, *args, **kwargs):
         # custom task-decorator arguments magically get applied as class attributes (!),


### PR DESCRIPTION
It’s better if code that tries to access `start` before it’s been set to an actual time gets an `AttributeError`, rather than unexpectedly handling a `None` in a way which may or may not raise