### PR TITLE
`RequestCache`: use `RelaxedContainerJSONEncoder` to encode cached payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 124.2.0
+
+* `RequestCache`: use `RelaxedContainerJSONEncoder` to encode cached payloads
+
 ## 124.1.0
 
 * Simplify object normalisation performed in `RelaxedContainerJSONEncodingMixin` by trusting `JSONEncoder` to recurse into our return values instead of doing this ourselves.

--- a/notifications_utils/clients/redis/request_cache.py
+++ b/notifications_utils/clients/redis/request_cache.py
@@ -6,6 +6,8 @@ from functools import singledispatch, wraps
 from inspect import signature
 from uuid import UUID
 
+from notifications_utils.json import RelaxedContainerJSONEncoder as RCJSONEncoder
+
 type _JSON = dict[str, "_JSON"] | list["_JSON"] | str | int | float | bool | None
 
 
@@ -119,7 +121,7 @@ class RequestCache:
 
                     self.redis_client.set(
                         redis_key,
-                        json.dumps(value),
+                        RCJSONEncoder().encode(value),
                         ex=int(final_ttl),
                         # client_method was (hopefully) side-effect free so this should not be an invalidation
                         skippable=True,

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "124.1.0"  # 27cb7463eaa444a1a61126449a1ed895
+__version__ = "124.2.0"  # 113fcb5021834f958b4be095f1d0c69e


### PR DESCRIPTION
We don't really want to run into any un-encodable values when caching.