### PR TITLE
Sync requirements after freezing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ help:
 .PHONY: freeze-requirements
 freeze-requirements: ## Pin all test requirements including sub dependencies into requirements_for_test.txt
 	uv pip compile requirements_for_test.in pyproject.toml --output-file requirements_for_test.txt $(EXTRA_UV_PIP_COMPILE_FLAGS)
+	uv pip sync requirements.txt
+	uv pip install -e .
 
 .PHONY: refreeze-requirements
 refreeze-requirements: ## Upgrade unpinned requirements


### PR DESCRIPTION
`sync` makes sure the specified dependencies – and only the specified dependencies – are installed. `install` installs the specified dependencies on top of whatever is already in the environment.

Running it as part of the freeze ensures that the freeze has produced a functional environment.

It’s what we do as the last part of the freeze step in other repos, for example:
https://github.com/alphagov/notifications-admin/blob/9d22ced9dca1abc9567cc713d2986d12c8dc026c/Makefile#L79C2-L79C30

Because utils is a package we also have to install itself after syncing.