### PR TITLE
Ignore type errors in `eventlet.py`

### DIFF
--- a/notifications_utils/eventlet.py
+++ b/notifications_utils/eventlet.py
@@ -247,8 +247,8 @@ if using_eventlet:
         return info
 
 else:
-    EventletTimeoutMiddleware = None
-    account_greenlet_times = None
+    EventletTimeoutMiddleware = None  # type: ignore
+    account_greenlet_times = None  # type: ignore[assignment]
 
     greenlet_thread_time_ns = lambda: None  # noqa
     greenlet_perf_counter_ns = lambda: None  # noqa


### PR DESCRIPTION
You can’t reassign a value to a type after it’s been defined because that changes the type.

In reality this can’t happen because it’s guarded by an `if` block. But the type checker isn’t smart enough to figure this out (or isn’t happy that we’re doing something slightly weird).

Anyway this is another example of monkey patching that I think is ok to ignore.