### PR TITLE
Stop overriding `gunicorn.SERVER_SOFTWARE`

### DIFF
--- a/notifications_utils/gunicorn/defaults.py
+++ b/notifications_utils/gunicorn/defaults.py
@@ -5,7 +5,6 @@ import os
 import sys
 import traceback
 
-import gunicorn
 from gunicorn.glogging import CONFIG_DEFAULTS as LOGGING_CONFIG_DEFAULTS
 
 
@@ -73,4 +72,3 @@ def set_gunicorn_defaults(globals_dict: dict):
         worker_abort=worker_abort,
         worker_int=worker_int,
     )
-    gunicorn.SERVER_SOFTWARE = "None"


### PR DESCRIPTION
We don’t want to reveal to software scanning for vulnerabilities which version of Gunicorn we are using.

Since 20.1.0 Gunicorn doesn’t put the version number in the `Server:` HTTP header. See discussion for why here:
https://github.com/benoitc/gunicorn/issues/825

We were overriding `SERVER_SOFTWARE` not `SERVER`. Gunicorn now only looks at `SERVER` (this may have been different in the past): https://github.com/benoitc/gunicorn/blob/a8283bbf5e1416d0dd13f994f71ec2761988aeab/gunicorn/http/wsgi.py#L293

This means we have been serving a `Server: gunicorn` header (without the version) for ages now anyway:
<img width="655" height="85" alt="image" src="https://github.com/user-attachments/assets/1b31d8af-2489-46ec-9c18-182015555f07" />

It hasn’t come up in an IT health check which I think means it’s fine to continue doing so. Continuing to do so means we:
- can remove a line of code
- don’t need to contradict mypy which complains that `SERVER` is `Final`