### PR TITLE
Remove references to gunicorn from HTTP headers in a type-checker-compliant way

### DIFF
--- a/notifications_utils/gunicorn/defaults.py
+++ b/notifications_utils/gunicorn/defaults.py
@@ -73,4 +73,4 @@ def set_gunicorn_defaults(globals_dict: dict):
         worker_abort=worker_abort,
         worker_int=worker_int,
     )
-    gunicorn.SERVER_SOFTWARE = "None"
+    gunicorn.SERVER_SOFTWARE = "None"  # type: ignore

--- a/notifications_utils/gunicorn/defaults.py
+++ b/notifications_utils/gunicorn/defaults.py
@@ -74,3 +74,4 @@ def set_gunicorn_defaults(globals_dict: dict):
         worker_int=worker_int,
     )
     gunicorn.SERVER_SOFTWARE = "None"  # type: ignore
+    gunicorn.SERVER = "None"  # type: ignore


### PR DESCRIPTION
Gunicorn uses the `SERVER` constant here:
https://github.com/benoitc/gunicorn/blob/a8283bbf5e1416d0dd13f994f71ec2761988aeab/gunicorn/http/wsgi.py#L293

To populate the `Server:` HTTP header here:
https://github.com/benoitc/gunicorn/blob/a8283bbf5e1416d0dd13f994f71ec2761988aeab/gunicorn/http/wsgi.py#L426

If we don’t want to reveal to any automated scanners what software our servers are running, we should change this.

<img width="655" height="85" alt="image" src="https://github.com/user-attachments/assets/1b31d8af-2489-46ec-9c18-182015555f07" />

***

We can keep setting `SERVER_SOFTWARE` to `"None"` as well, since Gunicorn still defines it and might start using it again some day.

***

Both should be ignored by the type checker since the type hints for Gunicorn mark them as final:
https://github.com/python/typeshed/blob/f9e0f8ce9a933648022d618961693ee74cb8d4f4/stubs/gunicorn/gunicorn/__init__.pyi#L6

But we have a good reason for overriding them.
