### PR TITLE
Always return a `bool` from `PhoneNumber._is_tv_number`

### DIFF
--- a/notifications_utils/recipient_validation/phone_number.py
+++ b/notifications_utils/recipient_validation/phone_number.py
@@ -170,6 +170,8 @@ class PhoneNumber:
         if re.match("7700[900000-900999]", phone_number_as_string):
             return True
 
+        return False
+
     @staticmethod
     def _thoroughly_normalise_number(phone_number: str) -> str:
         """


### PR DESCRIPTION
Will work the same as the implicit `None` when used in a conditional, but makes the type checker happy