### PR TITLE
Add mechanism for overriding `uv.toml` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 120.2.0
+
+* Adds the ability to specify per-project config for uv by creating an optional `uv-overrides.toml` file
+
 ## 120.1.0
 
 * `RedisClient`: add `redis_flakey` mechanism to avoid repeated timeouts

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "120.1.0"  # da1deafe23d042588e7116fd3a4b110b
+__version__ = "120.2.0"  # ee8e70ef43f9feb1db50237c166056d1

--- a/notifications_utils/version_tools/__init__.py
+++ b/notifications_utils/version_tools/__init__.py
@@ -10,6 +10,7 @@ import requirements
 
 requirements_file = pathlib.Path("requirements.in")
 frozen_requirements_file = pathlib.Path("requirements.txt")
+uv_overrides = pathlib.Path("uv-overrides.toml")
 repo_name = "alphagov/notifications-utils"
 config_files = {
     filename: importlib_resources.files("notifications_utils.version_tools").joinpath(filename).read_bytes()
@@ -117,6 +118,9 @@ def copy_config():
                 )
             )
             f.write(file_bytes)
+            if filename == "uv.toml" and uv_overrides.exists():
+                f.write(b"\n\n# This section was automatically copied from uv-overrides.toml\n\n")
+                f.write(uv_overrides.read_bytes())
 
 
 def get_semver_parts(version):


### PR DESCRIPTION
Sometimes we want to add per-repo config for `uv.toml`, for example being able to specify a package which should be excluded from the 7 day cooldown period.

This commit adds a mechanism for doing that, where each repo can optionally define a `uv-overrides.toml` file which gets appended to the copied `uv.toml` file.

When running `copy_config` it results in output like this:

<img width="853" height="437" alt="image" src="https://github.com/user-attachments/assets/d71bcbf2-5820-40c6-a873-f8190f089937" />
