### PR TITLE
Fix return type for `InvalidPhoneError` `classmethod`

### DIFF
--- a/notifications_utils/recipient_validation/errors.py
+++ b/notifications_utils/recipient_validation/errors.py
@@ -1,4 +1,5 @@
 from enum import StrEnum, auto
+from typing import Self
 
 import phonenumbers
 
@@ -57,7 +58,7 @@ class InvalidPhoneError(InvalidRecipientError):
         super().__init__(message=self.ERROR_MESSAGES[code])
 
     @classmethod
-    def from_phonenumbers_validation_result(cls, reason: phonenumbers.ValidationResult) -> str:
+    def from_phonenumbers_validation_result(cls, reason: phonenumbers.ValidationResult) -> Self:
         match reason:
             case phonenumbers.ValidationResult.TOO_LONG:
                 code = cls.Codes.TOO_LONG


### PR DESCRIPTION
This method returns an instance of the class, not a string.

[Python docs for `typing.Self`](https://docs.python.org/3/library/typing.html#typing.Self) say it’s appropriate to use for:
> `classmethods` that are used as alternative constructors and return instances of the `cls` parameter.