### PR TITLE
Linting: Fix ISC004 Unparenthesized implicit string concatenation in collection

### DIFF
--- a/tests/clients/zendesk/test_zendesk_client.py
+++ b/tests/clients/zendesk/test_zendesk_client.py
@@ -72,8 +72,10 @@ def test_zendesk_client_send_ticket_to_zendesk_with_user_suspended_error(zendesk
     response = zendesk_client.send_ticket_to_zendesk(ticket)
 
     assert caplog.messages == [
-        "Zendesk create ticket failed because user is suspended: "
-        "{'requester': [{'description': 'Requester: Joe Bloggs is suspended.'}]}"
+        (
+            "Zendesk create ticket failed because user is suspended: "
+            "{'requester': [{'description': 'Requester: Joe Bloggs is suspended.'}]}"
+        ),
     ]
     assert response is None
 


### PR DESCRIPTION
Ruff is going to make this rule on by default in version 0.16.0

Let’s get ahead of that by fixing this now.