### PR TITLE
Fix type ignore on import from `html` library

### DIFF
--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -1,10 +1,9 @@
 import math
 import re
 import string
-from html import (
-    _replace_charref,  # type: ignore (until mypy brings in https://github.com/python/typeshed/pull/15925)
-    escape,
-)
+
+# Type hint error ignored (until mypy brings in https://github.com/python/typeshed/pull/15925)
+from html import _replace_charref, escape  # type: ignore[attr-defined]
 from urllib.parse import quote
 
 import smartypants


### PR DESCRIPTION
Additional content after the `ignore` is invalid

Adding the specific error (`[attr-defined]`) so other errors will still be raised.

Also seems like the comments needs to be on the same line as the module to work.

<img width="928" height="87" alt="image" src="https://github.com/user-attachments/assets/e6456535-1aba-4174-8637-c38a744cf8fb" />
