### PR TITLE
Ignore error about import from `html` library

### DIFF
--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -1,7 +1,10 @@
 import math
 import re
 import string
-from html import _replace_charref, escape
+from html import (
+    _replace_charref,  # type: ignore (until mypy brings in https://github.com/python/typeshed/pull/15925)
+    escape,
+)
 from urllib.parse import quote
 
 import smartypants


### PR DESCRIPTION
mypy says:
> error: Module `html` has no attribute `_replace_charref`  [attr-defined]

Typeshed contains external type annotations for the Python standard library, and is used by mypy.

I’ve fixed this problem upstream in https://github.com/python/typeshed/pull/15925

This fix won’t be in mypy until the next feature release, so we need to ignore the error until then.