### PR TITLE
Remove `RecipientCSV.rows_as_list` and `RecipientCSV.get_rows()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 125.0.0
+
+* Removes `RecipientCSV.rows_as_list` and `RecipientCSV.get_rows()`. Use `for row in recipient_csv_instance:`, `len(recipient_csv_instance)`, etc. instead
+
 ## 124.2.1
 
 * Fix antivirus scan when the uploaded file is a Werkzeug `FileStorage` (requests 2.34)

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -165,7 +165,7 @@ class RecipientCSV:
     @property
     def rows(self):
         if not hasattr(self, "_rows_as_list"):
-            self._rows_as_list = InterruptibleIterableList(self.get_rows())
+            self._rows_as_list = InterruptibleIterableList(self._get_rows())
             self._rows_as_list.INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY = self.rows_list_iteration_interruptible_every
         return self._rows_as_list
 
@@ -184,7 +184,7 @@ class RecipientCSV:
                 continue  # skip the header row
             yield max((column_index for column_index, column in enumerate(row) if column), default=-1) + 1
 
-    def get_rows(self) -> "Iterator[Row | None]":
+    def _get_rows(self) -> "Iterator[Row | None]":
         index_of_first_empty_column = max(self._first_empty_column_indices, default=0)
         headers_of_populated_columns = self._raw_column_headers[:index_of_first_empty_column]
         headers_of_empty_columns = self._raw_column_headers[index_of_first_empty_column:]
@@ -201,7 +201,7 @@ class RecipientCSV:
             interruptible_iter(
                 rows_as_lists_of_columns,
                 self.get_rows_loop_interruptible_every,
-                label=f"{self.__class__.__name__}.get_rows",
+                label=f"{self.__class__.__name__}._get_rows",
             )
         ):
             if index >= self.max_rows:

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -50,6 +50,7 @@ class RecipientCSV:
     placeholders_as_column_keys: InsensitiveSet[str]
     _guestlist: Sequence[Any]
     _placeholders: Sequence[Any]
+    _rows_as_list: Sequence["None | Row"]
 
     def __init__(
         self,
@@ -76,7 +77,6 @@ class RecipientCSV:
         self.allow_sms_to_uk_landline = allow_sms_to_uk_landline
         self.remaining_messages = remaining_messages
         self.remaining_international_sms_messages = remaining_international_sms_messages
-        self.rows_as_list = None
         self.should_validate = should_validate
         self.should_validate_phone_number = should_validate_phone_number
 
@@ -164,10 +164,10 @@ class RecipientCSV:
 
     @property
     def rows(self):
-        if self.rows_as_list is None:
-            self.rows_as_list = InterruptibleIterableList(self.get_rows())
-            self.rows_as_list.INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY = self.rows_list_iteration_interruptible_every
-        return self.rows_as_list
+        if not hasattr(self, "_rows_as_list"):
+            self._rows_as_list = InterruptibleIterableList(self.get_rows())
+            self._rows_as_list.INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY = self.rows_list_iteration_interruptible_every
+        return self._rows_as_list
 
     @property
     def _rows(self) -> Iterator[Sequence[str]]:

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "124.2.1"  # 640b4f0c8b31fb225b357515f1ae8dd3
+__version__ = "125.0.0"  # 4458fa1f571a8f2bc4545c253d5f30ef

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -261,7 +261,7 @@ def test_get_rows_only_iterates_over_file_once(mocker):
         next(rows)
 
     assert row_mock.call_count == 3
-    assert recipients.rows_as_list is None
+    assert not hasattr(recipients, "_rows_as_list")
 
 
 @pytest.mark.parametrize(
@@ -1475,10 +1475,10 @@ def test_errors_on_qr_codes_with_too_much_data():
 
     assert recipients.has_errors is True
     assert len(list(recipients.rows_with_errors)) == 1
-    assert recipients.rows_as_list[0].has_error is False
-    assert recipients.rows_as_list[0].qr_code_too_long is None
-    assert recipients.rows_as_list[1].has_error is True
-    assert isinstance(recipients.rows_as_list[1].qr_code_too_long, QrCodeTooLong)
+    assert recipients[0].has_error is False
+    assert recipients[0].qr_code_too_long is None
+    assert recipients[1].has_error is True
+    assert isinstance(recipients[1].qr_code_too_long, QrCodeTooLong)
 
 
 def test_column_headers_are_cached(mocker):
@@ -1545,3 +1545,20 @@ def test_cell_ignore_and_error_checking(mocker):
         call("Phone Number", "789"),
         call("Name", "C"),
     ]
+
+
+def test_rows_as_list_is_not_defined_on_init():
+    recipients = RecipientCSV(
+        """
+        Phone Number, Name, Foo, Bar
+        123,          A,    foo, bar
+        456,          B,    foo, bar
+        789,          C,    foo, bar
+        """,
+        template=_sample_template("sms"),
+    )
+    with pytest.raises(AttributeError):
+        recipients._rows_as_list  # noqa: B018
+
+    assert len(recipients.rows) == 3  # Causes recipients._rows_as_list to be defined
+    assert len(recipients._rows_as_list) == 3

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -231,7 +231,7 @@ def test_get_rows_does_no_error_checking_of_rows_or_cells(mocker):
         max_errors_shown=3,
     )
 
-    rows = recipients.get_rows()
+    rows = recipients._get_rows()
     for _ in range(3):
         assert next(rows).recipient == "a@b.com"
 
@@ -256,7 +256,7 @@ def test_get_rows_only_iterates_over_file_once(mocker):
         template=_sample_template("email", "hello ((name))"),
     )
 
-    rows = recipients.get_rows()
+    rows = recipients._get_rows()
     for _ in range(3):
         next(rows)
 
@@ -1452,7 +1452,7 @@ def test_recipient_csv_checks_should_validate_flag(should_validate):
 
     recipients._get_error_for_field = Mock(return_value=None)
 
-    list(recipients.get_rows())
+    list(recipients._get_rows())
 
     assert template.is_message_empty.called is should_validate
     assert recipients._get_error_for_field.called is should_validate


### PR DESCRIPTION
If you try to look at `RecipientCSV.rows_as_list` before `RecipientCSV.rows` has been accessed you will incorrectly see that the file has no rows. This change makes it so you will get an `AttributeError` instead.

We still need to store the list, but we mark the attribute as internal with an underscore.

***

`RecipientCSV.get_rows()` doesn’t cache its results, or make its processing interruptible, so code which consumes this library should not be calling it. We can imply this by prefixing its name with an underscore.

***

Any code which needs to loop through the rows should instead loop over `RecipientCSV.rows` or the `RecipientCSV` instance itself, rather than using these now-internal properties or methods.


