### PR TITLE
revert china (+86) block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 123.4.0
+
+* Add China (+86 country code) back to `international_billing_rates.yml`
+
 ## 123.3.0
 
 * Remove China (+86 country code) from `international_billing_rates.yml` to remove China from the international pricing page and to raise an exception if a user tries to send.

--- a/notifications_utils/international_billing_rates.yml
+++ b/notifications_utils/international_billing_rates.yml
@@ -565,6 +565,21 @@
   rate_multiplier: 4
   names:
   - Vietnam
+'86':
+  attributes:
+    alpha: 'NO'
+    comment: Extremenly HIGH penalties for any traffic other than transactional
+    dlr: Carrier DLR
+    generic_sender: ''
+    numeric: LIMITED
+    sc: 'NO'
+    sender_and_registration_info: All senders CONVERTED into one available national
+      numeric sender
+    text_restrictions: Content template MUST be approved by the MNO. Transactional
+      traffic ONLY. Sufix added in the message text
+  rate_multiplier: 1
+  names:
+  - China
 '90':
   attributes:
     alpha: REG

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "123.3.0"  # e096a20786e15e75d8034ef155d89072
+__version__ = "123.4.0"  # 7f76838179732d2a3c76a302c70e90fe

--- a/tests/test_international_billing_rates.py
+++ b/tests/test_international_billing_rates.py
@@ -30,7 +30,7 @@ def test_international_billing_rates_are_in_correct_format(country_prefix, value
 
 
 def test_country_codes():
-    assert len(COUNTRY_PREFIXES) == 222
+    assert len(COUNTRY_PREFIXES) == 223
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Technical solution currently on pause - revert the change that introduced the block so that the head of utils can be brought into apps as needed.