### PR TITLE
Correctly count complex unicode characters in text messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 125.0.1
+
+* Fixes a number of bugs with counting characters in text message templates
+
 ## 125.0.0
 
 * Removes `RecipientCSV.rows_as_list` and `RecipientCSV.get_rows()`. Use `for row in recipient_csv_instance:`, `len(recipient_csv_instance)`, etc. instead

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -71,9 +71,12 @@ class SanitiseText:
             # For a full list of the types, see here: https://www.compart.com/en/unicode/decomposition.
             # If it's got a mapping, we're not sure how best to downgrade it, so just see if it's in the
             # REPLACEMENT_CHARACTERS map. If not, then it's probably a letter with a modifier, eg á
-            # ASSUMPTION: The first character of a combined unicode character (eg 'á' == '0061 0301')
-            # will be the ascii char
-            return cls.get_unicode_char_from_codepoint(decomposed.split()[0])
+            # If this is the case then the first character of a combined unicode character (eg 'á' == '0061 0301')
+            # will be an ASCII char in ALLOWED_CHARACTERS
+            first_character_of_decomposition = cls.get_unicode_char_from_codepoint(decomposed.split()[0])
+            if first_character_of_decomposition in cls.ALLOWED_CHARACTERS:
+                return first_character_of_decomposition
+            return None
         else:
             # try and find a mapping (eg en dash -> hyphen ('–': '-')), else return None
             return cls.REPLACEMENT_CHARACTERS.get(c)

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -233,18 +233,24 @@ class BaseSMSTemplate(Template):
         Return the number of characters in the message, after sanitising the
         content.
 
+        Encoding as `utf-16-le` (little endian) instead of `utf-16` gives us
+        bytes without a preceding BOM (byte-order mark). Each code point in
+        UTF-16 takes 2 bytes, so we floor divide by 2 to get the number of
+        code points.
+
         Note: if values are not provided, this will calculate the raw length of
         the unsubstituted placeholders, for example `foo ((placeholder))` has
         a length of 19.
         """
-        return len(self.content_with_placeholders_filled_in)
+        return len(self.content_with_placeholders_filled_in.encode("utf-16-le")) // 2
 
     @property
     def content_count_without_prefix(self) -> int:
         # subtract 2 extra characters to account for the colon and the space,
         # added max zero in case the content is empty the __str__ methods strips the white space.
         if self.prefix:
-            return max((self.content_count - len(self.prefix) - 2), 0)
+            prefix_length = len(sms_encode(self.prefix).encode("utf-16-le")) // 2
+            return max((self.content_count - prefix_length - 2), 0)
         else:
             return self.content_count
 

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -246,10 +246,12 @@ class BaseSMSTemplate(Template):
 
     @property
     def content_count_without_prefix(self) -> int:
-        # subtract 2 extra characters to account for the colon and the space,
-        # added max zero in case the content is empty the __str__ methods strips the white space.
         if self.prefix:
+            # See docstring of `content_count` for explanation
             prefix_length = len(sms_encode(self.prefix).encode("utf-16-le")) // 2
+
+            # subtract 2 extra characters to account for the colon and the space,
+            # added max zero in case the content is empty the __str__ methods strips the white space.
             return max((self.content_count - prefix_length - 2), 0)
         else:
             return self.content_count

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -230,13 +230,14 @@ class BaseSMSTemplate(Template):
     @cached_property
     def content_count(self) -> int:
         """
-        Return the number of characters in the message. Note that we don't distinguish between GSM and non-GSM
-        characters at this point, as `get_sms_fragment_count` handles that separately.
+        Return the number of characters in the message, after sanitising the
+        content.
 
-        Also note that if values aren't provided, will calculate the raw length of the unsubstituted placeholders,
-        as in the message `foo ((placeholder))` has a length of 19.
+        Note: if values are not provided, this will calculate the raw length of
+        the unsubstituted placeholders, for example `foo ((placeholder))` has
+        a length of 19.
         """
-        return len(self.unsanitised_content)
+        return len(self.content_with_placeholders_filled_in)
 
     @property
     def content_count_without_prefix(self) -> int:

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "125.0.0"  # 4458fa1f571a8f2bc4545c253d5f30ef
+__version__ = "125.0.1"  # cff7f04da846f2925ed4171143c18fdf

--- a/tests/test_sanitise_text.py
+++ b/tests/test_sanitise_text.py
@@ -21,6 +21,8 @@ params, ids = zip(
     # this unicode char is not decomposable
     (("😬", "?"), "undecomposable unicode char (grimace emoji)"),
     (("↉", "?"), "vulgar fraction (↉) that we do not try decomposing"),
+    # Unicode plane 2, decomposes but not to ASCII characters
+    (("嶲", "?"), "CJK Extension F"),
     strict=True,
 )
 

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -1052,6 +1052,146 @@ def test_character_count_for_sms_templates(
 
 
 @pytest.mark.parametrize(
+    "template_class",
+    [
+        SMSMessageTemplate,
+        SMSPreviewTemplate,
+    ],
+)
+@pytest.mark.parametrize(
+    "content, expected_count",
+    [
+        (
+            # Short Arabic (RTL)
+            "مرحبا",
+            5,
+        ),
+        (
+            # Arabic sentence (RTL)
+            "تم إرسال رسالتك",
+            15,
+        ),
+        (
+            # Arabic + Eastern Arabic numerals
+            "اختبار ١٢٣",
+            10,
+        ),
+        (
+            # Mixed LTR + RTL
+            "Hello مرحبا",
+            11,
+        ),
+        (
+            # Complex CJK (U+20BB7)
+            "𠮷",
+            2,
+        ),
+        (
+            # Complex char in Latin context
+            "Test 𠮷 char",
+            12,
+        ),
+        (
+            # CJK Extension F (U+2F9F4)
+            "嶲",
+            2,
+        ),
+        (
+            # Welsh (existing allowed set)
+            "Croeso Ŵ",
+            8,
+        ),
+        (
+            # Polish diacritics (ń)
+            "Dzień dobry",
+            11,
+        ),
+        (
+            # Hindi (Devanagari)
+            "नमस्ते",
+            6,
+        ),
+        (
+            # Chinese (Simplified)
+            "你好",
+            2,
+        ),
+        (
+            # Emoji (full Unicode)
+            "Test 😀",
+            7,
+        ),
+        (
+            # ZWJ family emoji (counts as multiple code points)
+            "👨‍👩‍👧‍👦",
+            11,
+        ),
+        (
+            # GSM baseline (control — should be 160-char encoding)
+            "Your code is 123456",
+            19,
+        ),
+        (
+            # “Smart punctuation” vs GSM hyphen (en-dash U+2013)
+            "–",
+            1,
+        ),
+        (
+            # Polish quotation marks + ś, ć
+            '„Cześć"',
+            7,
+        ),
+        (
+            # Arabic + English + CJK + emoji in one message
+            "مرحبا Test 𠮷 😀",
+            16,
+        ),
+        (
+            # En dash, em dash, curly quotes, ellipsis (all non-GSM-7 punctuation)
+            "– — “ ” …",
+            9,
+        ),
+    ],
+)
+def test_character_count_for_unicode_sms_templates(
+    template_class,
+    content,
+    expected_count,
+    mocker,
+):
+    # Once we allow a wide range of unicode characters in text message templates we can
+    # remove this mock and pass `content` directly to the `"content"` field of the template
+    # dict
+    mocker.patch.object(template_class, "content_with_placeholders_filled_in", content)
+
+    template = template_class({"content": "MOCKED", "template_type": "sms"})
+    assert template.content_count == expected_count, f"Wrong count ({content=}, {expected_count=})"
+
+
+@pytest.mark.parametrize(
+    "template_class",
+    [
+        SMSMessageTemplate,
+        SMSPreviewTemplate,
+    ],
+)
+def test_character_count_for_unicode_sms_template_with_unicode_prefix(template_class):
+    template = template_class({"content": "嶲", "template_type": "sms"}, prefix="👨‍👩‍👧‍👦")
+
+    # This encodes to:
+    #     Index:     1234567
+    #     Character: ????: ?
+    # It should change when we support wider range of unicode characters
+    assert template.content_count == 7
+
+    # This counts:
+    #     Index:     1
+    #     Character: ?
+    # It should change when we support wider range of unicode characters
+    assert template.content_count_without_prefix == 1
+
+
+@pytest.mark.parametrize(
     "template_content, expected_sms_fragment_count, expected_count_of_characters_above_previous_fragment_boundary",
     [
         ("à" * 71, 1, 71),  # welsh character in GSM


### PR DESCRIPTION
Our existing character count makes the assumption that 1 character in a message will be encoded and charged as 1 character by our providers.

This is true for the limited number of non-GSM characters we currently support, such as `Ŵ` and `ŷ`.

Once we start supporting a wider range of unicode characters, this assumption breaks because some characters require multiple code points to encode.

An extreme example is 👨‍👩‍👧‍👦, which is effectively:
> `👨` + `[joiner]` + `👩` + `[joiner]` + `👧` + `[joiner]` + `👦`

Each emoji takes 2 UTF-16 code points, and each joiner takes 1, so:
> 2 + 1 + 2 + 1 + 2 + 1 + 2 = 11

We encode the content as `utf-16-le` (little endian) instead of `utf-16` because that gives bytes without a preceding BOM (byte-order mark). Each code point in UTF-16 takes 2 bytes, so we floor divide by 2 to get the number of code points. This is what we are charged for.

---

All the test examples come from [📝 Multilingual SMS - feature doc](https://docs.google.com/document/d/1SpY9ecLJoA2zIvvxKqBFUXBRba6QreI0ihtkVX1ogWQ/edit?tab=t.23t60h9vu6k0#heading=h.dbyeyt1vcq4m)

I compared them against [QuickSMS SMS & RCS Character Counter](https://www.quicksms.com/sms-character-counter) (which was recommended by one of our providers) and verified that the counts match.

---

An alternative way of doing this would be:
```python
def content_count(self) -> int:
    # >= 65536 is unicode plane 2 
    sum(1 if ord(c) < 65536 else 2 for c in self.content_with_placeholders_filled_in)
```

However when I tested this it was 2.5× slower.

---

This pull request also fixes a number of bugs with the way we count characters, these are detailed in separate commits.

---

This pull request does not change how we encode messages, so it doesn’t yet change what we actually send.

https://trello.com/c/D0gIzzY6/683-prepare-the-billing-code-and-fragment-counter-for-unicode-support-in-sms