### PR TITLE
Fix argument type for `InvalidPhoneError.from_phonenumbers_validation_result`

### DIFF
--- a/notifications_utils/recipient_validation/errors.py
+++ b/notifications_utils/recipient_validation/errors.py
@@ -58,7 +58,7 @@ class InvalidPhoneError(InvalidRecipientError):
         super().__init__(message=self.ERROR_MESSAGES[code])
 
     @classmethod
-    def from_phonenumbers_validation_result(cls, reason: phonenumbers.ValidationResult) -> Self:
+    def from_phonenumbers_validation_result(cls, reason: int) -> Self:
         match reason:
             case phonenumbers.ValidationResult.TOO_LONG:
                 code = cls.Codes.TOO_LONG


### PR DESCRIPTION
`phonenumbers.is_possible_number_with_reason` returns an attribute of `phonenumbers.ValidationResult`.

All the attributes of `phonenumbers.ValidationResult` are `int`s:
https://github.com/daviddrysdale/python-phonenumbers/blob/0efec901889d8ca3fb8a4f894f4e13f4019cc75c/python/phonenumbers/phonenumberutil.pyi#L111C7-L117

We were wrongly specify the argument type as the type of the container, not the type of its attributes.