### PR TITLE
 add `RelaxedContainerJSONEncoder` to handle encoding of alternative container types in encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 123.5.0
+
+* Add `RelaxedContainerJSONEncoder` `JSONEncoder` subclass to allow encoding of structures with alternative implementations of `Sequence` and `Mapping`.
+* Add `FlaskRelaxedContainerJSONEncoder`, combining flask's modified `JSONEncoder` with `RelaxedContainerJSONEncoder`.
+
 ## 123.4.0
 
 * Add China (+86 country code) back to `international_billing_rates.yml`

--- a/notifications_utils/json.py
+++ b/notifications_utils/json.py
@@ -1,6 +1,8 @@
 from collections.abc import Iterator, Mapping, Sequence
 from json import JSONEncoder
 
+from flask.json.provider import DefaultJSONProvider as flask_DefaultJSONProvider
+
 type RelaxedJsonType = None | bool | int | float | str | Sequence["RelaxedJsonType"] | Mapping[str, "RelaxedJsonType"]
 
 
@@ -21,6 +23,7 @@ class RelaxedContainerJSONEncoder(JSONEncoder):
     A JSONEncoder subclass that will turn (almost) any encountered
     Sequence into a tuple and any Mapping into a plain dict.
     """
+
     def default(self, obj: RelaxedJsonType) -> StrictJsonType:
         match obj:
             case bool() | int() | float() | str() | None:
@@ -38,3 +41,7 @@ class RelaxedContainerJSONEncoder(JSONEncoder):
 
     def iterencode(self, obj: RelaxedJsonType, _one_shot: bool = False) -> Iterator[str]:
         return super().iterencode(obj, _one_shot)
+
+
+class FlaskRelaxedContainerJSONEncoder(flask_DefaultJSONProvider, RelaxedContainerJSONEncoder):
+    pass

--- a/notifications_utils/json.py
+++ b/notifications_utils/json.py
@@ -1,0 +1,40 @@
+from collections.abc import Iterator, Mapping, Sequence
+from json import JSONEncoder
+
+type RelaxedJsonType = None | bool | int | float | str | Sequence["RelaxedJsonType"] | Mapping[str, "RelaxedJsonType"]
+
+
+type StrictJsonType = (
+    None
+    | bool
+    | int
+    | float
+    | str
+    | list["StrictJsonType"]
+    | tuple["StrictJsonType", ...]
+    | dict[str, "StrictJsonType"]
+)
+
+
+class RelaxedContainerJSONEncoder(JSONEncoder):
+    """
+    A JSONEncoder subclass that will turn (almost) any encountered
+    Sequence into a tuple and any Mapping into a plain dict.
+    """
+    def default(self, obj: RelaxedJsonType) -> StrictJsonType:
+        match obj:
+            case bool() | int() | float() | str() | None:
+                return obj
+            case Sequence() if not isinstance(obj, bytes):
+                # not str because those have already been handled
+                return tuple(self.default(inner) for inner in obj)
+            case Mapping():
+                return {k: self.default(v) for k, v in obj.items()}
+
+        return super().default(obj)
+
+    def encode(self, obj: RelaxedJsonType) -> str:
+        return super().encode(obj)
+
+    def iterencode(self, obj: RelaxedJsonType, _one_shot: bool = False) -> Iterator[str]:
+        return super().iterencode(obj, _one_shot)

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "123.4.0"  # 7f76838179732d2a3c76a302c70e90fe
+__version__ = "123.5.0"  # 504df3290e964a6ab8c70280bd29b1e3

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,0 +1,51 @@
+import datetime
+import json
+
+import pytest
+from requests.structures import CaseInsensitiveDict
+
+from notifications_utils.insensitive_dict import InsensitiveDict, InsensitiveSet
+from notifications_utils.json import RelaxedContainerJSONEncoder
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_output",
+    (
+        (None, None),
+        (123, 123),
+        (True, True),
+        (False, False),
+        ({"foo": 123}, {"foo": 123}),
+        ([123, "foo", None], [123, "foo", None]),
+        (
+            [([],)],
+            [[[]]],
+        ),
+        (CaseInsensitiveDict({"foo": 123}), {"foo": 123}),
+        (InsensitiveDict({"foo": 123}), {"foo": 123}),
+        (InsensitiveSet(("foo", "bar", "Baz")), ["foo", "bar", "Baz"]),
+        (InsensitiveSet(("foo", None, "Baz")), ["foo", None, "Baz"]),
+        (
+            [InsensitiveDict({"foo": (InsensitiveDict({"foo": 123}), "baa")}), InsensitiveSet(("2", "1")), None],
+            [{"foo": [{"foo": 123}, "baa"]}, ["2", "1"], None],
+        ),
+    ),
+)
+def test_relaxed_container_json_encoder(input_value, expected_output):
+    json_encoded = RelaxedContainerJSONEncoder().encode(input_value)
+    assert json.loads(json_encoded) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value",
+    ({1, 2, 3}, datetime.datetime.fromisoformat("2020-10-10T01:02:03"), b"foo"),
+)
+def test_relaxed_container_json_encoder_unencodable(input_value):
+    with pytest.raises(TypeError):
+        RelaxedContainerJSONEncoder().encode(input_value)
+
+    with pytest.raises(TypeError):
+        RelaxedContainerJSONEncoder().encode([input_value])
+
+    with pytest.raises(TypeError):
+        RelaxedContainerJSONEncoder().encode({"foo": input_value})


### PR DESCRIPTION
This is an annoyance exposed by #1420 making `InsensitiveDict` no longer inherit directly from concrete `dict` - the default `json` encoder refuses to encode it.

Sadly `requests` doesn't have a nice way of substituting the encoder used for its `json=` kwarg, so to make use of this encoder we'll have to perform the encoding ourselves, provide it to the `data=` kwarg and ensure the `Content-type: application/json` request header is used.

Flask, on the other hand, does allow supplying a custom encoder for its automatic json encoding of responses, and so we mix our `RelaxedContainerJSONEncoder` in to flask's default (already enhanced) json encoder to make `FlaskRelaxedContainerJSONEncoder` which can be used with a flask app's `json_provider_class` attribute.