### PR TITLE
 add function `json_encodable` to ensure plain container types are used in a data structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 123.4.0
+
+* Add `json_encodable` function to ensure plain container types are used in a data structure.
+
 ## 123.3.0
 
 * Remove China (+86 country code) from `international_billing_rates.yml` to remove China from the international pricing page and to raise an exception if a user tries to send.

--- a/notifications_utils/json.py
+++ b/notifications_utils/json.py
@@ -1,0 +1,28 @@
+from collections.abc import Mapping, Sequence
+
+type RelaxedJsonType = None | bool | int | float | str | Sequence["RelaxedJsonType"] | Mapping[str, "RelaxedJsonType"]
+
+
+type StrictJsonType = (
+    None
+    | bool
+    | int
+    | float
+    | str
+    | list["StrictJsonType"]
+    | tuple["StrictJsonType", ...]
+    | dict[str, "StrictJsonType"]
+)
+
+
+def json_encodable(value: RelaxedJsonType) -> StrictJsonType:
+    match value:
+        case bool() | int() | float() | str() | None:
+            return value
+        case Sequence():
+            # not str because those have already been handled
+            return tuple(json_encodable(inner) for inner in value)
+        case Mapping():
+            return {k: json_encodable(v) for k, v in value.items()}
+        case _:
+            raise TypeError(f"Unexpected type {type(value)}")

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "123.3.0"  # e096a20786e15e75d8034ef155d89072
+__version__ = "123.4.0"  # e69e3b7af50a466d99b1203ea894d51c

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,0 +1,37 @@
+import json
+
+import pytest
+from requests.structures import CaseInsensitiveDict
+
+from notifications_utils.insensitive_dict import InsensitiveDict, InsensitiveSet
+from notifications_utils.json import json_encodable
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_output",
+    (
+        (None, None),
+        (123, 123),
+        (True, True),
+        (False, False),
+        ({"foo": 123}, {"foo": 123}),
+        ([123, "foo", None], (123, "foo", None)),
+        (
+            [([],)],
+            (((),),),
+        ),
+        (CaseInsensitiveDict({"foo": 123}), {"foo": 123}),
+        (InsensitiveDict({"foo": 123}), {"foo": 123}),
+        (InsensitiveSet(("foo", "bar", "Baz")), ("foo", "bar", "Baz")),
+        (InsensitiveSet(("foo", None, "Baz")), ("foo", None, "Baz")),
+        (
+            [InsensitiveDict({"foo": (InsensitiveDict({"foo": 123}), "baa")}), InsensitiveSet(("2", "1")), None],
+            ({"foo": ({"foo": 123}, "baa")}, ("2", "1"), None),
+        ),
+    ),
+)
+def test_json_encodable(input_value, expected_output):
+    result = json_encodable(input_value)
+    assert result == expected_output
+
+    json.dumps(json_encodable(input_value))


### PR DESCRIPTION
This is an annoyance exposed by #1420 making `InsensitiveDict` no longer inherit directly from concrete `dict` - the default `json` encoder refuses to encode it.

One approach we _could_ use to address this is with a custom `JSONEncoder` that interprets all `Mapping`s as `dict`s and all `Sequence`s as `tuple`s. But that isn't very convenient to use with `requests` and will likely upset static typing as it becomes more strict.
