### PR TITLE
Use `InsensitiveSet` to merge placeholders with personalisation keys

### DIFF
--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -122,15 +122,14 @@ class Template(ABC):
 
     @property
     def values(self) -> Mapping[str, Any]:
-        if hasattr(self, "_values"):
-            return self._values
-        return {}
+        return getattr(self, "_values", {})
 
     @values.setter
     def values(self, new_values: Mapping[str, Any] | None):
-        if not new_values:
-            self._values = {}
-        else:
+        with suppress(AttributeError):
+            del self._values
+
+        if new_values:
             self._values = InsensitiveDict(new_values).as_dict_with_keys(self.placeholders | new_values.keys())
 
     @property

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -131,11 +131,7 @@ class Template(ABC):
         if not new_values:
             self._values = {}
         else:
-            placeholders = InsensitiveDict.from_keys(self.placeholders)
-            self._values = InsensitiveDict(new_values).as_dict_with_keys(
-                self.placeholders
-                | {key for key in new_values.keys() if InsensitiveDict.make_key(key) not in placeholders.keys()}
-            )
+            self._values = InsensitiveDict(new_values).as_dict_with_keys(self.placeholders | new_values.keys())
 
     @property
     def placeholders(self) -> Set[str]:


### PR DESCRIPTION
We want a case-and-white-space-unique sequence of field names, giving preference to the format of keys as they appear in the template’s placeholders.

`InsensitiveSet` now gives us an elegant way of doing this.

This behaviour is already tested here:
https://github.com/alphagov/notifications-utils/blob/500a39050f718007f8888c6d8e95216dc67bf4aa/tests/test_base_template.py#L71-L82