### PR TITLE
Make `_MicrosecondAddingFormatterMixin` not a mixin

### DIFF
--- a/notifications_utils/logging/formatting.py
+++ b/notifications_utils/logging/formatting.py
@@ -7,7 +7,7 @@ LOG_FORMAT = '%(asctime)s %(app_name)s %(name)s %(levelname)s %(request_id)s "%(
 TIME_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
 
-class _MicrosecondAddingFormatterMixin:
+class _MicrosecondAddingFormatter(logging.Formatter):
     """
     Appends a `.` and then a 6-digit number of microseconds to whatever
     the superclass' `.formatTime(...)` returns.
@@ -23,11 +23,11 @@ class _MicrosecondAddingFormatterMixin:
         return f"{formatted}.{int((record.created - int(record.created)) * 1e6):06}"
 
 
-class Formatter(_MicrosecondAddingFormatterMixin, logging.Formatter):
+class Formatter(_MicrosecondAddingFormatter):
     pass
 
 
-class JSONFormatter(_MicrosecondAddingFormatterMixin, BaseJSONFormatter):
+class JSONFormatter(BaseJSONFormatter, _MicrosecondAddingFormatter):
     def process_log_record(self, log_record):
         rename_map = {
             "asctime": "time",


### PR DESCRIPTION
Mypy gives this error:
> error: `formatTime` undefined in superclass  [misc]

Mixins are hard to type hint.

Internet says:
> Typically, a mixin class is designed to be used with one specific base class. In such cases, it’s best to simply declare the mixin as a subclass of the base class, making it a regular subclass, even if it’s still not intended to be used directly.

– https://adamj.eu/tech/2025/05/01/python-type-hints-mixin-classes/

`BaseJsonFormatter` is a subclass of `logging.Formatter`: https://github.com/nhairs/python-json-logger/blob/01cb83c1be1f26eb9f75cd3233b270fc06dd7962/src/pythonjsonlogger/core.py#L108C25-L108C42

Our `Formatter` is also a subclass of `logging.Formatter`.

So we don’t need to use a mixin.