### PR TITLE
Fix type hint for `SMSMessageTemplate.__str__`

### DIFF
--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -317,7 +317,7 @@ class BaseSMSTemplate(Template):
 
 
 class SMSMessageTemplate(BaseSMSTemplate):
-    def __str__(self):
+    def __str__(self: BaseSMSTemplate):
         return sms_encode(self.unsanitised_content)
 
 


### PR DESCRIPTION
We have to make it explicit that it can accept any subclass of `BaseSMSTemplate`, not just instances of itself, otherwise mypy gives this error:
> error: Argument 1 to `__str__` has incompatible type `BaseSMSTemplate`; expected `SMSMessageTemplate`

The reason for doing this is explained by this comment:
https://github.com/alphagov/notifications-utils/blob/59de875df660b9b32087921cf2f4fa13b329d94e/notifications_utils/template.py#L212-L219