### PR TITLE
Make `template_type` an abstract property of `Template`

### DIFF
--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -65,6 +65,11 @@ template_env = Environment(
 
 
 class Template(ABC):
+    @property
+    @abstractmethod
+    def template_type(self):
+        pass
+
     def __init__(
         self,
         template,


### PR DESCRIPTION
Enforces that subclasses set it, and guarantees to type checkers that it will always be present