### PR TITLE
 `FlaskRelaxedContainerJSONEncoder`: rename to `FlaskRelaxedContainerJSONProvider`, don't implement `JSONEncoder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 124.0.0
+
+* Rename `FlaskRelaxedContainerJSONEncoder` to `FlaskRelaxedContainerJSONProvider`, don't implement `JSONEncoder`.
+
 ## 123.5.0
 
 * Add `RelaxedContainerJSONEncoder` `JSONEncoder` subclass to allow encoding of structures with alternative implementations of `Sequence` and `Mapping`.

--- a/notifications_utils/json.py
+++ b/notifications_utils/json.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterator, Mapping, Sequence
 from json import JSONEncoder
+from typing import Any, Protocol
 
 from flask.json.provider import DefaultJSONProvider as flask_DefaultJSONProvider
 
@@ -18,13 +19,23 @@ type StrictJsonType = (
 )
 
 
-class RelaxedContainerJSONEncoder(JSONEncoder):
+class JSONNormalizingProtocol(Protocol):
     """
-    A JSONEncoder subclass that will turn (almost) any encountered
-    Sequence into a tuple and any Mapping into a plain dict.
+    A class that uses a `default` method to normalize a python object into an easily
+    JSON-serializable type, e.g. JSONEncoder or flask DefaultJSONProvider
     """
 
-    def default(self, obj: RelaxedJsonType) -> StrictJsonType:
+    def default(self, obj: Any) -> StrictJsonType:
+        raise NotImplementedError
+
+
+class RelaxedContainerJSONEncodingMixin:
+    """
+    Can be mixed in with any JSONNormalizingProtocol class to make it turn (almost) any
+    encountered Sequence into a tuple and any Mapping into a plain dict.
+    """
+
+    def default(self: JSONNormalizingProtocol, obj: RelaxedJsonType) -> StrictJsonType:
         match obj:
             case bool() | int() | float() | str() | None:
                 return obj
@@ -34,8 +45,10 @@ class RelaxedContainerJSONEncoder(JSONEncoder):
             case Mapping():
                 return {k: self.default(v) for k, v in obj.items()}
 
-        return super().default(obj)
+        return super().default(obj)  # type: ignore[safe-super]
 
+
+class RelaxedContainerJSONEncoder(RelaxedContainerJSONEncodingMixin, JSONEncoder):
     def encode(self, obj: RelaxedJsonType) -> str:
         return super().encode(obj)
 
@@ -43,5 +56,5 @@ class RelaxedContainerJSONEncoder(JSONEncoder):
         return super().iterencode(obj, _one_shot)
 
 
-class FlaskRelaxedContainerJSONEncoder(flask_DefaultJSONProvider, RelaxedContainerJSONEncoder):
+class FlaskRelaxedContainerJSONProvider(RelaxedContainerJSONEncodingMixin, flask_DefaultJSONProvider):
     pass

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "123.5.0"  # 504df3290e964a6ab8c70280bd29b1e3
+__version__ = "124.0.0"  # 70bddc7527ee4f9bb5ce2f41537bc563

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+from collections import deque
 
 import pytest
 from requests.structures import CaseInsensitiveDict
@@ -25,9 +26,14 @@ from notifications_utils.json import RelaxedContainerJSONEncoder
         (InsensitiveDict({"foo": 123}), {"foo": 123}),
         (InsensitiveSet(("foo", "bar", "Baz")), ["foo", "bar", "Baz"]),
         (InsensitiveSet(("foo", None, "Baz")), ["foo", None, "Baz"]),
+        (deque((None, None, deque((True, False)))), [None, None, [True, False]]),
         (
-            [InsensitiveDict({"foo": (InsensitiveDict({"foo": 123}), "baa")}), InsensitiveSet(("2", "1")), None],
-            [{"foo": [{"foo": 123}, "baa"]}, ["2", "1"], None],
+            [
+                InsensitiveDict({"foo": (InsensitiveDict({"foo": deque((123, "456"))}), "baa")}),
+                InsensitiveSet(("2", "1")),
+                None,
+            ],
+            [{"foo": [{"foo": [123, "456"]}, "baa"]}, ["2", "1"], None],
         ),
     ),
 )


### PR DESCRIPTION
This was sloppy - we shouldn't *really* be mixing a `JSONEncoder` subclass in to a flask `JSONProvider` - that's not really the protocol it follows, it just happens to follow the same `default(..)` pattern.

So split the implementation of `default(..)` out to a true mixin (which requires a little bit of a dance to make mypy happy about it).