### PR TITLE
`AbstractInsensitiveSet`, `AbstractInsensitiveDict`: split into mutable and immutable variants

### DIFF
--- a/notifications_utils/insensitive_dict.py
+++ b/notifications_utils/insensitive_dict.py
@@ -417,10 +417,12 @@ class InsensitiveSet[T: str | None](ImmutableInsensitiveSet[T], AbstractMutableI
     _immutable_type: type[ImmutableInsensitiveSet[T]] = ImmutableInsensitiveSet
 
 
-ImmutableInsensitiveSet._mutable_type = InsensitiveSet._mutable_type = InsensitiveSet  # type: ignore[misc]
+ImmutableInsensitiveSet._mutable_type = InsensitiveSet  # type: ignore[misc]
 
 
-class AbstractInsensitiveDict[K, V](MutableMapping[K, V], metaclass=ABCMeta):
+class AbstractImmutableInsensitiveDict[K, V](Mapping[K, V], metaclass=ABCMeta):
+    _mutable_type: type[Self] | None = None
+
     __slots__ = ("_inner",)
     _inner: dict[K, V]
 
@@ -432,7 +434,19 @@ class AbstractInsensitiveDict[K, V](MutableMapping[K, V], metaclass=ABCMeta):
 
     def __init__(self, initial: Mapping[K, V] | Iterable[tuple[K, V]] = (), /):
         self._inner = {}
-        self.update(initial)
+        self._update(initial)
+
+    # needed on immutable type for internal use during construction
+    def _update(self, other: Mapping[K, V] | Iterable[tuple[K, V]], /, **kwargs: V) -> None:
+        if type(other) is type(self) or type(other) is self._mutable_type:  # type comparison deliberately strict
+            self._inner.update(other._inner)
+        else:
+            it = other.items() if isinstance(other, Mapping) else other
+            for k, v in it:
+                self._inner[self.make_key(k)] = v
+
+        for k, v in kwargs.items():
+            self._inner[self.make_key(k)] = v  # type: ignore[index]
 
     # Mapping[K, V]
 
@@ -444,14 +458,6 @@ class AbstractInsensitiveDict[K, V](MutableMapping[K, V], metaclass=ABCMeta):
 
     def __len__(self) -> int:
         return self._inner.__len__()
-
-    # MutableMapping[K, V]
-
-    def __setitem__(self, key: K, value: V):
-        self._inner.__setitem__(self.make_key(key), value)
-
-    def __delitem__(self, key: K):
-        self._inner.__delitem__(self.make_key(key))
 
     # Accelerate Mapping[K, V]
 
@@ -467,7 +473,10 @@ class AbstractInsensitiveDict[K, V](MutableMapping[K, V], metaclass=ABCMeta):
         if not isinstance(other, Mapping):
             return NotImplemented
 
-        other_dict = other if type(self) is type(other) else type(self)(other)  # type comparison deliberately strict
+        other_dict = (
+            # type comparison deliberately strict
+            other if type(other) is type(self) or type(other) is self._mutable_type else type(self)(other)
+        )
 
         return self._inner.__eq__(other_dict._inner)
 
@@ -498,22 +507,6 @@ class AbstractInsensitiveDict[K, V](MutableMapping[K, V], metaclass=ABCMeta):
 
         return self._inner.get(final_key, default)
 
-    # Accelerate MutableMapping[K, V]
-
-    def clear(self):
-        self._inner.clear()
-
-    def update(self, other: Mapping[K, V] | Iterable[tuple[K, V]], /, **kwargs: V) -> None:  # type: ignore[override]
-        if type(self) is type(other):  # type comparison deliberately strict
-            self._inner.update(other._inner)
-        else:
-            it = other.items() if isinstance(other, Mapping) else other
-            for k, v in it:
-                self[k] = v
-
-        for k, v in kwargs.items():
-            self[k] = v  # type: ignore[index]
-
     # bonus methods
 
     def as_dict_with_keys(self, keys: Iterable[K]) -> dict[K, V | None]:
@@ -525,10 +518,44 @@ class AbstractInsensitiveDict[K, V](MutableMapping[K, V], metaclass=ABCMeta):
         return other
 
 
-class InsensitiveDict[K: str | None, V](AbstractInsensitiveDict[K, V]):
+class AbstractMutableInsensitiveDict[K, V](
+    AbstractImmutableInsensitiveDict[K, V], MutableMapping[K, V], metaclass=ABCMeta
+):
+    _immutable_type: type[AbstractImmutableInsensitiveDict[K, V]] | None = None
+
+    # MutableMapping[K, V]
+
+    def __setitem__(self, key: K, value: V):
+        self._inner.__setitem__(self.make_key(key), value)
+
+    def __delitem__(self, key: K):
+        self._inner.__delitem__(self.make_key(key))
+
+    # Accelerate MutableMapping[K, V]
+
+    def clear(self):
+        self._inner.clear()
+
+    def update(self, other: Mapping[K, V] | Iterable[tuple[K, V]], /, **kwargs: V) -> None:  # type: ignore[override]
+        return self._update(other, **kwargs)
+
+
+AbstractInsensitiveDict = AbstractMutableInsensitiveDict
+
+
+class ImmutableInsensitiveDict[K: str | None, V](AbstractImmutableInsensitiveDict[K, V]):
+    _mutable_type: "type[InsensitiveDict[K, V]]"
+
     @staticmethod
     def make_key(original_key: Any) -> K:
         return _normalise_str_none(original_key)
 
     def keys(self) -> ImmutableInsensitiveSet[K]:  # type: ignore[override]
         return ImmutableInsensitiveSet(self)
+
+
+class InsensitiveDict[K: str | None, V](ImmutableInsensitiveDict[K, V], AbstractMutableInsensitiveDict[K, V]):
+    _immutable_type: type[ImmutableInsensitiveDict[K, V]] = ImmutableInsensitiveDict[K, V]
+
+
+ImmutableInsensitiveDict._mutable_type = InsensitiveDict  # type: ignore[misc]

--- a/notifications_utils/insensitive_dict.py
+++ b/notifications_utils/insensitive_dict.py
@@ -36,7 +36,9 @@ def _normalise_str_none(original_key: Any) -> str | None:
     return original_key.translate(_NORMALISE_STR_NONE_TRANSLATION_TABLE).lower()
 
 
-class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
+class AbstractImmutableInsensitiveSet[T](Set[T], Sequence[T], metaclass=ABCMeta):
+    _mutable_type: type[Self] | None = None
+
     __slots__ = ("_inner",)
     _inner: dict[T, T]
 
@@ -74,18 +76,6 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
 
     def __len__(self) -> int:
         return len(self._inner)
-
-    # MutableSet[T]
-
-    def add(self, item: T):
-        key = self.make_key(item)
-        if key not in self._inner:
-            self._inner[key] = item
-
-    def discard(self, item: T):
-        self._inner.pop(
-            self.make_key(item), None
-        )  # faster than possibly raising then ignoring exception if not present
 
     # Sequence[T]
 
@@ -153,7 +143,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
             return tuple(self._inner.keys()) == tuple(self.make_key(item) for item in other)
 
         # and add a shortcut for others of identical type
-        if type(self) is type(other):  # type comparison deliberately strict
+        if type(other) is type(self) or type(other) is self._mutable_type:  # type comparison deliberately strict
             return self._inner.keys() == other._inner.keys()
 
         return super().__eq__(other)
@@ -177,7 +167,10 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
         if not isinstance(other, Set):
             return NotImplemented
 
-        other_set = other if type(self) is type(other) else type(self)(other)  # type comparison deliberately strict
+        other_set = (
+            # type comparison deliberately strict
+            other if type(other) is type(self) or type(other) is self._mutable_type else type(self)(other)
+        )
 
         return self._inner.keys() <= other_set._inner.keys()
 
@@ -185,7 +178,10 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
         if not isinstance(other, Set):
             return NotImplemented
 
-        other_set = other if type(self) is type(other) else type(self)(other)  # type comparison deliberately strict
+        other_set = (
+            # type comparison deliberately strict
+            other if type(other) is type(self) or type(other) is self._mutable_type else type(self)(other)
+        )
 
         return self._inner.keys() >= other_set._inner.keys()
 
@@ -193,7 +189,10 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
         if not isinstance(other, Iterable):
             return NotImplemented
 
-        other_set = other if type(self) is type(other) else type(self)(other)  # type comparison deliberately strict
+        other_set = (
+            # type comparison deliberately strict
+            other if type(other) is type(self) or type(other) is self._mutable_type else type(self)(other)
+        )
 
         return type(self)._from_inner_pairs((k, v) for k, v in self._inner.items() if k in other_set._inner)
 
@@ -201,7 +200,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
         if not isinstance(other, Iterable):
             return NotImplemented
 
-        if type(self) is type(other):  # type comparison deliberately strict
+        if type(other) is type(self) or type(other) is self._mutable_type:  # type comparison deliberately strict
             return type(self)._from_inner_pairs((k, v) for k, v in other._inner.items() if k in self._inner)
 
         # ensure the un-normalised values come from the RHS
@@ -213,11 +212,10 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
 
         new_set = type(self)._from_inner_pairs(self._inner.items())
 
-        if type(self) is type(other):  # type comparison deliberately strict
+        if type(other) is type(self) or type(other) is self._mutable_type:  # type comparison deliberately strict
             new_set._add_inner_pairs(other._inner.items())
         else:
-            for value in other:
-                new_set.add(value)
+            new_set._add_inner_pairs((self.make_key(item), item) for item in other)
 
         return new_set
 
@@ -225,7 +223,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
         if not isinstance(other, Iterable):
             return NotImplemented
 
-        if type(self) is type(other):  # type comparison deliberately strict
+        if type(other) is type(self) or type(other) is self._mutable_type:  # type comparison deliberately strict
             new_set = type(self)._from_inner_pairs(other._inner.items())
         else:
             new_set = type(self)(other)
@@ -238,7 +236,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
         if not isinstance(other, Iterable):
             return NotImplemented
 
-        if type(self) is type(other):  # type comparison deliberately strict
+        if type(other) is type(self) or type(other) is self._mutable_type:  # type comparison deliberately strict
             return self._inner.keys().isdisjoint(other._inner.keys())
 
         return not any(item in self for item in other)
@@ -247,7 +245,10 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
         if not isinstance(other, Iterable):
             return NotImplemented
 
-        other_set = other if type(self) is type(other) else type(self)(other)  # type comparison deliberately strict
+        other_set = (
+            # type comparison deliberately strict
+            other if type(other) is type(self) or type(other) is self._mutable_type else type(self)(other)
+        )
 
         return type(self)._from_inner_pairs((k, v) for k, v in self._inner.items() if k not in other_set._inner)
 
@@ -255,7 +256,7 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
         if not isinstance(other, Iterable):
             return NotImplemented
 
-        if type(self) is type(other):  # type comparison deliberately strict
+        if type(other) is type(self) or type(other) is self._mutable_type:  # type comparison deliberately strict
             return type(self)._from_inner_pairs((k, v) for k, v in other._inner.items() if k not in self._inner)
 
         return type(self)(item for item in other if item not in self)
@@ -264,7 +265,10 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
         if not isinstance(other, Iterable):
             return NotImplemented
 
-        other_set = other if type(self) is type(other) else type(self)(other)  # type comparison deliberately strict
+        other_set = (
+            # type comparison deliberately strict
+            other if type(other) is type(self) or type(other) is self._mutable_type else type(self)(other)
+        )
 
         return type(self)._from_inner_pairs(
             chain(
@@ -277,7 +281,10 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
         if not isinstance(other, Iterable):
             return NotImplemented
 
-        other_set = other if type(self) is type(other) else type(self)(other)  # type comparison deliberately strict
+        other_set = (
+            # type comparison deliberately strict
+            other if type(other) is type(self) or type(other) is self._mutable_type else type(self)(other)
+        )
 
         return type(self)._from_inner_pairs(
             chain(
@@ -285,64 +292,6 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
                 ((k, v) for k, v in self._inner.items() if k not in other_set._inner),
             )
         )
-
-    # Accelerate MutableSet[T]
-
-    def remove(self, item: T):
-        del self._inner[self.make_key(item)]
-
-    def pop(self) -> T:
-        try:
-            return self._inner.pop(next(reversed(self._inner)))
-        except StopIteration as e:
-            raise KeyError from e
-
-    def clear(self):
-        self._inner.clear()
-
-    def __iand__(self, other: Iterable[T]) -> Self:
-        if not isinstance(other, Iterable):
-            return NotImplemented
-
-        other_set = other if type(self) is type(other) else type(self)(other)  # type comparison deliberately strict
-
-        for k in tuple(self._inner):  # must take copy of keys so we can modify underlying dict during iteration
-            if k not in other_set._inner:
-                del self._inner[k]
-
-        return self
-
-    def __ixor__(self, other: Iterable[T]) -> Self:  # type: ignore[override]
-        if not isinstance(other, Iterable):
-            return NotImplemented
-
-        other_set = other if type(self) is type(other) else type(self)(other)  # type comparison deliberately strict
-
-        intersection = self & other_set
-        self -= intersection
-        other_set -= intersection
-        self |= other_set
-
-        return self
-
-    def __isub__(self, other: Iterable[T]) -> Self:
-        if not isinstance(other, Iterable):
-            return NotImplemented
-
-        if type(self) is type(other):  # type comparison deliberately strict
-            for k in other._inner:
-                self._inner.pop(k, None)
-
-        return super().__isub__(other)  # type: ignore[arg-type]
-
-    def __ior__(self, other: Iterable[T]) -> Self:  # type: ignore[override]
-        if not isinstance(other, Iterable):
-            return NotImplemented
-
-        if type(self) is type(other):  # type comparison deliberately strict
-            self._add_inner_pairs(other._inner.items())
-
-        return super().__ior__(other)  # type: ignore[arg-type]
 
     # only included because old InsensitiveSet implemented them (note builtins.set accepts *others)
 
@@ -373,10 +322,102 @@ class AbstractInsensitiveSet[T](MutableSet[T], Sequence[T], metaclass=ABCMeta):
         return f"{self.__class__.__name__}({list(self._inner.values())!r})"
 
 
-class InsensitiveSet[T: str | None](AbstractInsensitiveSet[T]):
+class AbstractMutableInsensitiveSet[T](AbstractImmutableInsensitiveSet[T], MutableSet[T], metaclass=ABCMeta):
+    _immutable_type: type[AbstractImmutableInsensitiveSet[T]] | None = None
+
+    # MutableSet[T]
+
+    def add(self, item: T):
+        key = self.make_key(item)
+        if key not in self._inner:
+            self._inner[key] = item
+
+    def discard(self, item: T):
+        self._inner.pop(
+            self.make_key(item), None
+        )  # faster than possibly raising then ignoring exception if not present
+
+    # Accelerate MutableSet[T]
+
+    def remove(self, item: T):
+        del self._inner[self.make_key(item)]
+
+    def pop(self) -> T:
+        try:
+            return self._inner.pop(next(reversed(self._inner)))
+        except StopIteration as e:
+            raise KeyError from e
+
+    def clear(self):
+        self._inner.clear()
+
+    def __iand__(self, other: Iterable[T]) -> Self:
+        if not isinstance(other, Iterable):
+            return NotImplemented
+
+        other_set = (
+            # type comparison deliberately strict
+            other if type(other) is type(self) or type(other) is self._immutable_type else type(self)(other)
+        )
+
+        for k in tuple(self._inner):  # must take copy of keys so we can modify underlying dict during iteration
+            if k not in other_set._inner:
+                del self._inner[k]
+
+        return self
+
+    def __ixor__(self, other: Iterable[T]) -> Self:  # type: ignore[override]
+        if not isinstance(other, Iterable):
+            return NotImplemented
+
+        other_set = (
+            # type comparison deliberately strict
+            other if type(other) is type(self) or type(other) is self._immutable_type else type(self)(other)
+        )
+
+        intersection = self & other_set
+        self -= intersection
+        other_set -= intersection
+        self |= other_set
+
+        return self
+
+    def __isub__(self, other: Iterable[T]) -> Self:
+        if not isinstance(other, Iterable):
+            return NotImplemented
+
+        if type(other) is type(self) or type(other) is self._immutable_type:  # type comparison deliberately strict
+            for k in other._inner:
+                self._inner.pop(k, None)
+
+        return super().__isub__(other)  # type: ignore[arg-type]
+
+    def __ior__(self, other: Iterable[T]) -> Self:  # type: ignore[override]
+        if not isinstance(other, Iterable):
+            return NotImplemented
+
+        if type(other) is type(self) or type(other) is self._immutable_type:  # type comparison deliberately strict
+            self._add_inner_pairs(other._inner.items())
+
+        return super().__ior__(other)  # type: ignore[arg-type]
+
+
+AbstractInsensitiveSet = AbstractMutableInsensitiveSet
+
+
+class ImmutableInsensitiveSet[T: str | None](AbstractImmutableInsensitiveSet[T]):
+    _mutable_type: "type[InsensitiveSet[T]]"
+
     @staticmethod
     def make_key(original_key: Any) -> T:
         return _normalise_str_none(original_key)
+
+
+class InsensitiveSet[T: str | None](ImmutableInsensitiveSet[T], AbstractMutableInsensitiveSet[T]):
+    _immutable_type: type[ImmutableInsensitiveSet[T]] = ImmutableInsensitiveSet
+
+
+ImmutableInsensitiveSet._mutable_type = InsensitiveSet._mutable_type = InsensitiveSet  # type: ignore[misc]
 
 
 class AbstractInsensitiveDict[K, V](MutableMapping[K, V], metaclass=ABCMeta):
@@ -437,7 +478,7 @@ class AbstractInsensitiveDict[K, V](MutableMapping[K, V], metaclass=ABCMeta):
         return self._inner.values()
 
     @abstractmethod
-    def keys(self) -> AbstractInsensitiveSet[K]:  # type: ignore[override]
+    def keys(self) -> AbstractImmutableInsensitiveSet[K]:  # type: ignore[override]
         ...
 
     @overload
@@ -489,5 +530,5 @@ class InsensitiveDict[K: str | None, V](AbstractInsensitiveDict[K, V]):
     def make_key(original_key: Any) -> K:
         return _normalise_str_none(original_key)
 
-    def keys(self) -> InsensitiveSet[K]:  # type: ignore[override]
-        return InsensitiveSet(self)
+    def keys(self) -> ImmutableInsensitiveSet[K]:  # type: ignore[override]
+        return ImmutableInsensitiveSet(self)

--- a/tests/test_insensitive_dict.py
+++ b/tests/test_insensitive_dict.py
@@ -2,7 +2,7 @@ from functools import partial
 
 import pytest
 
-from notifications_utils.insensitive_dict import InsensitiveDict, InsensitiveSet
+from notifications_utils.insensitive_dict import ImmutableInsensitiveSet, InsensitiveDict, InsensitiveSet
 from notifications_utils.recipients import Cell, Row
 from notifications_utils.template import SMSPreviewTemplate
 
@@ -164,9 +164,14 @@ def test_update():
     )
 
 
-def test_insensitive_set():
+def test_key_stored_as_normalised_format():
+    assert tuple(InsensitiveDict({"foo": 1, "FOO": 2, "f_o_o": 3}).items()) == (("foo", 3),)
+
+
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+def test_insensitive_set(cls):
     assert tuple(
-        InsensitiveSet(
+        cls(
             [
                 "foo",
                 "F o o ",
@@ -183,8 +188,9 @@ def test_insensitive_set():
     )
 
 
-def test_insensitive_set_contains():
-    foobar = InsensitiveSet(("foo", "bar"))
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+def test_insensitive_set_contains(cls):
+    foobar = cls(("foo", "bar"))
 
     for key in (
         "foo",
@@ -204,12 +210,9 @@ def test_insensitive_set_contains():
         assert key not in foobar
 
 
-def test_key_stored_as_normalised_format():
-    assert tuple(InsensitiveDict({"foo": 1, "FOO": 2, "f_o_o": 3}).items()) == (("foo", 3),)
-
-
-def test_insensitive_set_index():
-    foobarbaz = InsensitiveSet(("foo", "bar", "FOO", "BAR", "B A Z"))
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+def test_insensitive_set_index(cls):
+    foobarbaz = cls(("foo", "bar", "FOO", "BAR", "B A Z"))
 
     assert foobarbaz.index("foo") == foobarbaz.index("FOO") == foobarbaz.index("f_o_o") == 0
     assert foobarbaz.index("bar") == foobarbaz.index("BAR") == foobarbaz.index("B A R") == 1
@@ -219,57 +222,115 @@ def test_insensitive_set_index():
         foobarbaz.index("foobar")
 
 
-def test_insensitive_set_is_disjoint():
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+@pytest.mark.parametrize("other_cls", (InsensitiveSet, ImmutableInsensitiveSet, set))
+def test_insensitive_set_is_disjoint(cls, other_cls):
     foobarbaz = InsensitiveSet(("foo", "bar", "FOO", "BAR", "B A Z"))
 
-    assert foobarbaz.isdisjoint({"foobar"})
-    assert not foobarbaz.isdisjoint({"baz"})
+    assert foobarbaz.isdisjoint(other_cls(("foobar",)))
+    assert not foobarbaz.isdisjoint(other_cls(("baz",)))
 
 
-def test_insensitive_set_is_subset():
-    foobarbaz = InsensitiveSet(("foo", "bar", "FOO", "BAR", "B A Z"))
-    superset = {"foo", "bar", "BAZ", "foobar"}
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+@pytest.mark.parametrize("other_cls", (InsensitiveSet, ImmutableInsensitiveSet, set))
+def test_insensitive_set_is_subset(cls, other_cls):
+    foobarbaz = cls(("foo", "bar", "FOO", "BAR", "B A Z"))
+    superset = other_cls(
+        (
+            "foo",
+            "bar",
+            "BAZ",
+            "foobar",
+        )
+    )
     assert foobarbaz.issubset(superset)
 
     assert foobarbaz < superset
     assert foobarbaz <= superset
-    assert not foobarbaz < {"foo", "bar", "BAZ"}
+    assert not foobarbaz < other_cls(
+        (
+            "foo",
+            "bar",
+            "BAZ",
+        )
+    )
 
 
-def test_insensitive_set_is_superset():
-    foobarbaz = InsensitiveSet(("foo", "bar", "FOO", "BAR", "B A Z"))
-    subset = {"Foo", "Bar"}
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+@pytest.mark.parametrize("other_cls", (InsensitiveSet, ImmutableInsensitiveSet, set))
+def test_insensitive_set_is_superset(cls, other_cls):
+    foobarbaz = cls(("foo", "bar", "FOO", "BAR", "B A Z"))
+    subset = other_cls(
+        (
+            "Foo",
+            "Bar",
+        )
+    )
     assert foobarbaz.issuperset(subset)
 
     assert foobarbaz > subset
     assert foobarbaz >= subset
-    assert not foobarbaz > {"foo", "bar", "BAZ"}
+    assert not foobarbaz > other_cls(
+        (
+            "foo",
+            "bar",
+            "BAZ",
+        )
+    )
 
 
-def test_insensitive_set_union():
-    foobar = InsensitiveSet(("foo", "bar", "FOO", "BAR"))
-    barbaz = {"Bar", "B A Z"}
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+@pytest.mark.parametrize("other_cls", (InsensitiveSet, ImmutableInsensitiveSet, set))
+def test_insensitive_set_union(cls, other_cls):
+    foobar = cls(("foo", "bar", "FOO", "BAR"))
+    barbaz = other_cls(
+        (
+            "Bar",
+            "B A Z",
+        )
+    )
     assert foobar.union(barbaz) == {"foo", "bar", "B A Z"}
     assert foobar | barbaz == {"foo", "bar", "B A Z"}
 
 
-def test_insensitive_set_intersection():
-    foobar = InsensitiveSet(("foo", "bar", "FOO", "BAR"))
-    barbaz = {"Bar", "B A Z"}
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+@pytest.mark.parametrize("other_cls", (InsensitiveSet, ImmutableInsensitiveSet, set))
+def test_insensitive_set_intersection(cls, other_cls):
+    foobar = cls(("foo", "bar", "FOO", "BAR"))
+    barbaz = other_cls(
+        (
+            "Bar",
+            "B A Z",
+        )
+    )
     assert foobar.intersection(barbaz) == {"BAR"}
     assert foobar & barbaz == {"BAR"}
 
 
-def test_insensitive_set_difference():
-    foobar = InsensitiveSet(("foo", "bar", "FOO", "BAR"))
-    barbaz = {"Bar", "B A Z"}
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+@pytest.mark.parametrize("other_cls", (InsensitiveSet, ImmutableInsensitiveSet, set))
+def test_insensitive_set_difference(cls, other_cls):
+    foobar = cls(("foo", "bar", "FOO", "BAR"))
+    barbaz = other_cls(
+        (
+            "Bar",
+            "B A Z",
+        )
+    )
     assert foobar.difference(barbaz) == {"foo"}
     assert foobar - barbaz == {"foo"}
 
 
-def test_insensitive_set_symmetric_difference():
-    foobar = InsensitiveSet(("foo", "bar", "FOO", "BAR"))
-    barbaz = {"Bar", "B A Z"}
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+@pytest.mark.parametrize("other_cls", (InsensitiveSet, ImmutableInsensitiveSet, set))
+def test_insensitive_set_symmetric_difference(cls, other_cls):
+    foobar = cls(("foo", "bar", "FOO", "BAR"))
+    barbaz = other_cls(
+        (
+            "Bar",
+            "B A Z",
+        )
+    )
     assert foobar.symmetric_difference(barbaz) == {"foo", "B A Z"}
     assert foobar ^ barbaz == {"foo", "B A Z"}
 
@@ -287,8 +348,15 @@ def test_insensitive_set_pop():
         foobar.pop()
 
 
-def test_insensitive_set_or_iterable():
-    assert tuple(InsensitiveSet(f" {i}" for i in range(8)) | (f"{i} " for i in range(18, 4, -1))) == (
+def test_immutable_insensitive_set_cant_pop():
+    foobar = ImmutableInsensitiveSet(("foo", "bar", "FOO", " BAR ", "baz"))
+    with pytest.raises((AttributeError, TypeError)):
+        foobar.pop()
+
+
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+def test_insensitive_set_or_iterable(cls):
+    assert tuple(cls(f" {i}" for i in range(8)) | (f"{i} " for i in range(18, 4, -1))) == (
         " 0",
         " 1",
         " 2",
@@ -311,8 +379,9 @@ def test_insensitive_set_or_iterable():
     )
 
 
-def test_insensitive_set_ror_iterable():
-    assert tuple((f"{i} " for i in range(18, 4, -1)) | InsensitiveSet(f" {i}" for i in range(8))) == (
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+def test_insensitive_set_ror_iterable(cls):
+    assert tuple((f"{i} " for i in range(18, 4, -1)) | cls(f" {i}" for i in range(8))) == (
         "18 ",
         "17 ",
         "16 ",
@@ -335,24 +404,27 @@ def test_insensitive_set_ror_iterable():
     )
 
 
-def test_insensitive_set_and_iterable():
-    assert tuple(InsensitiveSet(f" {i}" for i in range(8)) & (f"{i} " for i in range(18, 4, -1))) == (
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+def test_insensitive_set_and_iterable(cls):
+    assert tuple(cls(f" {i}" for i in range(8)) & (f"{i} " for i in range(18, 4, -1))) == (
         " 5",
         " 6",
         " 7",
     )
 
 
-def test_insensitive_set_rand_iterable():
-    assert tuple((f"{i} " for i in range(18, 4, -1)) & InsensitiveSet(f" {i}" for i in range(8))) == (
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+def test_insensitive_set_rand_iterable(cls):
+    assert tuple((f"{i} " for i in range(18, 4, -1)) & cls(f" {i}" for i in range(8))) == (
         "7 ",
         "6 ",
         "5 ",
     )
 
 
-def test_insensitive_set_xor_iterable():
-    assert tuple(InsensitiveSet(f" {i}" for i in range(8)) ^ (f"{i} " for i in range(18, 4, -1))) == (
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+def test_insensitive_set_xor_iterable(cls):
+    assert tuple(cls(f" {i}" for i in range(8)) ^ (f"{i} " for i in range(18, 4, -1))) == (
         " 0",
         " 1",
         " 2",
@@ -372,8 +444,9 @@ def test_insensitive_set_xor_iterable():
     )
 
 
-def test_insensitive_set_rxor_iterable():
-    assert tuple((f"{i} " for i in range(18, 4, -1)) ^ InsensitiveSet(f" {i}" for i in range(8))) == (
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+def test_insensitive_set_rxor_iterable(cls):
+    assert tuple((f"{i} " for i in range(18, 4, -1)) ^ cls(f" {i}" for i in range(8))) == (
         "18 ",
         "17 ",
         "16 ",
@@ -393,8 +466,9 @@ def test_insensitive_set_rxor_iterable():
     )
 
 
-def test_insensitive_set_sub_iterable():
-    assert tuple(InsensitiveSet(f" {i}" for i in range(8)) - (f"{i} " for i in range(18, 4, -1))) == (
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+def test_insensitive_set_sub_iterable(cls):
+    assert tuple(cls(f" {i}" for i in range(8)) - (f"{i} " for i in range(18, 4, -1))) == (
         " 0",
         " 1",
         " 2",
@@ -403,8 +477,9 @@ def test_insensitive_set_sub_iterable():
     )
 
 
-def test_insensitive_set_rsub_iterable():
-    assert tuple((f"{i} " for i in range(18, 4, -1)) - InsensitiveSet(f" {i}" for i in range(8))) == (
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+def test_insensitive_set_rsub_iterable(cls):
+    assert tuple((f"{i} " for i in range(18, 4, -1)) - cls(f" {i}" for i in range(8))) == (
         "18 ",
         "17 ",
         "16 ",
@@ -419,8 +494,9 @@ def test_insensitive_set_rsub_iterable():
     )
 
 
-def test_insensitive_set_iand_iterable():
-    s = InsensitiveSet(f" {i}" for i in range(8))
+@pytest.mark.parametrize("cls, expect_reassign", ((InsensitiveSet, False), (ImmutableInsensitiveSet, True)))
+def test_insensitive_set_iand_iterable(cls, expect_reassign):
+    q = s = cls(f" {i}" for i in range(8))
     s &= (f"{i} " for i in range(18, 4, -1))
 
     assert tuple(s) == (
@@ -429,9 +505,12 @@ def test_insensitive_set_iand_iterable():
         " 7",
     )
 
+    assert (q is not s) == expect_reassign
 
-def test_insensitive_set_ior_iterable():
-    s = InsensitiveSet(f" {i}" for i in range(8))
+
+@pytest.mark.parametrize("cls, expect_reassign", ((InsensitiveSet, False), (ImmutableInsensitiveSet, True)))
+def test_insensitive_set_ior_iterable(cls, expect_reassign):
+    q = s = cls(f" {i}" for i in range(8))
     s |= (f"{i} " for i in range(18, 4, -1))
 
     assert tuple(s) == (
@@ -456,9 +535,12 @@ def test_insensitive_set_ior_iterable():
         "8 ",
     )
 
+    assert (q is not s) == expect_reassign
 
-def test_insensitive_set_ixor_iterable():
-    s = InsensitiveSet(f" {i}" for i in range(8))
+
+@pytest.mark.parametrize("cls, expect_reassign", ((InsensitiveSet, False), (ImmutableInsensitiveSet, True)))
+def test_insensitive_set_ixor_iterable(cls, expect_reassign):
+    q = s = cls(f" {i}" for i in range(8))
     s ^= (f"{i} " for i in range(18, 4, -1))
 
     assert tuple(s) == (
@@ -480,9 +562,12 @@ def test_insensitive_set_ixor_iterable():
         "8 ",
     )
 
+    assert (q is not s) == expect_reassign
 
-def test_insensitive_set_isub_iterable():
-    s = InsensitiveSet(f" {i}" for i in range(8))
+
+@pytest.mark.parametrize("cls, expect_reassign", ((InsensitiveSet, False), (ImmutableInsensitiveSet, True)))
+def test_insensitive_set_isub_iterable(cls, expect_reassign):
+    q = s = cls(f" {i}" for i in range(8))
     s -= (f"{i} " for i in range(18, 4, -1))
 
     assert tuple(s) == (
@@ -493,6 +578,8 @@ def test_insensitive_set_isub_iterable():
         " 4",
     )
 
+    assert (q is not s) == expect_reassign
+
 
 def test_insensitive_set_invalid_inequality():
     with pytest.raises(TypeError):
@@ -502,46 +589,54 @@ def test_insensitive_set_invalid_inequality():
         InsensitiveSet() >= 1  # noqa: B015
 
 
-def test_insensitive_set_eq_set():
-    assert {f" {i}" for i in range(8)} == InsensitiveSet(f"{i} " for i in range(7, -1, -1))
-    assert InsensitiveSet(f"{i} " for i in range(7, -1, -1)) == {f" {i}" for i in range(8)}
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+@pytest.mark.parametrize("other_cls", (InsensitiveSet, ImmutableInsensitiveSet, set))
+def test_insensitive_set_eq_set(cls, other_cls):
+    assert other_cls(f" {i}" for i in range(8)) == cls(f"{i} " for i in range(7, -1, -1))
+    assert cls(f"{i} " for i in range(7, -1, -1)) == other_cls(f" {i}" for i in range(8))
 
-    assert {f" {i}" for i in range(8)} != InsensitiveSet(f"{i} " for i in range(8, -1, -1))
-    assert InsensitiveSet(f"{i} " for i in range(8, -1, -1)) != {f" {i}" for i in range(8)}
-
-
-def test_insensitive_set_eq_insensitive_set_not_order_sensitive():
-    assert InsensitiveSet(f" {i}" for i in range(8)) == InsensitiveSet(f"{i} " for i in range(7, -1, -1))
-    assert InsensitiveSet(f" {i}" for i in range(8)) == InsensitiveSet(f"{i} " for i in range(8))
-    assert InsensitiveSet(f" {i}" for i in range(8)) != InsensitiveSet(f"{i} " for i in range(7))
+    assert other_cls(f" {i}" for i in range(8)) != cls(f"{i} " for i in range(8, -1, -1))
+    assert cls(f"{i} " for i in range(8, -1, -1)) != other_cls(f" {i}" for i in range(8))
 
 
-def test_insensitive_set_eq_iterable_order_sensitive():
-    assert InsensitiveSet(f" {i}" for i in range(8)) != (f"{i} " for i in range(7, -1, -1))
-    assert InsensitiveSet(f" {i}" for i in range(8)) == (f"{i} " for i in range(8))
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+@pytest.mark.parametrize("other_cls", (InsensitiveSet, ImmutableInsensitiveSet))
+def test_insensitive_set_eq_insensitive_set_not_order_sensitive(cls, other_cls):
+    assert cls(f" {i}" for i in range(8)) == other_cls(f"{i} " for i in range(7, -1, -1))
+    assert cls(f" {i}" for i in range(8)) == other_cls(f"{i} " for i in range(8))
+    assert cls(f" {i}" for i in range(8)) != other_cls(f"{i} " for i in range(7))
 
 
-def test_insensitive_set_getitem_positive_int():
-    insensitive_set = InsensitiveSet(f" {i}" for i in range(8))
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+def test_insensitive_set_eq_iterable_order_sensitive(cls):
+    assert cls(f" {i}" for i in range(8)) != (f"{i} " for i in range(7, -1, -1))
+    assert cls(f" {i}" for i in range(8)) == (f"{i} " for i in range(8))
+
+
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+def test_insensitive_set_getitem_positive_int(cls):
+    insensitive_set = cls(f" {i}" for i in range(8))
     for i in range(8):
         assert insensitive_set[i] == f" {i}"
 
 
-def test_insensitive_set_getitem_negative_int():
-    insensitive_set = InsensitiveSet(f" {i}" for i in range(8))
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
+def test_insensitive_set_getitem_negative_int(cls):
+    insensitive_set = cls(f" {i}" for i in range(8))
     for i, j in zip(range(8), range(-8, 0), strict=True):
         assert insensitive_set[j] == f" {i}"
 
 
+@pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))
 @pytest.mark.parametrize("start", tuple(range(-5, 4)) + (None,))
 @pytest.mark.parametrize("stop", tuple(range(-5, 4)) + (None,))
 @pytest.mark.parametrize("step", (-1, 1, None))
-def test_insensitive_set_getitem_slices(start, stop, step):
+def test_insensitive_set_getitem_slices(cls, start, stop, step):
     tup = tuple(f" {i}" for i in range(4))
-    iset = InsensitiveSet(tup)
+    iset = cls(tup)
 
     iset_ret = iset[start:stop:step]
     tup_ret = tup[start:stop:step]
 
-    assert isinstance(iset_ret, InsensitiveSet)
+    assert isinstance(iset_ret, cls)
     assert tuple(iset_ret) == tuple(tup_ret)

--- a/tests/test_insensitive_dict.py
+++ b/tests/test_insensitive_dict.py
@@ -2,19 +2,27 @@ from functools import partial
 
 import pytest
 
-from notifications_utils.insensitive_dict import ImmutableInsensitiveSet, InsensitiveDict, InsensitiveSet
+from notifications_utils.insensitive_dict import (
+    ImmutableInsensitiveDict,
+    ImmutableInsensitiveSet,
+    InsensitiveDict,
+    InsensitiveSet,
+)
 from notifications_utils.recipients import Cell, Row
 from notifications_utils.template import SMSPreviewTemplate
 
 
-def test_columns_as_dict_with_keys():
-    assert InsensitiveDict({"Date of Birth": "01/01/2001", "TOWN": "London"}).as_dict_with_keys(
-        {"date_of_birth", "town"}
-    ) == {"date_of_birth": "01/01/2001", "town": "London"}
+@pytest.mark.parametrize("cls", (InsensitiveDict, ImmutableInsensitiveDict))
+def test_columns_as_dict_with_keys(cls):
+    assert cls({"Date of Birth": "01/01/2001", "TOWN": "London"}).as_dict_with_keys({"date_of_birth", "town"}) == {
+        "date_of_birth": "01/01/2001",
+        "town": "London",
+    }
 
 
-def test_columns_as_dict():
-    assert dict(InsensitiveDict({"date of birth": "01/01/2001", "TOWN": "London"})) == {
+@pytest.mark.parametrize("cls", (InsensitiveDict, ImmutableInsensitiveDict))
+def test_columns_as_dict(cls):
+    assert dict(cls({"date of birth": "01/01/2001", "TOWN": "London"})) == {
         "dateofbirth": "01/01/2001",
         "town": "London",
     }
@@ -57,8 +65,9 @@ def test_missing_data():
         ("bar", False),
     ],
 )
-def test_lookup(key, should_be_present, in_dictionary):
-    assert (key in InsensitiveDict(in_dictionary)) == should_be_present
+@pytest.mark.parametrize("cls", (InsensitiveDict, ImmutableInsensitiveDict))
+def test_lookup(cls, key, should_be_present, in_dictionary):
+    assert (key in cls(in_dictionary)) == should_be_present
 
 
 @pytest.mark.parametrize(
@@ -80,6 +89,14 @@ def test_set_item(key_in, lookup_key):
     columns = InsensitiveDict({})
     columns[key_in] = "bar"
     assert columns[lookup_key] == "bar"
+    columns[key_in] = "baz"
+    assert columns[lookup_key] == "baz"
+
+
+def test_immutable_cant_set_item():
+    columns = ImmutableInsensitiveDict({})
+    with pytest.raises((AttributeError, TypeError)):
+        columns["foo"] = "bar"
 
 
 @pytest.mark.parametrize(
@@ -108,6 +125,16 @@ def test_del_item(key_in, delete_key):
     assert tuple(columns.items()) == ()
 
 
+def test_immutable_cant_del_item():
+    columns = ImmutableInsensitiveDict({"foo": "bar", "baz": 123})
+
+    with pytest.raises((AttributeError, TypeError)):
+        del columns["foo"]
+
+    with pytest.raises((AttributeError, TypeError)):
+        del columns["nonexistent"]
+
+
 @pytest.mark.parametrize(
     "key_in",
     [
@@ -134,6 +161,16 @@ def test_pop_item(key_in, pop_key):
     assert tuple(columns.items()) == (("baz", 123),)
 
 
+def test_immutable_cant_pop_item():
+    columns = ImmutableInsensitiveDict({"foo": "bar", "baz": 123})
+
+    with pytest.raises((AttributeError, TypeError)):
+        columns.pop("foo")
+
+    with pytest.raises((AttributeError, TypeError)):
+        columns.pop("nonexistent")
+
+
 def test_maintains_insertion_order():
     d = InsensitiveDict(
         {
@@ -145,6 +182,17 @@ def test_maintains_insertion_order():
     assert tuple(d.keys()) == ("b", "a", "c")
     d["BB"] = None
     assert tuple(d.keys()) == ("b", "a", "c", "bb")
+
+
+def test_immutable_maintains_insertion_order():
+    d = ImmutableInsensitiveDict(
+        {
+            "B": None,
+            "A": None,
+            "C": None,
+        }
+    )
+    assert tuple(d.keys()) == ("b", "a", "c")
 
 
 def test_update():
@@ -164,8 +212,21 @@ def test_update():
     )
 
 
-def test_key_stored_as_normalised_format():
-    assert tuple(InsensitiveDict({"foo": 1, "FOO": 2, "f_o_o": 3}).items()) == (("foo", 3),)
+def test_immutable_cant_update():
+    d = ImmutableInsensitiveDict(
+        {
+            "A": "A1",
+            "B": "B1",
+            "C": "C1",
+        }
+    )
+    with pytest.raises((AttributeError, TypeError)):
+        d.update((("b ", "B2"), ("c ", "C2"), ("d_", "D1"), (" c", "C3")))
+
+
+@pytest.mark.parametrize("cls", (InsensitiveDict, ImmutableInsensitiveDict))
+def test_key_stored_as_normalised_format(cls):
+    assert tuple(cls({"foo": 1, "FOO": 2, "f_o_o": 3}).items()) == (("foo", 3),)
 
 
 @pytest.mark.parametrize("cls", (InsensitiveSet, ImmutableInsensitiveSet))


### PR DESCRIPTION
One being a subtype of the other, and, on concrete classes, each knowing about its mutable/immutable counterpart so it can special-case handling for performance.

Use of the immutable types should allow us to reduce the ambiguity of function call interfaces and prevent code from making unexpected mutations of possibly-shared data structures.

Have left aliases in here to allow `AbstractMutableInsensitiveSet` and `AbstractMutableInsensitiveDict` to still be imported as `AbstractInsensitiveSet` and `AbstractInsensitiveDict` respectively. And `InsensitiveSet` and `InsensitiveDict` still refer to their mutable variants so shouldn't lead to any behaviour change.