### PR TITLE
Add type hint for `SanitiseText.ALLOWED_CHARACTERS`

### DIFF
--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -1,8 +1,9 @@
 import unicodedata
+from collections.abc import Set
 
 
 class SanitiseText:
-    ALLOWED_CHARACTERS: set[str] = set()
+    ALLOWED_CHARACTERS: Set[str] = set()
 
     REPLACEMENT_CHARACTERS = {
         "‑": "-",  # NON-BREAKING HYPHEN (U+2011)

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -2,7 +2,7 @@ import unicodedata
 
 
 class SanitiseText:
-    ALLOWED_CHARACTERS = set()
+    ALLOWED_CHARACTERS: set[str] = set()
 
     REPLACEMENT_CHARACTERS = {
         "‑": "-",  # NON-BREAKING HYPHEN (U+2011)


### PR DESCRIPTION
Fixes this error:
> Need type annotation for "ALLOWED_CHARACTERS" (hint: "ALLOWED_CHARACTERS: set[<type>] = ...")