### PR TITLE
Remove implicit `Optional`

### DIFF
--- a/notifications_utils/recipient_validation/errors.py
+++ b/notifications_utils/recipient_validation/errors.py
@@ -6,7 +6,7 @@ import phonenumbers
 class InvalidRecipientError(Exception):
     message = "Not a valid recipient address"
 
-    def __init__(self, message: str = None):
+    def __init__(self, message: str | None = None):
         super().__init__(message or self.message)
 
 


### PR DESCRIPTION
> [PEP 484](https://peps.python.org/pep-0484/) prohibits implicit `Optional`

If a variable can be a `None`, we have to explicitly declare this.