### PR TITLE
Remove `InsensitiveDict.from_keys()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 121.0.0
+
+* Removes `InsensitiveDict.from_keys`
+* Removes the `override_duplicates` argument to `InsensitiveDict`
+
 ## 120.2.0
 
 * Adds the ability to specify per-project config for uv by creating an optional `uv-overrides.toml` file

--- a/notifications_utils/insensitive_dict.py
+++ b/notifications_utils/insensitive_dict.py
@@ -22,17 +22,6 @@ class InsensitiveDict[V](dict[str, V]):
             if overwrite_duplicates or key not in self:
                 self[key] = value
 
-    @classmethod
-    def from_keys(cls, keys):
-        """
-        This behaves like `dict.from_keys`, except:
-        - it normalises the keys to ignore case, whitespace, hypens and
-          underscores
-        - it stores the original, unnormalised key as the value of the
-          item so it can be retrieved later
-        """
-        return cls({key: key for key in keys}, overwrite_duplicates=False)
-
     def keys(self) -> Set[str]:  # type: ignore[override]
         return InsensitiveSet(self)
 

--- a/notifications_utils/insensitive_dict.py
+++ b/notifications_utils/insensitive_dict.py
@@ -17,10 +17,9 @@ class InsensitiveDict[V](dict[str, V]):
 
     KEY_TRANSLATION_TABLE: Mapping[int, None] = {ord(c): None for c in " _-"}
 
-    def __init__(self, row_dict, overwrite_duplicates=True):
+    def __init__(self, row_dict):
         for key, value in row_dict.items():
-            if overwrite_duplicates or key not in self:
-                self[key] = value
+            self[key] = value
 
     def keys(self) -> Set[str]:  # type: ignore[override]
         return InsensitiveSet(self)

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -116,10 +116,8 @@ class RecipientCSV:
             self._placeholders = list(value) + self.recipient_column_headers
         except TypeError:
             self._placeholders = self.recipient_column_headers
-        self.placeholders_as_column_keys = [InsensitiveDict.make_key(placeholder) for placeholder in self._placeholders]
-        self.recipient_column_headers_as_column_keys = [
-            InsensitiveDict.make_key(placeholder) for placeholder in self.recipient_column_headers
-        ]
+        self.placeholders_as_column_keys = InsensitiveSet(self._placeholders)
+        self.recipient_column_headers_as_column_keys = InsensitiveSet(self.recipient_column_headers)
 
     @property
     def has_errors(self) -> bool:
@@ -209,7 +207,7 @@ class RecipientCSV:
             for column_name, column_value in zip(column_headers, row[:length_of_widest_row], strict=False):
                 column_value = strip_and_remove_obscure_whitespace(column_value)
 
-                if InsensitiveDict.make_key(column_name) in self.recipient_column_headers_as_column_keys:
+                if column_name in self.recipient_column_headers_as_column_keys:
                     output_dict[column_name] = column_value or None
                 else:
                     insert_or_append_to_dict(output_dict, column_name, column_value or None)
@@ -313,7 +311,7 @@ class RecipientCSV:
         raw_recipient_column_headers = [
             InsensitiveDict.make_key(column_header)
             for column_header in self._raw_column_headers
-            if InsensitiveDict.make_key(column_header) in self.recipient_column_headers_as_column_keys
+            if column_header in self.recipient_column_headers_as_column_keys
         ]
 
         return OrderedSet(
@@ -359,7 +357,7 @@ class RecipientCSV:
         if self.is_address_column(key):
             return
 
-        if InsensitiveDict.make_key(key) in self.recipient_column_headers_as_column_keys:
+        if key in self.recipient_column_headers_as_column_keys:
             if value in [None, ""] or isinstance(value, list):
                 if self.duplicate_recipient_column_headers:
                     return None
@@ -378,7 +376,7 @@ class RecipientCSV:
             except InvalidRecipientError as error:
                 return str(error)
 
-        if InsensitiveDict.make_key(key) not in self.placeholders_as_column_keys:
+        if key not in self.placeholders_as_column_keys:
             return
 
         if value in [None, ""]:

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -13,7 +13,7 @@ from notifications_utils.formatters import (
     strip_all_whitespace,
     strip_and_remove_obscure_whitespace,
 )
-from notifications_utils.insensitive_dict import InsensitiveDict
+from notifications_utils.insensitive_dict import InsensitiveDict, InsensitiveSet
 from notifications_utils.interruptible_io import InterruptibleIterableList, interruptible_iter
 from notifications_utils.recipient_validation import email_address
 from notifications_utils.recipient_validation.errors import InvalidEmailError, InvalidPhoneError, InvalidRecipientError
@@ -33,7 +33,7 @@ first_column_headings = {
     "letter": [line.replace("_", " ") for line in address_lines_1_to_6_and_postcode_keys + [address_line_7_key]],
 }
 
-address_columns = InsensitiveDict.from_keys(first_column_headings["letter"])
+address_columns = InsensitiveSet(first_column_headings["letter"])
 
 
 class RecipientCSV:
@@ -295,7 +295,7 @@ class RecipientCSV:
 
     @property
     def column_headers_as_column_keys(self):
-        return InsensitiveDict.from_keys(self.column_headers).keys()
+        return InsensitiveSet(self.column_headers)
 
     @property
     def missing_column_headers(self):
@@ -333,8 +333,8 @@ class RecipientCSV:
     def has_recipient_columns(self) -> bool:
         if self.template_type == "letter":
             sets_to_check = [
-                InsensitiveDict.from_keys(address_lines_1_to_6_and_postcode_keys).keys(),
-                InsensitiveDict.from_keys(address_lines_1_to_7_keys).keys(),
+                InsensitiveSet(address_lines_1_to_6_and_postcode_keys),
+                InsensitiveSet(address_lines_1_to_7_keys),
             ]
         else:
             sets_to_check = [

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "120.2.0"  # ee8e70ef43f9feb1db50237c166056d1
+__version__ = "121.0.0"  # 66b54696423f7035abaf480a6e7a1016

--- a/tests/test_insensitive_dict.py
+++ b/tests/test_insensitive_dict.py
@@ -135,16 +135,8 @@ def test_insensitive_set_contains():
         assert key not in foobar
 
 
-@pytest.mark.parametrize(
-    "extra_args, expected_dict",
-    (
-        ({}, {"foo": 3}),
-        ({"overwrite_duplicates": True}, {"foo": 3}),
-        ({"overwrite_duplicates": False}, {"foo": 1}),
-    ),
-)
-def test_overwrite_duplicates(extra_args, expected_dict):
-    assert InsensitiveDict({"foo": 1, "FOO": 2, "f_o_o": 3}, **extra_args) == expected_dict
+def test_key_stored_as_normalised_format():
+    assert tuple(InsensitiveDict({"foo": 1, "FOO": 2, "f_o_o": 3}).items()) == (("foo", 3),)
 
 
 def test_insensitive_set_index():


### PR DESCRIPTION
This was mostly used by the internals of the old version of `InsensitiveSet`, or as a way of getting the behavior of `InsensitiveSet` before it existed.

Using `InsensitiveSet` directly is the better approach in all cases now.