### PR TITLE
`InsensitiveDict`: repimplement using nested dict instead of inheritance 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 122.0.0
+
+* Reimplement `InsensitiveDict` as an implementation of a generic `MutableMapping` rather than inheriting directly from `dict`. This allows us to avoid some typing complications, but means some `dict`-only methods and operators are not implemented. However, all the generic `MutableMapping` methods should behave "correctly" (i.e. normalise keys), including `update` and `setdefault`, which the previous implementation ignored.
+
 ## 121.0.0
 
 * Removes `InsensitiveDict.from_keys`

--- a/notifications_utils/field.py
+++ b/notifications_utils/field.py
@@ -1,5 +1,5 @@
 import re
-from collections.abc import Callable, Mapping, Sequence, Set
+from collections.abc import Callable, Mapping, Sequence
 from typing import Any, Literal, Self
 
 from markupsafe import Markup
@@ -74,16 +74,16 @@ class Field:
     placeholder_tag_redacted: str = "<span class='placeholder-redacted'>hidden</span>"
 
     content: str
-    sanitizer: Callable[[str], str]
+    sanitizer: Callable[[str | None], str | None]
     markdown_lists: bool
     redact_missing_personalisation: bool
 
-    _values: Mapping[str, Any]
+    _values: InsensitiveDict[str | None, Any]
 
     def __init__(
         self,
         content: str,
-        values: Mapping[str, Any] | None = None,
+        values: Mapping[str | None, Any] | None = None,
         with_brackets: bool = True,
         html: Literal["escape", "passthrough"] = "escape",
         markdown_lists: bool = False,
@@ -116,12 +116,14 @@ class Field:
         return str(self).splitlines()
 
     @property
-    def values(self) -> Mapping[str, Any]:
+    def values(self) -> InsensitiveDict[str | None, Any]:
         return self._values
 
     @values.setter
-    def values(self, new_values: Mapping[str, Any] | None):
-        self._values = InsensitiveDict({self.sanitizer(k): v for k, v in new_values.items()}) if new_values else {}
+    def values(self, new_values: Mapping[str | None, Any] | None):
+        self._values = (
+            InsensitiveDict({self.sanitizer(k): v for k, v in new_values.items()}) if new_values else InsensitiveDict()
+        )
 
     def format_match(self, match: re.Match) -> str:
         return self.format_placeholder(Placeholder.from_match(match))
@@ -169,21 +171,21 @@ class Field:
 
     @property
     def _raw_formatted(self) -> str:
-        return re.sub(self.placeholder_pattern, self.format_match, self.sanitizer(self.content))
+        return re.sub(self.placeholder_pattern, self.format_match, self.sanitizer(self.content) or "")
 
     @property
     def formatted(self) -> str:
         return Markup(self._raw_formatted)
 
     @property
-    def placeholders(self) -> Set[str]:
+    def placeholders(self) -> InsensitiveSet[str]:
         if not self.content or "(" not in self.content:
             return InsensitiveSet()
         return InsensitiveSet(Placeholder(body).name for body in re.findall(self.placeholder_pattern, self.content))
 
     @property
     def replaced(self) -> str:
-        return re.sub(self.placeholder_pattern, self.replace_match, self.sanitizer(self.content))
+        return re.sub(self.placeholder_pattern, self.replace_match, self.sanitizer(self.content) or "")
 
 
 class PlainTextField(Field):

--- a/notifications_utils/insensitive_dict.py
+++ b/notifications_utils/insensitive_dict.py
@@ -169,10 +169,15 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, Iterable):
-            return False
+            return NotImplemented
 
         if not isinstance(other, Set):
+            # note order-sensitive
             return tuple(self._inner.keys()) == tuple(self.make_key(item) for item in other)
+
+        # and add a shortcut for others of identical type
+        if type(self) is type(other):  # type comparison deliberately strict
+            return self._inner.keys() == other._inner.keys()
 
         return super().__eq__(other)
 

--- a/notifications_utils/insensitive_dict.py
+++ b/notifications_utils/insensitive_dict.py
@@ -65,8 +65,9 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
 
     @staticmethod
     @abstractmethod
-    def make_key(original_key: T) -> T:
-        return original_key
+    def make_key(original_key: Any) -> T:
+        # a real implementation needs to raise TypeError if type is unworkable
+        return original_key  # type: ignore
 
     def __init__(self, it: Iterable[T] | None = None, /):
         self._inner = {}

--- a/notifications_utils/insensitive_dict.py
+++ b/notifications_utils/insensitive_dict.py
@@ -314,7 +314,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
     def remove(self, item: T):
         del self._inner[self.make_key(item)]
 
-    def pop(self):
+    def pop(self) -> T:
         try:
             return self._inner.pop(next(reversed(self._inner)))
         except StopIteration as e:

--- a/notifications_utils/insensitive_dict.py
+++ b/notifications_utils/insensitive_dict.py
@@ -1,62 +1,39 @@
 from abc import ABCMeta, abstractmethod
-from collections.abc import Iterable, Iterator, Mapping, MutableSet, Sequence, Set
+from collections.abc import (
+    ItemsView,
+    Iterable,
+    Iterator,
+    Mapping,
+    MutableMapping,
+    MutableSet,
+    Sequence,
+    Set,
+    ValuesView,
+)
 from functools import lru_cache
 from itertools import chain, islice
-from typing import Self, overload
+from typing import Any, Self, overload
+
+_NORMALISE_STR_NONE_TRANSLATION_TABLE: Mapping[int, None] = {ord(c): None for c in " _-"}
 
 
-class InsensitiveDict[V](dict[str, V]):
-    """
-    `InsensitiveDict` behaves like an ordered dictionary, except it normalises
-    case, whitespace, hypens and underscores in keys.
+@overload
+def _normalise_str_none(original_key: str) -> str: ...
 
-    In other words,
-    InsensitiveDict({'FIRST_NAME': 'example'}) == InsensitiveDict({'first name': 'example'})
-    >>> True
-    """
 
-    KEY_TRANSLATION_TABLE: Mapping[int, None] = {ord(c): None for c in " _-"}
+@overload
+def _normalise_str_none(original_key: None) -> None: ...
 
-    def __init__(self, row_dict):
-        for key, value in row_dict.items():
-            self[key] = value
 
-    def keys(self) -> Set[str]:  # type: ignore[override]
-        return InsensitiveSet(self)
+@lru_cache(maxsize=1_024, typed=False)  # Corresponds to 1,000 column limit when reading Excel files
+def _normalise_str_none(original_key: Any) -> str | None:
+    if not isinstance(original_key, str | None):
+        raise TypeError
 
-    def __getitem__(self, key: str) -> V:
-        return super().__getitem__(self.make_key(key))
+    if original_key is None:
+        return None
 
-    def __setitem__(self, key: str, value: V):
-        super().__setitem__(self.make_key(key), value)
-
-    def __contains__(self, key) -> bool:
-        return super().__contains__(self.make_key(key))
-
-    @overload
-    def get(self, key: str, default: None = ...) -> V | None: ...
-
-    @overload
-    def get(self, key: str, default: V = ...) -> V: ...
-
-    @overload
-    def get[X](self, key: str, default: X = ...) -> V | X: ...
-
-    def get[X](self, key: str, default: V | X | None = None) -> V | X | None:
-        return self[key] if key in self else default
-
-    def copy(self) -> Self:
-        return self.__class__(super().copy())
-
-    def as_dict_with_keys(self, keys: Iterable[str]) -> dict[str, V | None]:
-        return {key: self.get(key) for key in keys}
-
-    @staticmethod
-    @lru_cache(maxsize=1_024, typed=False)  # Corresponds to 1,000 column limit when reading Excel files
-    def make_key(original_key: str) -> str:
-        if original_key is None:
-            return None
-        return original_key.translate(InsensitiveDict.KEY_TRANSLATION_TABLE).lower()
+    return original_key.translate(_NORMALISE_STR_NONE_TRANSLATION_TABLE).lower()
 
 
 class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
@@ -396,7 +373,121 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
         return f"{self.__class__.__name__}({list(self._inner.values())!r})"
 
 
-class InsensitiveSet(AbstractInsensitiveSet[str]):
+class InsensitiveSet[T: str | None](AbstractInsensitiveSet[T]):
     @staticmethod
-    def make_key(original_key: str) -> str:
-        return InsensitiveDict.make_key(original_key)
+    def make_key(original_key: Any) -> T:
+        return _normalise_str_none(original_key)
+
+
+class AbstractInsensitiveDict[K, V](MutableMapping[K, V], metaclass=ABCMeta):
+    __slots__ = ("_inner",)
+    _inner: dict[K, V]
+
+    @staticmethod
+    @abstractmethod
+    def make_key(original_key: Any) -> K:
+        # a real implementation needs to raise TypeError if type is unworkable
+        return original_key  # type: ignore
+
+    def __init__(self, initial: Mapping[K, V] | Iterable[tuple[K, V]] = (), /):
+        self._inner = {}
+        self.update(initial)
+
+    # Mapping[K, V]
+
+    def __getitem__(self, key: K) -> V:
+        return self._inner.__getitem__(self.make_key(key))
+
+    def __iter__(self) -> Iterator[K]:
+        return self._inner.__iter__()
+
+    def __len__(self) -> int:
+        return self._inner.__len__()
+
+    # MutableMapping[K, V]
+
+    def __setitem__(self, key: K, value: V):
+        self._inner.__setitem__(self.make_key(key), value)
+
+    def __delitem__(self, key: K):
+        self._inner.__delitem__(self.make_key(key))
+
+    # Accelerate Mapping[K, V]
+
+    def __contains__(self, key: Any) -> bool:
+        try:
+            final_key = self.make_key(key)
+        except TypeError:
+            return False
+
+        return self._inner.__contains__(final_key)
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Mapping):
+            return NotImplemented
+
+        other_dict = other if type(self) is type(other) else type(self)(other)  # type comparison deliberately strict
+
+        return self._inner.__eq__(other_dict._inner)
+
+    def items(self) -> ItemsView[K, V]:
+        return self._inner.items()
+
+    def values(self) -> ValuesView[V]:
+        return self._inner.values()
+
+    @abstractmethod
+    def keys(self) -> AbstractInsensitiveSet[K]:  # type: ignore[override]
+        ...
+
+    @overload
+    def get(self, key: K, default: None = ..., /) -> V | None: ...
+
+    @overload
+    def get(self, key: K, default: V = ..., /) -> V: ...
+
+    @overload
+    def get[X](self, key: K, default: X = ..., /) -> V | X: ...
+
+    def get[X](self, key: K, default: V | X | None = None, /) -> V | X | None:
+        try:
+            final_key = self.make_key(key)
+        except TypeError:
+            return default
+
+        return self._inner.get(final_key, default)
+
+    # Accelerate MutableMapping[K, V]
+
+    def clear(self):
+        self._inner.clear()
+
+    def update(self, other: Mapping[K, V] | Iterable[tuple[K, V]], /, **kwargs: V) -> None:  # type: ignore[override]
+        if type(self) is type(other):  # type comparison deliberately strict
+            self._inner.update(other._inner)
+        else:
+            it = other.items() if isinstance(other, Mapping) else other
+            for k, v in it:
+                self[k] = v
+
+        for k, v in kwargs.items():
+            self[k] = v  # type: ignore[index]
+
+    # bonus methods
+
+    def as_dict_with_keys(self, keys: Iterable[K]) -> dict[K, V | None]:
+        return {key: self.get(key) for key in keys}
+
+    def copy(self) -> Self:
+        other = type(self)()
+        other._inner = self._inner.copy()
+        return other
+
+
+class InsensitiveDict[K: str | None, V](AbstractInsensitiveDict[K, V]):
+    @staticmethod
+    def make_key(original_key: Any) -> K:
+        return _normalise_str_none(original_key)
+
+    def keys(self) -> InsensitiveSet[K]:  # type: ignore[override]
+        return InsensitiveSet(self)

--- a/notifications_utils/insensitive_dict.py
+++ b/notifications_utils/insensitive_dict.py
@@ -212,7 +212,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
 
         return self._inner.keys() >= other_set._inner.keys()
 
-    def __and__(self, other: Iterable) -> Self:
+    def __and__(self, other: Iterable[T]) -> Self:
         if not isinstance(other, Iterable):
             return NotImplemented
 
@@ -220,7 +220,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
 
         return type(self)._from_inner_pairs((k, v) for k, v in self._inner.items() if k in other_set._inner)
 
-    def __rand__(self, other: Iterable) -> Self:
+    def __rand__(self, other: Iterable[T]) -> Self:
         if not isinstance(other, Iterable):
             return NotImplemented
 
@@ -230,7 +230,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
         # ensure the un-normalised values come from the RHS
         return type(self)(item for item in other if item in self)
 
-    def __or__(self, other: Iterable) -> Self:
+    def __or__(self, other: Iterable[T]) -> Self:  # type: ignore[override]
         if not isinstance(other, Iterable):
             return NotImplemented
 
@@ -244,7 +244,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
 
         return new_set
 
-    def __ror__(self, other: Iterable) -> Self:
+    def __ror__(self, other: Iterable[T]) -> Self:
         if not isinstance(other, Iterable):
             return NotImplemented
 
@@ -257,7 +257,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
 
         return new_set
 
-    def isdisjoint(self, other: Iterable) -> bool:
+    def isdisjoint(self, other: Iterable[T]) -> bool:
         if not isinstance(other, Iterable):
             return NotImplemented
 
@@ -266,7 +266,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
 
         return not any(item in self for item in other)
 
-    def __sub__(self, other: Iterable) -> Self:
+    def __sub__(self, other: Iterable[T]) -> Self:
         if not isinstance(other, Iterable):
             return NotImplemented
 
@@ -274,7 +274,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
 
         return type(self)._from_inner_pairs((k, v) for k, v in self._inner.items() if k not in other_set._inner)
 
-    def __rsub__(self, other: Iterable) -> Self:
+    def __rsub__(self, other: Iterable[T]) -> Self:
         if not isinstance(other, Iterable):
             return NotImplemented
 
@@ -283,7 +283,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
 
         return type(self)(item for item in other if item not in self)
 
-    def __xor__(self, other: Iterable) -> Self:
+    def __xor__(self, other: Iterable[T]) -> Self:  # type: ignore[override]
         if not isinstance(other, Iterable):
             return NotImplemented
 
@@ -296,7 +296,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
             )
         )
 
-    def __rxor__(self, other: Iterable) -> Self:
+    def __rxor__(self, other: Iterable[T]) -> Self:
         if not isinstance(other, Iterable):
             return NotImplemented
 
@@ -323,7 +323,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
     def clear(self):
         self._inner.clear()
 
-    def __iand__(self, other: Iterable) -> Self:
+    def __iand__(self, other: Iterable[T]) -> Self:
         if not isinstance(other, Iterable):
             return NotImplemented
 
@@ -335,7 +335,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
 
         return self
 
-    def __ixor__(self, other: Iterable) -> Self:
+    def __ixor__(self, other: Iterable[T]) -> Self:  # type: ignore[override]
         if not isinstance(other, Iterable):
             return NotImplemented
 
@@ -348,7 +348,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
 
         return self
 
-    def __isub__(self, other: Iterable) -> Self:
+    def __isub__(self, other: Iterable[T]) -> Self:
         if not isinstance(other, Iterable):
             return NotImplemented
 
@@ -358,7 +358,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
 
         return super().__isub__(other)  # type: ignore[arg-type]
 
-    def __ior__(self, other: Iterable) -> Self:
+    def __ior__(self, other: Iterable[T]) -> Self:  # type: ignore[override]
         if not isinstance(other, Iterable):
             return NotImplemented
 
@@ -369,22 +369,22 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
 
     # only included because old InsensitiveSet implemented them (note builtins.set accepts *others)
 
-    def issubset(self, other: Set) -> bool:
+    def issubset(self, other: Set[T]) -> bool:
         return self <= other
 
-    def issuperset(self, other: Set) -> bool:
+    def issuperset(self, other: Set[T]) -> bool:
         return self >= other
 
-    def intersection(self, other: Iterable) -> Self:
+    def intersection(self, other: Iterable[T]) -> Self:
         return self & other
 
-    def difference(self, other: Iterable) -> Self:
+    def difference(self, other: Iterable[T]) -> Self:
         return self - other
 
-    def union(self, other: Iterable) -> Self:
+    def union(self, other: Iterable[T]) -> Self:
         return self | other
 
-    def symmetric_difference(self, other: Iterable) -> Self:
+    def symmetric_difference(self, other: Iterable[T]) -> Self:
         return self ^ other
 
     # generally helpful

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -1,10 +1,11 @@
 import csv
 import sys
+from collections.abc import Callable, Container, Iterable, Iterator, Mapping, MutableMapping, Sequence
 from contextlib import suppress
 from functools import lru_cache
 from io import StringIO
-from itertools import islice
-from typing import cast
+from itertools import chain, islice
+from typing import Any, cast
 
 from ordered_set import OrderedSet
 from werkzeug.utils import cached_property
@@ -44,6 +45,11 @@ class RecipientCSV:
     rows_list_iteration_interruptible_every: int = 512
 
     _template: Template
+    template_type: str
+    recipient_column_headers_as_column_keys: InsensitiveSet[str]
+    placeholders_as_column_keys: InsensitiveSet[str]
+    _guestlist: Sequence[Any]
+    _placeholders: Sequence[Any]
 
     def __init__(
         self,
@@ -83,7 +89,7 @@ class RecipientCSV:
         return self.rows[requested_index]
 
     @property
-    def guestlist(self):
+    def guestlist(self) -> Sequence[Any]:
         return self._guestlist
 
     @guestlist.setter
@@ -107,7 +113,7 @@ class RecipientCSV:
         self.placeholders = self._template.placeholders
 
     @property
-    def placeholders(self):
+    def placeholders(self) -> Sequence[Any]:
         return self._placeholders
 
     @placeholders.setter
@@ -132,7 +138,7 @@ class RecipientCSV:
         )  # `or` is 3x faster than using `any()` here
 
     @property
-    def allowed_to_send_to(self):
+    def allowed_to_send_to(self) -> bool:
         if self.template_type == "letter":
             return True
         if not self.guestlist:
@@ -140,18 +146,18 @@ class RecipientCSV:
         return all(allowed_to_send_to(row.recipient, self.guestlist) for row in self.rows)
 
     @cached_property
-    def international_sms_count(self):
+    def international_sms_count(self) -> int:
         if self.template_type != "sms":
             return 0
         return sum(self._international_sms_count_generator())
 
-    def _international_sms_count_generator(self):
+    def _international_sms_count_generator(self) -> Iterator[bool]:
         for row in self.rows:
             with suppress(InvalidPhoneError):
                 yield not get_phone_number_object(row.recipient).is_uk_phone_number()
 
     @property
-    def more_international_sms_than_can_send(self):
+    def more_international_sms_than_can_send(self) -> bool:
         if self.template_type != "sms":
             return False
         return self.international_sms_count > max(self.remaining_international_sms_messages, 0)
@@ -164,7 +170,7 @@ class RecipientCSV:
         return self.rows_as_list
 
     @property
-    def _rows(self):
+    def _rows(self) -> Iterator[Sequence[str]]:
         return csv.reader(
             StringIO(self.file_data.strip()),
             quoting=csv.QUOTE_MINIMAL,
@@ -172,18 +178,18 @@ class RecipientCSV:
         )
 
     @property
-    def _first_empty_column_indices(self):
+    def _first_empty_column_indices(self) -> Iterator[int]:
         for row_index, row in enumerate(self._rows):
             if row_index == 0:
                 continue  # skip the header row
             yield max((column_index for column_index, column in enumerate(row) if column), default=-1) + 1
 
-    def get_rows(self):
+    def get_rows(self) -> "Iterator[Row | None]":
         index_of_first_empty_column = max(self._first_empty_column_indices, default=0)
         headers_of_populated_columns = self._raw_column_headers[:index_of_first_empty_column]
         headers_of_empty_columns = self._raw_column_headers[index_of_first_empty_column:]
         unique_headers_of_empty_columns = list(OrderedSet(headers_of_empty_columns) - set(headers_of_populated_columns))
-        column_headers = headers_of_populated_columns + unique_headers_of_empty_columns
+        column_headers = tuple(chain(headers_of_populated_columns, unique_headers_of_empty_columns))
         length_of_column_headers = len(column_headers)
         length_of_widest_row = max(index_of_first_empty_column, length_of_column_headers)
 
@@ -202,7 +208,7 @@ class RecipientCSV:
                 yield None
                 continue
 
-            output_dict = {}
+            output_dict: dict[str | None, Any] = {}
 
             for column_name, column_value in zip(column_headers, row[:length_of_widest_row], strict=False):
                 column_value = strip_and_remove_obscure_whitespace(column_value)
@@ -233,56 +239,56 @@ class RecipientCSV:
             )
 
     @property
-    def more_rows_than_can_send(self):
+    def more_rows_than_can_send(self) -> bool:
         return len(self) > self.remaining_messages
 
     @property
-    def too_many_rows(self):
+    def too_many_rows(self) -> bool:
         return len(self) > self.max_rows
 
     @property
-    def initial_rows(self):
+    def initial_rows(self) -> "Iterator[Row | None]":
         return islice(self.rows, self.max_initial_rows_shown)
 
     @property
-    def displayed_rows(self):
+    def displayed_rows(self) -> "Iterator[Row | None]":
         if any(self.rows_with_errors) and not self.missing_column_headers:
             return self.initial_rows_with_errors
         return self.initial_rows
 
-    def _filter_rows(self, attr):
+    def _filter_rows(self, attr) -> "Iterator[Row]":
         return (row for row in self.rows if row and getattr(row, attr))
 
     @property
-    def rows_with_errors(self):
+    def rows_with_errors(self) -> "Iterator[Row]":
         return self._filter_rows("has_error")
 
     @property
-    def rows_with_bad_recipients(self):
+    def rows_with_bad_recipients(self) -> "Iterator[Row]":
         return self._filter_rows("has_bad_recipient")
 
     @property
-    def rows_with_missing_data(self):
+    def rows_with_missing_data(self) -> "Iterator[Row]":
         return self._filter_rows("has_missing_data")
 
     @property
-    def rows_with_message_too_long(self):
+    def rows_with_message_too_long(self) -> "Iterator[Row]":
         return self._filter_rows("message_too_long")
 
     @property
-    def rows_with_empty_message(self):
+    def rows_with_empty_message(self) -> "Iterator[Row]":
         return self._filter_rows("message_empty")
 
     @property
-    def rows_with_bad_qr_codes(self):
+    def rows_with_bad_qr_codes(self) -> "Iterator[Row]":
         return self._filter_rows("qr_code_too_long")
 
     @property
-    def initial_rows_with_errors(self):
+    def initial_rows_with_errors(self) -> "Iterator[Row]":
         return islice(self.rows_with_errors, self.max_errors_shown)
 
     @cached_property
-    def _raw_column_headers(self):
+    def _raw_column_headers(self) -> Sequence[str]:
         for row in self._rows:
             return row
         return []
@@ -292,7 +298,7 @@ class RecipientCSV:
         return list(OrderedSet(self._raw_column_headers))
 
     @property
-    def column_headers_as_column_keys(self):
+    def column_headers_as_column_keys(self) -> InsensitiveSet[str]:
         return InsensitiveSet(self.column_headers)
 
     @property
@@ -308,7 +314,7 @@ class RecipientCSV:
 
     @cached_property
     def duplicate_recipient_column_headers(self):
-        raw_recipient_column_headers = [
+        raw_recipient_column_headers: list[str] = [
             InsensitiveDict.make_key(column_header)
             for column_header in self._raw_column_headers
             if column_header in self.recipient_column_headers_as_column_keys
@@ -320,15 +326,16 @@ class RecipientCSV:
             if raw_recipient_column_headers.count(InsensitiveDict.make_key(column_header)) > 1
         )
 
-    def is_address_column(self, key):
+    def is_address_column(self, key) -> bool:
         return self.template_type == "letter" and key in address_columns
 
     @property
-    def count_of_required_recipient_columns(self):
+    def count_of_required_recipient_columns(self) -> int:
         return 3 if self.template_type == "letter" else 1
 
     @property
     def has_recipient_columns(self) -> bool:
+        sets_to_check: Iterable[Iterable[str]]
         if self.template_type == "letter":
             sets_to_check = [
                 InsensitiveSet(address_lines_1_to_6_and_postcode_keys),
@@ -353,9 +360,9 @@ class RecipientCSV:
 
         return False
 
-    def _get_error_for_field(self, key, value):  # noqa: C901
+    def _get_error_for_field(self, key, value) -> str | None:  # noqa: C901
         if self.is_address_column(key):
-            return
+            return None
 
         if key in self.recipient_column_headers_as_column_keys:
             if value in [None, ""] or isinstance(value, list):
@@ -377,26 +384,35 @@ class RecipientCSV:
                 return str(error)
 
         if key not in self.placeholders_as_column_keys:
-            return
+            return None
 
         if value in [None, ""]:
             return Cell.missing_field_error
 
+        return None
 
-class Row(InsensitiveDict):
-    message_too_long = False
-    message_empty = False
+
+class Row(InsensitiveDict[str | None, Any]):
+    message_too_long: bool = False
+    message_empty: bool = False
+
+    index: int
+    recipient_column_headers: Sequence[str]
+    placeholders: InsensitiveSet[str]
+    allow_international_letters: bool
+    _template: Template
+    qr_code_too_long: QrCodeTooLong | None
 
     def __init__(
         self,
-        row_dict,
+        row_dict: Mapping[str | None, Any],
         *,
-        index,
+        index: int,
         error_fn,
         recipient_column_headers,
-        placeholders,
+        placeholders: InsensitiveSet[str],
         template: Template,
-        allow_international_letters,
+        allow_international_letters: bool,
         validate_row=True,
     ):
         self.index = index
@@ -443,7 +459,7 @@ class Row(InsensitiveDict):
         return self.get(self.recipient_column_headers[0]).recipient_error
 
     @property
-    def has_bad_postal_address(self):
+    def has_bad_postal_address(self) -> bool:
         return self.template_type == "letter" and not self.as_postal_address.valid
 
     def _has_qr_code_with_too_much_data(self) -> QrCodeTooLong | None:
@@ -479,21 +495,34 @@ class Row(InsensitiveDict):
         )
 
     @property
-    def personalisation(self):
-        return InsensitiveDict({key: cell.data for key, cell in self.items() if key in self.placeholders})
+    def personalisation(self) -> InsensitiveDict[str, Any]:
+        return cast(
+            InsensitiveDict[str, Any],
+            InsensitiveDict({key: cell.data for key, cell in self.items() if key in self.placeholders}),
+        )
 
     @property
-    def recipient_and_personalisation(self):
+    def recipient_and_personalisation(self) -> InsensitiveDict[str | None, Any]:
         return InsensitiveDict({key: cell.data for key, cell in self.items()})
 
 
 class Cell:
     __slots__ = ("data", "ignore", "error")
-    missing_field_error = "Missing"
+    missing_field_error: str = "Missing"
 
-    def __init__(self, key=None, value=None, error_fn=None, placeholders=None):
+    data: Any
+    ignore: bool
+    error: str | None
+
+    def __init__(
+        self,
+        key: str | None = None,
+        value=None,
+        error_fn: Callable[[Any, Any], str | None] | None = None,
+        placeholders: Container[str] | None = None,
+    ):
         self.data = value
-        self.ignore = InsensitiveDict.make_key(key) not in (placeholders or [])
+        self.ignore = (not placeholders) or InsensitiveDict.make_key(key) not in placeholders
         self.error = error_fn(key, value) if error_fn and not self.ignore else None
 
     def __eq__(self, other) -> bool:
@@ -505,12 +534,12 @@ class Cell:
         )
 
     @property
-    def recipient_error(self):
+    def recipient_error(self) -> bool:
         return self.error not in (None, self.missing_field_error)
 
 
 @lru_cache(maxsize=32, typed=False)
-def format_recipient(recipient):
+def format_recipient(recipient) -> str:
     if not isinstance(recipient, str):
         return ""
     with suppress(InvalidPhoneError):
@@ -522,15 +551,15 @@ def format_recipient(recipient):
 
 
 @lru_cache(maxsize=RecipientCSV.max_rows, typed=False)
-def get_phone_number_object(phone_number):
+def get_phone_number_object(phone_number: str) -> PhoneNumber:
     return PhoneNumber(phone_number)
 
 
-def allowed_to_send_to(recipient, allowlist):
+def allowed_to_send_to(recipient: str | Sequence[str], allowlist: Sequence[str]) -> bool:
     return format_recipient(recipient) in (format_recipient(x) for x in allowlist)
 
 
-def insert_or_append_to_dict(dict_, key, value):
+def insert_or_append_to_dict[K, Vi](dict_: MutableMapping[K, Vi | list[Vi]], key: K, value: Vi):
     if not (key or value):
         # We don’t care about completely empty values so it’s faster to
         # ignore them rather than working out how to store them

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -6,7 +6,7 @@ from contextlib import suppress
 from functools import lru_cache
 from html import unescape
 from os import path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from jinja2 import Template as jinja2_Template
@@ -41,7 +41,7 @@ from notifications_utils.formatters import (
     strip_unsupported_characters,
     unlink_govuk_escaped,
 )
-from notifications_utils.insensitive_dict import InsensitiveDict
+from notifications_utils.insensitive_dict import InsensitiveDict, InsensitiveSet
 from notifications_utils.markdown import (
     notify_email_markdown,
     notify_email_preheader_markdown,
@@ -78,12 +78,12 @@ class Template(ABC):
     redact_missing_personalisation: bool
 
     _template: Mapping[str, Any]
-    _values: Mapping[str, Any]
+    _values: Mapping[str | None, Any]
 
     def __init__(
         self,
         template: Mapping[str, Any],
-        values: Mapping[str, Any] | None = None,
+        values: Mapping[str | None, Any] | None = None,
         redact_missing_personalisation: bool = False,
     ):
         if not isinstance(template, Mapping):
@@ -121,19 +121,21 @@ class Template(ABC):
         ).strip()
 
     @property
-    def values(self) -> Mapping[str, Any]:
+    def values(self) -> Mapping[str | None, Any]:
         return getattr(self, "_values", {})
 
     @values.setter
-    def values(self, new_values: Mapping[str, Any] | None):
+    def values(self, new_values: Mapping[str | None, Any] | None) -> None:
         with suppress(AttributeError):
             del self._values
 
         if new_values:
-            self._values = InsensitiveDict(new_values).as_dict_with_keys(self.placeholders | new_values.keys())
+            self._values = InsensitiveDict(new_values).as_dict_with_keys(
+                cast(InsensitiveSet[str | None], self.placeholders) | iter(new_values.keys())
+            )
 
     @property
-    def placeholders(self) -> Set[str]:
+    def placeholders(self) -> InsensitiveSet[str]:
         return get_placeholders(self.content)
 
     @property
@@ -141,7 +143,7 @@ class Template(ABC):
         return [placeholder for placeholder in self.placeholders if self.values.get(placeholder) is None]
 
     @property
-    def additional_data(self) -> Set[str]:
+    def additional_data(self) -> Set[str | None]:
         return self.values.keys() - self.placeholders
 
     def get_raw(self, key, default=None):
@@ -176,7 +178,7 @@ class BaseSMSTemplate(Template):
     def __init__(
         self,
         template: Mapping[str, Any],
-        values: Mapping[str, Any] | None = None,
+        values: Mapping[str | None, Any] | None = None,
         prefix: str | None = None,
         show_prefix: bool = True,
         sender: Any = None,
@@ -187,11 +189,11 @@ class BaseSMSTemplate(Template):
         super().__init__(template, values)
 
     @property
-    def values(self) -> Mapping[str, Any]:
+    def values(self) -> Mapping[str | None, Any]:
         return super().values
 
     @values.setter
-    def values(self, new_values: Mapping[str, Any] | None):
+    def values(self, new_values: Mapping[str | None, Any] | None):
         # If we change the values of the template it’s possible the
         # content will have changed, so we need to reset the cached
         # count and content
@@ -324,7 +326,7 @@ class SMSBodyPreviewTemplate(BaseSMSTemplate):
     def __init__(
         self,
         template: Mapping[str, Any],
-        values: Mapping[str, Any] | None = None,
+        values: Mapping[str | None, Any] | None = None,
     ):
         super().__init__(template, values, show_prefix=False)
 
@@ -357,7 +359,7 @@ class SMSPreviewTemplate(BaseSMSTemplate):
     def __init__(
         self,
         template: Mapping[str, Any],
-        values: Mapping[str, Any] | None = None,
+        values: Mapping[str | None, Any] | None = None,
         prefix: str | None = None,
         show_prefix: bool = True,
         sender: Any = None,
@@ -412,7 +414,7 @@ class BaseEmailTemplate(Template):
     def __init__(
         self,
         template: Mapping[str, Any],
-        values: Mapping[str, Any] | None = None,
+        values: Mapping[str | None, Any] | None = None,
         unsubscribe_link: str | None = None,
         **kwargs,
     ):
@@ -436,7 +438,7 @@ class BaseEmailTemplate(Template):
         )
 
     @property
-    def placeholders(self) -> Set[str]:
+    def placeholders(self) -> InsensitiveSet[str]:
         return get_placeholders(self._subject) | super().placeholders
 
     @property
@@ -549,7 +551,7 @@ class HTMLEmailTemplate(BaseEmailTemplate):
     def __init__(
         self,
         template: Mapping[str, Any],
-        values: Mapping[str, Any] | None = None,
+        values: Mapping[str | None, Any] | None = None,
         govuk_banner: bool = True,
         complete_html: bool = True,
         brand_logo: str | None = None,
@@ -627,7 +629,7 @@ class BaseLetterTemplate(Template):
     def __init__(
         self,
         template: Mapping[str, Any],
-        values: Mapping[str, Any] | None = None,
+        values: Mapping[str | None, Any] | None = None,
         contact_block: str | None = None,
         admin_base_url: str = "http://localhost:6012",
         logo_file_name: str | None = None,
@@ -669,7 +671,7 @@ class BaseLetterTemplate(Template):
         )
 
     @property
-    def placeholders(self) -> Set[str]:
+    def placeholders(self) -> InsensitiveSet[str]:
         return (
             get_placeholders(self.contact_block)
             | get_placeholders(self._welsh_subject)
@@ -787,7 +789,7 @@ class LetterPrintTemplate(LetterPreviewTemplate):
     def __init__(
         self,
         template: Mapping[str, Any],
-        values: Mapping[str, Any] | None = None,
+        values: Mapping[str | None, Any] | None = None,
         contact_block: str | None = None,
         admin_base_url: str = "http://localhost:6012",
         logo_file_name: str | None = None,
@@ -827,5 +829,5 @@ def do_nice_typography(value: str) -> str:
 
 
 @lru_cache(maxsize=1024)
-def get_placeholders(content: str) -> Set[str]:
+def get_placeholders(content: str) -> InsensitiveSet[str]:
     return Field(content).placeholders

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "121.0.0"  # 66b54696423f7035abaf480a6e7a1016
+__version__ = "122.0.0"  # a997c2c68ddf467e964b2aa922515dad

--- a/tests/test_insensitive_dict.py
+++ b/tests/test_insensitive_dict.py
@@ -82,6 +82,58 @@ def test_set_item(key_in, lookup_key):
     assert columns[lookup_key] == "bar"
 
 
+@pytest.mark.parametrize(
+    "key_in",
+    [
+        "foo",
+        "F_O O",
+    ],
+)
+@pytest.mark.parametrize(
+    "delete_key",
+    [
+        "foo",
+        "f_o_o",
+        "F O O",
+    ],
+)
+def test_del_item(key_in, delete_key):
+    columns = InsensitiveDict({key_in: "bar"})
+    del columns[delete_key]
+
+    assert delete_key not in columns
+    assert key_in not in columns
+    assert not columns
+    assert len(columns) == 0
+    assert tuple(columns.items()) == ()
+
+
+@pytest.mark.parametrize(
+    "key_in",
+    [
+        "foo",
+        "F_O O",
+    ],
+)
+@pytest.mark.parametrize(
+    "pop_key",
+    [
+        "foo",
+        "f_o_o",
+        "F O O",
+    ],
+)
+def test_pop_item(key_in, pop_key):
+    columns = InsensitiveDict({key_in: "bar", "baz": 123})
+    assert columns.pop(pop_key) == "bar"
+
+    assert pop_key not in columns
+    assert key_in not in columns
+    assert columns
+    assert len(columns) == 1
+    assert tuple(columns.items()) == (("baz", 123),)
+
+
 def test_maintains_insertion_order():
     d = InsensitiveDict(
         {
@@ -90,9 +142,26 @@ def test_maintains_insertion_order():
             "C": None,
         }
     )
-    assert d.keys() == ["b", "a", "c"]
+    assert tuple(d.keys()) == ("b", "a", "c")
     d["BB"] = None
-    assert d.keys() == ["b", "a", "c", "bb"]
+    assert tuple(d.keys()) == ("b", "a", "c", "bb")
+
+
+def test_update():
+    d = InsensitiveDict(
+        {
+            "A": "A1",
+            "B": "B1",
+            "C": "C1",
+        }
+    )
+    d.update((("b ", "B2"), ("c ", "C2"), ("d_", "D1"), (" c", "C3")))
+    assert tuple(d.items()) == (
+        ("a", "A1"),
+        ("b", "B2"),
+        ("c", "C3"),
+        ("d", "D1"),
+    )
 
 
 def test_insensitive_set():


### PR DESCRIPTION
Individual commits have more information, but in short this gives us an easier time in several ways - beyond giving us a more complete/"correct" implementation it should make type hinting work better.

Some changes to `InsensitiveSet` are included to make it work more like the new `InsensitiveDict` (e.g. it now takes a type parameter that should allow us to be more precise about where the keys are `str | None` and where they are just `str`.

Included are a lot of typing fixups to make `RecipientCSV`, `Template` and `Field` use `InsensitiveSet` and `InsensitiveDict` correctly, being able to differentiate between types that have `str` keys and those that have `str | None` keys.