### PR TITLE
add more type hints to `Template` and related classes

### DIFF
--- a/notifications_utils/take.py
+++ b/notifications_utils/take.py
@@ -1,3 +1,7 @@
+from collections.abc import Callable
+from typing import Self
+
+
 class Take(str):
-    def then(self, func, *args, **kwargs):
+    def then(self, func: Callable[..., str], *args, **kwargs) -> Self:
         return self.__class__(func(self, *args, **kwargs))

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -1,14 +1,15 @@
+import datetime
 import math
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, Set
+from collections.abc import Mapping, Sequence, Set
 from contextlib import suppress
-from datetime import UTC, datetime
 from functools import lru_cache
 from html import unescape
 from os import path
 from typing import Any, Literal
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
+from jinja2 import Template as jinja2_Template
 from markupsafe import Markup
 from ordered_set import OrderedSet
 from werkzeug.utils import cached_property
@@ -76,19 +77,19 @@ class Template(ABC):
     content: Any
     redact_missing_personalisation: bool
 
-    _template: dict[str, Any]
+    _template: Mapping[str, Any]
     _values: Mapping[str, Any]
 
     def __init__(
         self,
-        template: dict[str, Any],
+        template: Mapping[str, Any],
         values: Mapping[str, Any] | None = None,
         redact_missing_personalisation: bool = False,
     ):
-        if not isinstance(template, dict):
-            raise TypeError("Template must be a dict")
-        if values is not None and not isinstance(values, dict):
-            raise TypeError("Values must be a dict")
+        if not isinstance(template, Mapping):
+            raise TypeError("Template must be a Mapping")
+        if values is not None and not isinstance(values, Mapping):
+            raise TypeError("Values must be a Mapping")
         if template.get("template_type") != self.template_type:
             raise TypeError(
                 f"Cannot initialise {self.__class__.__name__} with {template.get('template_type')} template_type"
@@ -100,11 +101,11 @@ class Template(ABC):
         self.values = values
         self.redact_missing_personalisation = redact_missing_personalisation
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'{self.__class__.__name__}("{self.content}", {self.values})'
 
     @abstractmethod
-    def __str__(self):
+    def __str__(self) -> str:
         pass
 
     @property
@@ -141,21 +142,21 @@ class Template(ABC):
         return get_placeholders(self.content)
 
     @property
-    def missing_data(self):
+    def missing_data(self) -> Sequence[str]:
         return [placeholder for placeholder in self.placeholders if self.values.get(placeholder) is None]
 
     @property
-    def additional_data(self):
+    def additional_data(self) -> Set[str]:
         return self.values.keys() - self.placeholders
 
     def get_raw(self, key, default=None):
         return self._template.get(key, default)
 
     @property
-    def content_count(self):
+    def content_count(self) -> int:
         return len(self.content_with_placeholders_filled_in)
 
-    def is_message_empty(self):
+    def is_message_empty(self) -> bool:
         if not self.content:
             return True
 
@@ -167,20 +168,23 @@ class Template(ABC):
 
         return self.content_count == 0
 
-    def is_message_too_long(self):
+    def is_message_too_long(self) -> bool:
         return False
 
 
 class BaseSMSTemplate(Template):
-    template_type = "sms"
+    template_type: str = "sms"
+    _prefix: str | None
+    show_prefix: bool
+    sender: Any
 
     def __init__(
         self,
-        template,
-        values=None,
-        prefix=None,
-        show_prefix=True,
-        sender=None,
+        template: Mapping[str, Any],
+        values: Mapping[str, Any] | None = None,
+        prefix: str | None = None,
+        show_prefix: bool = True,
+        sender: Any = None,
     ):
         self.prefix = prefix
         self.show_prefix = show_prefix
@@ -188,11 +192,11 @@ class BaseSMSTemplate(Template):
         super().__init__(template, values)
 
     @property
-    def values(self):
+    def values(self) -> Mapping[str, Any]:
         return super().values
 
     @values.setter
-    def values(self, value):
+    def values(self, new_values: Mapping[str, Any] | None):
         # If we change the values of the template it’s possible the
         # content will have changed, so we need to reset the cached
         # count and content
@@ -205,10 +209,10 @@ class BaseSMSTemplate(Template):
         # the property object instead, which has the special method
         # fset, which invokes the setter it as if we were
         # assigning to it outside this class.
-        super(BaseSMSTemplate, type(self)).values.fset(self, value)
+        super(BaseSMSTemplate, type(self)).values.fset(self, new_values)  # type: ignore[attr-defined]
 
     @property
-    def content_with_placeholders_filled_in(self):
+    def content_with_placeholders_filled_in(self) -> str:
         # We always call SMSMessageTemplate.__str__ regardless of
         # subclass, to avoid any HTML formatting. SMS templates differ
         # in that the content can include the service name as a prefix.
@@ -219,15 +223,15 @@ class BaseSMSTemplate(Template):
         return SMSMessageTemplate.__str__(self)
 
     @property
-    def prefix(self):
+    def prefix(self) -> str | None:
         return self._prefix if self.show_prefix else None
 
     @prefix.setter
-    def prefix(self, value):
+    def prefix(self, value: str | None):
         self._prefix = value
 
     @cached_property
-    def content_count(self):
+    def content_count(self) -> int:
         """
         Return the number of characters in the message. Note that we don't distinguish between GSM and non-GSM
         characters at this point, as `get_sms_fragment_count` handles that separately.
@@ -238,7 +242,7 @@ class BaseSMSTemplate(Template):
         return len(self.unsanitised_content)
 
     @property
-    def content_count_without_prefix(self):
+    def content_count_without_prefix(self) -> int:
         # subtract 2 extra characters to account for the colon and the space,
         # added max zero in case the content is empty the __str__ methods strips the white space.
         if self.prefix:
@@ -247,7 +251,7 @@ class BaseSMSTemplate(Template):
             return self.content_count
 
     @property
-    def fragment_count(self):
+    def fragment_count(self) -> int:
         if self.non_gsm_characters:
             return 1 if self.content_count <= 70 else math.ceil(float(self.content_count) / 67)
 
@@ -257,7 +261,7 @@ class BaseSMSTemplate(Template):
         return 1 if character_count <= 160 else math.ceil(float(character_count) / 153)
 
     @property
-    def count_of_characters_above_previous_fragment_boundary(self):
+    def count_of_characters_above_previous_fragment_boundary(self) -> int:
         if self.fragment_count == 2:
             boundary = 70 if self.non_gsm_characters else 160
         else:
@@ -269,7 +273,7 @@ class BaseSMSTemplate(Template):
         return self.content_count + self.count_extended_gsm_chars - boundary
 
     @property
-    def non_gsm_characters(self):
+    def non_gsm_characters(self) -> Set[str]:
         """
         Returns a set of all the non gsm characters in a text. this doesn't include characters that we will
         downgrade (eg emoji, ellipsis, ñ, etc). This only includes welsh non gsm characters that will force
@@ -277,7 +281,7 @@ class BaseSMSTemplate(Template):
         """
         return OrderedSet(self.unsanitised_content) & SanitiseSMS.WELSH_NON_GSM_CHARACTERS
 
-    def is_message_too_long(self):
+    def is_message_too_long(self) -> bool:
         """
         Message is validated with out the prefix.
         We have decided to be lenient and let the message go over the character limit. The SMS provider will
@@ -287,18 +291,18 @@ class BaseSMSTemplate(Template):
         return self.content_count_without_prefix > SMS_CHAR_COUNT_LIMIT
 
     @property
-    def count_of_characters_above_limit(self):
+    def count_of_characters_above_limit(self) -> int:
         return max(0, self.content_count_without_prefix - SMS_CHAR_COUNT_LIMIT)
 
     @property
-    def count_extended_gsm_chars(self):
+    def count_extended_gsm_chars(self) -> int:
         return sum(map(self.unsanitised_content.count, SanitiseSMS.EXTENDED_GSM_CHARACTERS))
 
-    def is_message_empty(self):
+    def is_message_empty(self) -> bool:
         return self.content_count_without_prefix == 0
 
     @cached_property
-    def unsanitised_content(self):
+    def unsanitised_content(self) -> str:
         # This is faster to call than SMSMessageTemplate.__str__ if all
         # you need to know is how many characters are in the message
         if self.values:
@@ -317,19 +321,19 @@ class BaseSMSTemplate(Template):
 
 
 class SMSMessageTemplate(BaseSMSTemplate):
-    def __str__(self: BaseSMSTemplate):
+    def __str__(self: BaseSMSTemplate) -> str:
         return sms_encode(self.unsanitised_content)
 
 
 class SMSBodyPreviewTemplate(BaseSMSTemplate):
     def __init__(
         self,
-        template,
-        values=None,
+        template: Mapping[str, Any],
+        values: Mapping[str, Any] | None = None,
     ):
         super().__init__(template, values, show_prefix=False)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return Markup(
             Take(
                 Field(
@@ -348,19 +352,24 @@ class SMSBodyPreviewTemplate(BaseSMSTemplate):
 
 
 class SMSPreviewTemplate(BaseSMSTemplate):
-    jinja_template = template_env.get_template("sms_preview_template.jinja2")
+    jinja_template: jinja2_Template = template_env.get_template("sms_preview_template.jinja2")
+
+    show_recipient: bool
+    show_sender: bool
+    downgrade_non_sms_characters: bool
+    redact_missing_personalisation: bool
 
     def __init__(
         self,
-        template,
-        values=None,
-        prefix=None,
-        show_prefix=True,
-        sender=None,
-        show_recipient=False,
-        show_sender=False,
-        downgrade_non_sms_characters=True,
-        redact_missing_personalisation=False,
+        template: Mapping[str, Any],
+        values: Mapping[str, Any] | None = None,
+        prefix: str | None = None,
+        show_prefix: bool = True,
+        sender: Any = None,
+        show_recipient: bool = False,
+        show_sender: bool = False,
+        downgrade_non_sms_characters: bool = True,
+        redact_missing_personalisation: bool = False,
     ):
         self.show_recipient = show_recipient
         self.show_sender = show_sender
@@ -368,7 +377,7 @@ class SMSPreviewTemplate(BaseSMSTemplate):
         super().__init__(template, values, prefix, show_prefix, sender)
         self.redact_missing_personalisation = redact_missing_personalisation
 
-    def __str__(self):
+    def __str__(self) -> str:
         return Markup(
             self.jinja_template.render(
                 {
@@ -400,9 +409,18 @@ class SMSPreviewTemplate(BaseSMSTemplate):
 
 
 class BaseEmailTemplate(Template):
-    template_type = "email"
+    template_type: str = "email"
 
-    def __init__(self, template, values=None, unsubscribe_link=None, **kwargs):
+    unsubscribe_link: str | None
+    _subject: str
+
+    def __init__(
+        self,
+        template: Mapping[str, Any],
+        values: Mapping[str, Any] | None = None,
+        unsubscribe_link: str | None = None,
+        **kwargs,
+    ):
         self.unsubscribe_link = unsubscribe_link
         self._subject = template["subject"]
         super().__init__(template, values, **kwargs)
@@ -490,7 +508,7 @@ class BaseEmailTemplate(Template):
 
 
 class PlainTextEmailTemplate(BaseEmailTemplate):
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             Take(Field(self.content_with_unsubscribe_link, self.values, html="passthrough", markdown_lists=True))
             .then(unlink_govuk_escaped)
@@ -520,22 +538,31 @@ class PlainTextEmailTemplate(BaseEmailTemplate):
 
 
 class HTMLEmailTemplate(BaseEmailTemplate):
-    jinja_template = template_env.get_template("email_template.jinja2")
+    jinja_template: jinja2_Template = template_env.get_template("email_template.jinja2")
 
     PREHEADER_LENGTH_IN_CHARACTERS: int = 256
 
+    govuk_banner: bool
+    complete_html: bool
+    brand_logo: str | None
+    brand_text: str | None
+    brand_colour: str | None
+    brand_banner: bool
+    brand_alt_text: Any
+    rebrand: bool
+
     def __init__(
         self,
-        template,
-        values=None,
-        govuk_banner=True,
-        complete_html=True,
-        brand_logo=None,
-        brand_text=None,
-        brand_colour=None,
-        brand_banner=False,
+        template: Mapping[str, Any],
+        values: Mapping[str, Any] | None = None,
+        govuk_banner: bool = True,
+        complete_html: bool = True,
+        brand_logo: str | None = None,
+        brand_text: str | None = None,
+        brand_colour: str | None = None,
+        brand_banner: bool = False,
         brand_alt_text=None,
-        rebrand=False,
+        rebrand: bool = False,
         **kwargs,
     ):
         super().__init__(template, values, **kwargs)
@@ -549,7 +576,7 @@ class HTMLEmailTemplate(BaseEmailTemplate):
         self.rebrand = rebrand
 
     @property
-    def preheader(self):
+    def preheader(self) -> str:
         return " ".join(
             Take(
                 Field(
@@ -567,7 +594,7 @@ class HTMLEmailTemplate(BaseEmailTemplate):
             .split()
         )[: self.PREHEADER_LENGTH_IN_CHARACTERS].strip()
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.jinja_template.render(
             {
                 "subject": self.subject,
@@ -586,21 +613,31 @@ class HTMLEmailTemplate(BaseEmailTemplate):
 
 
 class BaseLetterTemplate(Template):
-    template_type = "letter"
-    max_page_count = LETTER_MAX_PAGE_COUNT
-    max_sheet_count = LETTER_MAX_PAGE_COUNT // 2
+    template_type: str = "letter"
+    max_page_count: int = LETTER_MAX_PAGE_COUNT
+    max_sheet_count: int = LETTER_MAX_PAGE_COUNT // 2
 
-    address_block = "\n".join(f"(({line.replace('_', ' ')}))" for line in address_lines_1_to_7_keys)
+    address_block: str = "\n".join(f"(({line.replace('_', ' ')}))" for line in address_lines_1_to_7_keys)
+
+    contact_block: str
+    _subject: str
+    _welsh_subject: str
+    welsh_content: str | None
+    admin_base_url: str
+    logo_file_name: str | None
+    language: Literal["english", "welsh"]
+    includes_first_page: bool
+    _date: datetime.date
 
     def __init__(
         self,
-        template,
-        values=None,
-        contact_block=None,
-        admin_base_url="http://localhost:6012",
-        logo_file_name=None,
-        redact_missing_personalisation=False,
-        date: datetime | None = None,
+        template: Mapping[str, Any],
+        values: Mapping[str, Any] | None = None,
+        contact_block: str | None = None,
+        admin_base_url: str = "http://localhost:6012",
+        logo_file_name: str | None = None,
+        redact_missing_personalisation: bool = False,
+        date: datetime.datetime | None = None,
         language: Literal["english", "welsh"] = "english",
         includes_first_page: bool = True,
     ):
@@ -622,7 +659,7 @@ class BaseLetterTemplate(Template):
         self.includes_first_page = includes_first_page
 
     @property
-    def subject(self):
+    def subject(self) -> str:
         return (
             Take(
                 Field(
@@ -637,7 +674,7 @@ class BaseLetterTemplate(Template):
         )
 
     @property
-    def placeholders(self):
+    def placeholders(self) -> Set[str]:
         return (
             get_placeholders(self.contact_block)
             | get_placeholders(self._welsh_subject)
@@ -647,7 +684,7 @@ class BaseLetterTemplate(Template):
         )
 
     @property
-    def postal_address(self):
+    def postal_address(self) -> PostalAddress:
         return PostalAddress.from_personalisation(InsensitiveDict(self.values))
 
     def has_qr_code_with_too_much_data(self) -> QrCodeTooLong | None:
@@ -675,7 +712,7 @@ class BaseLetterTemplate(Template):
         ).splitlines()
 
     @property
-    def _contact_block(self):
+    def _contact_block(self) -> str:
         return (
             Take(
                 Field(
@@ -697,8 +734,8 @@ class BaseLetterTemplate(Template):
         return self._date.strftime(f"%-d {month} %Y")
 
     @date.setter
-    def date(self, value: datetime | None):
-        self._date = utc_string_to_aware_gmt_datetime(value or datetime.now(UTC)).date()
+    def date(self, value: datetime.datetime | None):
+        self._date = utc_string_to_aware_gmt_datetime(value or datetime.datetime.now(datetime.UTC)).date()
 
     @property
     def _personalised_content(self) -> Field:
@@ -711,7 +748,7 @@ class BaseLetterTemplate(Template):
         )
 
     @property
-    def _message(self):
+    def _message(self) -> str:
         return (
             Take(self._personalised_content)
             .then(add_trailing_newline)
@@ -723,10 +760,10 @@ class BaseLetterTemplate(Template):
 
 
 class LetterPreviewTemplate(BaseLetterTemplate):
-    jinja_template = template_env.get_template("letter_pdf/preview.jinja2")
+    jinja_template: jinja2_Template = template_env.get_template("letter_pdf/preview.jinja2")
 
     @property
-    def render_params(self):
+    def render_params(self) -> Mapping[str, Any]:
         return {
             "admin_base_url": self.admin_base_url,
             "logo_file_name": self.logo_file_name,
@@ -741,23 +778,25 @@ class LetterPreviewTemplate(BaseLetterTemplate):
             "includes_first_page": self.includes_first_page,
         }
 
-    def __str__(self):
+    def __str__(self) -> str:
         return Markup(self.jinja_template.render(self.render_params))
 
 
 class LetterPrintTemplate(LetterPreviewTemplate):
-    jinja_template = template_env.get_template("letter_pdf/print.jinja2")
+    jinja_template: jinja2_Template = template_env.get_template("letter_pdf/print.jinja2")
+
+    includes_first_page: bool
 
     def __init__(
         self,
-        template,
-        values=None,
-        contact_block=None,
-        admin_base_url="http://localhost:6012",
-        logo_file_name=None,
-        redact_missing_personalisation=False,
-        date=None,
-        language="english",
+        template: Mapping[str, Any],
+        values: Mapping[str, Any] | None = None,
+        contact_block: str | None = None,
+        admin_base_url: str = "http://localhost:6012",
+        logo_file_name: str | None = None,
+        redact_missing_personalisation: bool = False,
+        date: datetime.datetime | None = None,
+        language: Literal["english", "welsh"] = "english",
         includes_first_page: bool = True,
     ):
         super().__init__(
@@ -773,11 +812,14 @@ class LetterPrintTemplate(LetterPreviewTemplate):
         self.includes_first_page = includes_first_page
 
     @property
-    def render_params(self):
-        return super().render_params | {"includes_first_page": self.includes_first_page}
+    def render_params(self) -> Mapping[str, Any]:
+        return {
+            **super().render_params,
+            "includes_first_page": self.includes_first_page,
+        }
 
 
-def do_nice_typography(value):
+def do_nice_typography(value: str) -> str:
     return (
         Take(value)
         .then(remove_whitespace_before_punctuation)

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -697,16 +697,18 @@ class BaseLetterTemplate(Template):
         return None
 
     @property
-    def _address_block(self):
+    def _address_block(self) -> Sequence[str]:
         if self.postal_address.has_enough_lines and not self.postal_address.has_too_many_lines:
             return self.postal_address.normalised_lines
 
-        if "address line 7" not in self.values and "postcode" in self.values:
-            self.values["address line 7"] = self.values["postcode"]
+        values = dict(self.values)
+
+        if "address line 7" not in values and "postcode" in values:
+            values["address line 7"] = values["postcode"]
 
         return Field(
             self.address_block,
-            self.values,
+            values,
             html="escape",
             with_brackets=False,
         ).splitlines()


### PR DESCRIPTION
This includes a change to `BaseLetterTemplate._address_block` to remove a weird side effect (noticed because we don't declare the `values` `Mapping` to be mutable).