### PR TITLE
Ignore monkey-patching-related type errors in `flask.py`, `eventlet.py` and `request_helper.py`

### DIFF
--- a/notifications_utils/eventlet.py
+++ b/notifications_utils/eventlet.py
@@ -139,7 +139,7 @@ if using_eventlet:
         if getattr(current_greenlet, "_thread_time_ns_atstart", None) is None:
             return None
 
-        return (time.thread_time_ns() - current_greenlet._thread_time_ns_atstart) + getattr(
+        return (time.thread_time_ns() - current_greenlet._thread_time_ns_atstart) + getattr(  # type: ignore[attr-defined]
             current_greenlet, "_thread_time_ns_accum", 0
         )
 
@@ -157,7 +157,7 @@ if using_eventlet:
         if getattr(current_greenlet, "_perf_counter_ns_atstart", None) is None:
             return None
 
-        return (time.perf_counter_ns() - current_greenlet._perf_counter_ns_atstart) + getattr(
+        return (time.perf_counter_ns() - current_greenlet._perf_counter_ns_atstart) + getattr(  # type: ignore[attr-defined]
             current_greenlet, "_perf_counter_ns_accum", 0
         )
 
@@ -177,8 +177,8 @@ if using_eventlet:
         """
         current_greenlet = greenlet.getcurrent()
 
-        current_greenlet._thread_time_ns_max_continuous = 0
-        current_greenlet._perf_counter_ns_max_continuous = 0
+        current_greenlet._thread_time_ns_max_continuous = 0  # type: ignore[attr-defined]
+        current_greenlet._perf_counter_ns_max_continuous = 0  # type: ignore[attr-defined]
 
     def greenlet_thread_time_ns_max_continuous() -> int | None:
         """
@@ -199,7 +199,7 @@ if using_eventlet:
         # the max continuous period could be the one we're currenly *in*
         current_continuous_ns = 0
         if getattr(current_greenlet, "_thread_time_ns_atstart", None) is not None:
-            current_continuous_ns = time.thread_time_ns() - current_greenlet._thread_time_ns_atstart
+            current_continuous_ns = time.thread_time_ns() - current_greenlet._thread_time_ns_atstart  # type: ignore[attr-defined]
 
         return max(current_continuous_ns, getattr(current_greenlet, "_thread_time_ns_max_continuous", None) or 0)
 
@@ -222,7 +222,7 @@ if using_eventlet:
         # the max continuous period could be the one we're currenly *in*
         current_continuous_ns = 0
         if getattr(current_greenlet, "_perf_counter_ns_atstart", None) is not None:
-            current_continuous_ns = time.perf_counter_ns() - current_greenlet._perf_counter_ns_atstart
+            current_continuous_ns = time.perf_counter_ns() - current_greenlet._perf_counter_ns_atstart  # type: ignore[attr-defined]
 
         return max(current_continuous_ns, getattr(current_greenlet, "_perf_counter_ns_max_continuous", None) or 0)
 

--- a/notifications_utils/logging/flask.py
+++ b/notifications_utils/logging/flask.py
@@ -170,7 +170,7 @@ def init_app(app, extra_filters: Sequence[logging.Filter] = ()):
         context = {
             "status": response.status_code,
             "request_time": (
-                (_perf_counter_ns - request.before_request_perf_counter_ns) * _ns_per_s   # type: ignore[attr-defined]
+                (_perf_counter_ns - request.before_request_perf_counter_ns) * _ns_per_s  # type: ignore[attr-defined]
                 if getattr(request, "before_request_perf_counter_ns", None) is not None
                 else None
             ),

--- a/notifications_utils/logging/flask.py
+++ b/notifications_utils/logging/flask.py
@@ -136,11 +136,11 @@ def init_app(app, extra_filters: Sequence[logging.Filter] = ()):
     def before_request():
         # annotating this onto request instead of flask.g as it probably shouldn't
         # be inheritable from a request-less application context
-        request.before_request_perf_counter_ns = perf_counter_ns()
-        request.before_request_thread_time_ns = thread_time_ns()
+        request.before_request_perf_counter_ns = perf_counter_ns()  # type: ignore[attr-defined]
+        request.before_request_thread_time_ns = thread_time_ns()  # type: ignore[attr-defined]
 
         if app.config["NOTIFY_EVENTLET_STATS"]:
-            request.before_request_greenlet_context_switch_count = utils_eventlet.greenlet_context_switch_count()
+            request.before_request_greenlet_context_switch_count = utils_eventlet.greenlet_context_switch_count()  # type: ignore[attr-defined]
             utils_eventlet.reset_greenlet_stats()
 
         # emit an early log message to record that the request was received by the app
@@ -170,12 +170,12 @@ def init_app(app, extra_filters: Sequence[logging.Filter] = ()):
         context = {
             "status": response.status_code,
             "request_time": (
-                (_perf_counter_ns - request.before_request_perf_counter_ns) * _ns_per_s
+                (_perf_counter_ns - request.before_request_perf_counter_ns) * _ns_per_s   # type: ignore[attr-defined]
                 if getattr(request, "before_request_perf_counter_ns", None) is not None
                 else None
             ),
             "request_cpu_time": (
-                (_thread_time_ns - request.before_request_thread_time_ns) * _ns_per_s
+                (_thread_time_ns - request.before_request_thread_time_ns) * _ns_per_s  # type: ignore[attr-defined]
                 if getattr(request, "before_request_thread_time_ns", None) is not None
                 else None
             ),

--- a/notifications_utils/request_helper.py
+++ b/notifications_utils/request_helper.py
@@ -123,10 +123,20 @@ class ResponseHeaderMiddleware:
             lower_existing_header_names = frozenset(name.lower() for name, value in headers)
 
             if self.trace_id_header not in lower_existing_header_names:
-                headers.append((self.trace_id_header, str(request.trace_id)))
+                headers.append(
+                    (
+                        self.trace_id_header,
+                        str(request.trace_id),  # type: ignore[attr-defined]
+                    )
+                )
 
             if self.span_id_header not in lower_existing_header_names:
-                headers.append((self.span_id_header, str(request.span_id)))
+                headers.append(
+                    (
+                        self.span_id_header,
+                        str(request.span_id),  # type: ignore[attr-defined]
+                    )
+                )
 
             return start_response(status, headers, exc_info)
 


### PR DESCRIPTION
We have a good reason for defining new attributes on the request object:
https://github.com/alphagov/notifications-utils/blob/0352d2073844d62c35f23a067de73d58fb63a60e/notifications_utils/logging/flask.py#L137-L138

Howecer the type checker is unhappy about this because these aren’t know attributes of a Flask request. So the best we can do is just ignore them.

***

There are similar examples of monkey patching in `eventlet.py` and `request_helper.py` which we ignore in the same way.