### PR TITLE
 `RelaxedContainerJSONEncodingMixin`: simplify (and accelerate?) implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 124.1.0
+
+* Simplify object normalisation performed in `RelaxedContainerJSONEncodingMixin` by trusting `JSONEncoder` to recurse into our return values instead of doing this ourselves.
+* `ZendeskClient`: use `RelaxedContainerJSONEncoder` for json payloads
+
 ## 124.0.0
 
 * Rename `FlaskRelaxedContainerJSONEncoder` to `FlaskRelaxedContainerJSONProvider`, don't implement `JSONEncoder`.

--- a/notifications_utils/clients/zendesk/zendesk_client.py
+++ b/notifications_utils/clients/zendesk/zendesk_client.py
@@ -7,6 +7,7 @@ from urllib.parse import urlencode
 import requests
 from flask import current_app
 
+from notifications_utils.json import RelaxedContainerJSONEncoder as RCJSONEncoder
 from notifications_utils.timezones import local_timezone
 
 
@@ -69,7 +70,10 @@ class ZendeskClient:
 
     def send_ticket_to_zendesk(self, ticket):
         response = self.requests_session.post(
-            self.ZENDESK_TICKET_URL, json=ticket.request_data, auth=(f"{self.NOTIFY_ZENDESK_EMAIL}/token", self.api_key)
+            self.ZENDESK_TICKET_URL,
+            data=RCJSONEncoder().encode(ticket.request_data),
+            auth=(f"{self.NOTIFY_ZENDESK_EMAIL}/token", self.api_key),
+            headers={"Content-type": "application/json"},
         )
 
         if response.status_code != 201:
@@ -157,8 +161,9 @@ class ZendeskClient:
         update_url = self.ZENDESK_UPDATE_TICKET_URL.format(ticket_id=ticket_id)
         response = self.requests_session.put(
             update_url,
-            json=data,
+            data=RCJSONEncoder().encode(data),
             auth=(f"{self.NOTIFY_ZENDESK_EMAIL}/token", self.api_key),
+            headers={"Content-type": "application/json"},
         )
 
         if response.status_code != 200:

--- a/notifications_utils/json.py
+++ b/notifications_utils/json.py
@@ -19,13 +19,16 @@ type StrictJsonType = (
 )
 
 
+type StrictJsonTopLevelType = None | bool | int | float | str | list[Any] | tuple[Any, ...] | dict[str, Any]
+
+
 class JSONNormalizingProtocol(Protocol):
     """
     A class that uses a `default` method to normalize a python object into an easily
     JSON-serializable type, e.g. JSONEncoder or flask DefaultJSONProvider
     """
 
-    def default(self, obj: Any) -> StrictJsonType:
+    def default(self, obj: Any) -> StrictJsonTopLevelType:
         raise NotImplementedError
 
 
@@ -35,15 +38,12 @@ class RelaxedContainerJSONEncodingMixin:
     encountered Sequence into a tuple and any Mapping into a plain dict.
     """
 
-    def default(self: JSONNormalizingProtocol, obj: RelaxedJsonType) -> StrictJsonType:
+    def default(self: JSONNormalizingProtocol, obj: RelaxedJsonType) -> StrictJsonTopLevelType:
         match obj:
-            case bool() | int() | float() | str() | None:
-                return obj
-            case Sequence() if not isinstance(obj, bytes):
-                # not str because those have already been handled
-                return tuple(self.default(inner) for inner in obj)
+            case Sequence() if not isinstance(obj, bytes):  # not str because those have already been handled
+                return tuple(obj)
             case Mapping():
-                return {k: self.default(v) for k, v in obj.items()}
+                return dict(obj)
 
         return super().default(obj)  # type: ignore[safe-super]
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "124.0.0"  # 70bddc7527ee4f9bb5ce2f41537bc563
+__version__ = "124.1.0"  # 27cb7463eaa444a1a61126449a1ed895


### PR DESCRIPTION
Rather than recursing into containers ourselves (which will result in us re-allocating any further containers we encounter even if they're already an acceptable type), rely on `JSONEncoder` to recurse into the result we return to it and re-enter our `default(..)` method if any more problematic types are encountered.

Also convert `ZendeskClient` to use it for json payloads.