### PR TITLE
fix: antivirus scan for uploaded files in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 124.2.1
+
+* Fix antivirus scan when the uploaded file is a Werkzeug `FileStorage` (requests 2.34)
+
 ## 124.2.0
 
 * `RequestCache`: use `RelaxedContainerJSONEncoder` to encode cached payloads

--- a/notifications_utils/clients/antivirus/antivirus_client.py
+++ b/notifications_utils/clients/antivirus/antivirus_client.py
@@ -1,6 +1,7 @@
 import requests
 from flask import current_app, request
 from flask.ctx import has_request_context
+from werkzeug.datastructures import FileStorage
 
 
 class AntivirusError(Exception):
@@ -18,6 +19,18 @@ class AntivirusError(Exception):
             status_code = 503
 
         return cls(message, status_code)
+
+
+def _multipart_file(document_stream):
+    """
+    Format the file for the HTTP library we use to call antivirus.
+
+    - Admin uploads arrive as a FileStorage, so we send requests the stream it wraps.
+    - Document-download-api sends plain bytes, which requests can take as-is.
+    """
+    if isinstance(document_stream, FileStorage):
+        return document_stream.stream
+    return document_stream
 
 
 class AntivirusClient:
@@ -41,7 +54,7 @@ class AntivirusClient:
             response = self.requests_session.post(
                 f"{self.api_host}/scan",
                 headers=headers,
-                files={"document": document_stream},
+                files={"document": _multipart_file(document_stream)},
             )
 
             response.raise_for_status()
@@ -52,6 +65,9 @@ class AntivirusClient:
 
             raise error from e
         finally:
-            document_stream.seek(0)
+            # Only rewind when the input supports it (admin uploads, BytesIO).
+            # Document-download-api passes bytes, which have no rewind.
+            if hasattr(document_stream, "seek"):
+                document_stream.seek(0)
 
         return response.json()["ok"]

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "124.2.0"  # 113fcb5021834f958b4be095f1d0c69e
+__version__ = "124.2.1"  # 640b4f0c8b31fb225b357515f1ae8dd3

--- a/tests/clients/antivirus/test_antivirus_client.py
+++ b/tests/clients/antivirus/test_antivirus_client.py
@@ -2,12 +2,18 @@ import io
 
 import pytest
 import requests
+from werkzeug.datastructures import FileStorage
 
 from notifications_utils import request_helper
 from notifications_utils.clients.antivirus.antivirus_client import (
     AntivirusClient,
     AntivirusError,
+    _multipart_file,
 )
+
+# Who calls scan() in production:
+# - notifications-admin: user picks a file in the browser (PDF on letter templates, logos, etc.)
+# - document-download-api: file content arrives as raw bytes inside a JSON API request
 
 
 @pytest.fixture(scope="function")
@@ -17,6 +23,16 @@ def app_antivirus_client(app, mocker):
         auth_token="test-antivirus-key",
     )
     return app, client
+
+
+def _register_scan_ok(rmock):
+    rmock.request(
+        "POST",
+        "https://antivirus/scan",
+        json={"ok": True},
+        request_headers={"Authorization": "Bearer test-antivirus-key"},
+        status_code=200,
+    )
 
 
 @pytest.mark.parametrize(
@@ -52,6 +68,55 @@ def test_scan_document(app_antivirus_client, rmock, mocker, with_request_helper)
     assert resp
     assert "filecontents" in rmock.last_request.text
     assert document.tell() == 0
+
+
+def test_scan_document_accepts_werkzeug_file_storage(app_antivirus_client, rmock):
+    """Same shape as notifications-admin when someone uploads a file through a form (e.g. attach PDF to a letter)."""
+    app, antivirus_client = app_antivirus_client
+
+    with app.test_request_context():
+        # Stands in for a file the user chose in admin (name + contents + type).
+        document = FileStorage(
+            stream=io.BytesIO(b"filecontents"),
+            filename="attachment.pdf",
+            content_type="application/pdf",
+        )
+        _register_scan_ok(rmock)
+
+        resp = antivirus_client.scan(document)
+
+    assert resp
+    assert "filecontents" in rmock.last_request.text
+    assert document.tell() == 0
+
+
+def test_scan_document_accepts_raw_bytes(app_antivirus_client, rmock):
+    """Same shape as document-download-api: file content as plain bytes, not a browser upload object."""
+    app, antivirus_client = app_antivirus_client
+
+    with app.test_request_context():
+        document = b"filecontents"
+        assert not hasattr(document, "seek")
+        _register_scan_ok(rmock)
+
+        resp = antivirus_client.scan(document)
+
+    assert resp
+    assert "filecontents" in rmock.last_request.text
+
+
+def test_multipart_file_unwraps_file_storage_for_requests():
+    """Admin uploads (letter attach-pages, Sentry NOTIFICATIONS-ADMIN-QE) go to requests as the wrapped stream."""
+    stream = io.BytesIO(b"filecontents")
+    document = FileStorage(stream=stream, filename="attachment.pdf", content_type="application/pdf")
+
+    assert _multipart_file(document) is stream
+
+
+def test_multipart_file_leaves_bytes_unchanged():
+    """document-download-api sends bytes; we should not wrap or change them."""
+    document = b"filecontents"
+    assert _multipart_file(document) is document
 
 
 def test_should_raise_for_status(app_antivirus_client, rmock):


### PR DESCRIPTION
As part of vulnerability work, I was trying to upgrade notifications-admin
One of the dependencies that were bumped was `requests`.

It seems like the last time we tried to bump admin with this dependency, we ran into this issue [here](https://govuk-notify-gds.sentry.io/issues/7626487773/?project=4504949328838656&query=is%3Aunresolved&referrer=issue-stream):
`TypeError: a bytes-like object is required, not 'FileStorage'`

That's because after dependency upgrades, `requests 2.34` no longer accepts the way we were sending files chosen in the browser.

So with this change fixes how we build that HTTP upload for admin, without changing what each app passes in. Document-download-api still passes plain bytes; that path is unchanged.

https://tedboy.github.io/flask/generated/generated/werkzeug.FileStorage.html

https://trello.com/c/AY4TcgE0/718-vulnerability-review-replenishment-28-july-3-august-2026-pigeon


