### PR TITLE
`_ns_per_s`: handle `None` values

### DIFF
--- a/notifications_utils/eventlet.py
+++ b/notifications_utils/eventlet.py
@@ -3,6 +3,8 @@ import time
 from collections.abc import Callable
 from contextlib import nullcontext
 
+from notifications_utils.logging.formatting import _ns_per_s
+
 
 # eventlet's own Timeout class inherits from BaseException instead of
 # Exception, which makes more likely that an attempted catch-all
@@ -17,9 +19,6 @@ class HardEventletTimeout(EventletTimeout):
 
 class SoftEventletTimeout(EventletTimeout):
     pass
-
-
-_ns_per_s = 1.0e-9
 
 
 # eventlet detection cribbed from

--- a/notifications_utils/logging/flask.py
+++ b/notifications_utils/logging/flask.py
@@ -24,11 +24,10 @@ from .formatting import (
     BaseJSONFormatter,  # noqa
     Formatter,
     JSONFormatter,
+    _ns_per_s,
 )
 
 logger = logging.getLogger(__name__)
-
-_ns_per_s = 1.0e-9
 
 
 def _common_request_extra_log_context():

--- a/notifications_utils/logging/formatting.py
+++ b/notifications_utils/logging/formatting.py
@@ -39,3 +39,16 @@ class JSONFormatter(_MicrosecondAddingFormatterMixin, BaseJSONFormatter):
             log_record[newkey] = log_record.pop(key, None)
         log_record["logType"] = "application"
         return log_record
+
+
+class PerSecondConversion:
+    def __init__(self, *, factor):
+        self.factor = factor
+
+    def __rmul__(self, other):
+        if other is None:
+            return None
+        return other * self.factor
+
+
+_ns_per_s = PerSecondConversion(factor=1.0e-9)


### PR DESCRIPTION
Here we take a value which could be `None` or a time in nanoseconds and multiply it to get a value in seconds:
https://github.com/alphagov/notifications-utils/blob/9b5d7cb624c314c08c2abf951fbf64b73b418808/notifications_utils/logging/flask.py#L84-L85

Simple multiplication won’t work against `None` and will raise an error.

This commit makes `_ns_per_s` a magic variable which can return `None` if the value it’s multiplied by is `None`.

This may be overengineered.