### PR TITLE
`NotifyTask`: measure thread time used by celery task execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 125.1.0
+
+* `NotifyTask`: measure thread time used by celery task execution, annotate this on to completion log messages and emit a metric.
+
 ## 125.0.1
 
 * Fixes a number of bugs with counting characters in text message templates

--- a/notifications_utils/celery.py
+++ b/notifications_utils/celery.py
@@ -2,6 +2,7 @@ import logging
 import time
 from contextlib import contextmanager, nullcontext
 from os import getpid
+from time import thread_time_ns
 
 from celery import Celery, Task
 from celery.backends.base import DisabledBackend
@@ -9,6 +10,8 @@ from flask import Flask, current_app, g, request
 from flask.ctx import has_app_context, has_request_context
 from opentelemetry import metrics
 
+from notifications_utils.eventlet import greenlet_thread_time_ns  # not that we (currently) use eventlet with celery
+from notifications_utils.logging.formatting import _ns_per_s
 from notifications_utils.semconv import TASK_DURATION_HISTOGRAM_BUCKETS
 
 duration_histogram = metrics.get_meter(__name__).create_histogram(
@@ -18,10 +21,18 @@ duration_histogram = metrics.get_meter(__name__).create_histogram(
     explicit_bucket_boundaries_advisory=TASK_DURATION_HISTOGRAM_BUCKETS,
 )
 
+celery_task_cpu_time_histogram = metrics.get_meter(__name__).create_histogram(
+    "celery.task.cpu_time",
+    unit="s",
+    description="The total python thread_time used by a celery task execution.",
+    explicit_bucket_boundaries_advisory=TASK_DURATION_HISTOGRAM_BUCKETS,
+)
+
 
 class NotifyTask(Task):
     abstract = True
     start: float
+    start_thread_time_ns: int
     app: "NotifyCelery"
 
     def __init__(self, *args, **kwargs):
@@ -53,9 +64,9 @@ class NotifyTask(Task):
             g.request_id = self.request_id
             yield
 
-    def _record_duration(self, duration: float, status: str) -> None:
-        duration_histogram.record(
-            duration,
+    def _record_histogram(self, histogram: metrics.Histogram, value: float, status: str) -> None:
+        histogram.record(
+            value,
             {
                 "celery.task.name": self.name,
                 "celery.task.status": status,
@@ -67,6 +78,9 @@ class NotifyTask(Task):
         # enables request id tracing for these logs
         with self.app_context():
             elapsed_time = time.monotonic() - self.start
+            elapsed_thread_time = (
+                (greenlet_thread_time_ns() or thread_time_ns()) - self.start_thread_time_ns
+            ) * _ns_per_s
 
             self.app.flask_app.logger.info(
                 "Celery task %s (queue: %s) took %.4f",
@@ -79,17 +93,22 @@ class NotifyTask(Task):
                     "queue_name": self.queue_name,
                     "retry_number": self.request.retries,
                     "duration": elapsed_time,
+                    "celery_task_cpu_time": elapsed_thread_time,
                     # avoid name collision with LogRecord's own `process` attribute
                     "process_": getpid(),
                 },
             )
 
-            self._record_duration(elapsed_time, "success")
+            self._record_histogram(duration_histogram, elapsed_time, "success")
+            self._record_histogram(celery_task_cpu_time_histogram, elapsed_thread_time, "success")
 
     def on_retry(self, exc, task_id, args, kwargs, einfo):
         # enables request id tracing for these logs
         with self.app_context():
             elapsed_time = time.monotonic() - self.start
+            elapsed_thread_time = (
+                (greenlet_thread_time_ns() or thread_time_ns()) - self.start_thread_time_ns
+            ) * _ns_per_s
 
             self.app.flask_app.logger.warning(
                 "Celery task %s (queue: %s) failed for retry after %.4f",
@@ -103,17 +122,22 @@ class NotifyTask(Task):
                     "queue_name": self.queue_name,
                     "retry_number": self.request.retries,
                     "duration": elapsed_time,
+                    "celery_task_cpu_time": elapsed_thread_time,
                     # avoid name collision with LogRecord's own `process` attribute
                     "process_": getpid(),
                 },
             )
 
-            self._record_duration(elapsed_time, "retry")
+            self._record_histogram(duration_histogram, elapsed_time, "retry")
+            self._record_histogram(celery_task_cpu_time_histogram, elapsed_thread_time, "retry")
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         # enables request id tracing for these logs
         with self.app_context():
             elapsed_time = time.monotonic() - self.start
+            elapsed_thread_time = (
+                (greenlet_thread_time_ns() or thread_time_ns()) - self.start_thread_time_ns
+            ) * _ns_per_s
 
             self.app.flask_app.logger.exception(
                 "Celery task %s (queue: %s) failed after %.4f",
@@ -126,17 +150,20 @@ class NotifyTask(Task):
                     "queue_name": self.queue_name,
                     "retry_number": self.request.retries,
                     "duration": elapsed_time,
+                    "celery_task_cpu_time": elapsed_thread_time,
                     # avoid name collision with LogRecord's own `process` attribute
                     "process_": getpid(),
                 },
             )
 
-            self._record_duration(elapsed_time, "failure")
+            self._record_histogram(duration_histogram, elapsed_time, "failure")
+            self._record_histogram(celery_task_cpu_time_histogram, elapsed_thread_time, "failure")
 
     def __call__(self, *args, **kwargs):
         # ensure task has flask context to access config, logger, etc
         with self.app_context():
             self.start = time.monotonic()
+            self.start_thread_time_ns = greenlet_thread_time_ns() or thread_time_ns()
 
             if self.request.id is not None:
                 # we're not being called synchronously

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "125.0.1"  # cff7f04da846f2925ed4171143c18fdf
+__version__ = "125.1.0"  # 909d86735c524d0abac04d89479efa46

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -9,7 +9,8 @@ from celery.backends.redis import RedisBackend
 from flask import g
 from freezegun import freeze_time
 
-from notifications_utils.celery import NotifyCelery, duration_histogram
+from notifications_utils.celery import NotifyCelery, celery_task_cpu_time_histogram, duration_histogram
+from notifications_utils.testing.comparisons import RestrictedAny
 
 
 @pytest.fixture
@@ -61,7 +62,8 @@ def request_id_task(celery_task):
 
 
 def test_success_should_log_and_record_timing(async_task, caplog, mocker):
-    record_mock = mocker.patch.object(duration_histogram, "record")
+    duration_record_mock = mocker.patch.object(duration_histogram, "record")
+    cputime_record_mock = mocker.patch.object(celery_task_cpu_time_histogram, "record")
 
     with freeze_time() as frozen, caplog.at_level(logging.INFO):
         async_task()
@@ -69,20 +71,34 @@ def test_success_should_log_and_record_timing(async_task, caplog, mocker):
 
         async_task.on_success(retval=None, task_id=1234, args=[], kwargs={})
 
-    record_mock.assert_called_once_with(
-        5.0,
-        {
-            "celery.task.name": async_task.name,
-            "celery.task.status": "success",
-            "sqs.queue.name": "test-queue",
-        },
-    )
+    assert duration_record_mock.mock_calls == [
+        mocker.call(
+            5.0,
+            {
+                "celery.task.name": async_task.name,
+                "celery.task.status": "success",
+                "sqs.queue.name": "test-queue",
+            },
+        )
+    ]
+    assert cputime_record_mock.mock_calls == [
+        mocker.call(
+            RestrictedAny(lambda x: x > 0),
+            {
+                "celery.task.name": async_task.name,
+                "celery.task.status": "success",
+                "sqs.queue.name": "test-queue",
+            },
+        )
+    ]
+
     assert f"Celery task {async_task.name} (queue: test-queue) started" in caplog.messages
     assert f"Celery task {async_task.name} (queue: test-queue) took 5.0000" in caplog.messages
 
 
 def test_success_no_early_log(async_task_early_debug, caplog, mocker):
-    record_mock = mocker.patch.object(duration_histogram, "record")
+    duration_record_mock = mocker.patch.object(duration_histogram, "record")
+    cputime_record_mock = mocker.patch.object(celery_task_cpu_time_histogram, "record")
 
     with freeze_time() as frozen, caplog.at_level(logging.INFO):
         async_task_early_debug()
@@ -90,20 +106,34 @@ def test_success_no_early_log(async_task_early_debug, caplog, mocker):
 
         async_task_early_debug.on_success(retval=None, task_id=1234, args=[], kwargs={})
 
-    record_mock.assert_called_once_with(
-        5.0,
-        {
-            "celery.task.name": async_task_early_debug.name,
-            "celery.task.status": "success",
-            "sqs.queue.name": "test-queue",
-        },
-    )
+    assert duration_record_mock.mock_calls == [
+        mocker.call(
+            5.0,
+            {
+                "celery.task.name": async_task_early_debug.name,
+                "celery.task.status": "success",
+                "sqs.queue.name": "test-queue",
+            },
+        )
+    ]
+    assert cputime_record_mock.mock_calls == [
+        mocker.call(
+            RestrictedAny(lambda x: x > 0),
+            {
+                "celery.task.name": async_task_early_debug.name,
+                "celery.task.status": "success",
+                "sqs.queue.name": "test-queue",
+            },
+        )
+    ]
+
     assert f"Celery task {async_task_early_debug.name} (queue: test-queue) started" not in caplog.messages
     assert f"Celery task {async_task_early_debug.name} (queue: test-queue) took 5.0000" in caplog.messages
 
 
 def test_success_queue_when_applied_synchronously(celery_task, caplog, mocker):
-    record_mock = mocker.patch.object(duration_histogram, "record")
+    duration_record_mock = mocker.patch.object(duration_histogram, "record")
+    cputime_record_mock = mocker.patch.object(celery_task_cpu_time_histogram, "record")
 
     with freeze_time() as frozen, caplog.at_level(logging.INFO):
         celery_task()
@@ -111,20 +141,34 @@ def test_success_queue_when_applied_synchronously(celery_task, caplog, mocker):
 
         celery_task.on_success(retval=None, task_id=1234, args=[], kwargs={})
 
-    record_mock.assert_called_once_with(
-        5.0,
-        {
-            "celery.task.name": celery_task.name,
-            "celery.task.status": "success",
-            "sqs.queue.name": "none",
-        },
-    )
+    assert duration_record_mock.mock_calls == [
+        mocker.call(
+            5.0,
+            {
+                "celery.task.name": celery_task.name,
+                "celery.task.status": "success",
+                "sqs.queue.name": "none",
+            },
+        )
+    ]
+    assert cputime_record_mock.mock_calls == [
+        mocker.call(
+            RestrictedAny(lambda x: x > 0),
+            {
+                "celery.task.name": celery_task.name,
+                "celery.task.status": "success",
+                "sqs.queue.name": "none",
+            },
+        )
+    ]
+
     assert f"Celery task {celery_task.name} (queue: none) started" not in caplog.messages
     assert f"Celery task {celery_task.name} (queue: none) took 5.0000" in caplog.messages
 
 
 def test_retry_should_log_and_record_metrics(async_task, caplog, mocker):
-    record_mock = mocker.patch.object(duration_histogram, "record")
+    duration_record_mock = mocker.patch.object(duration_histogram, "record")
+    cputime_record_mock = mocker.patch.object(celery_task_cpu_time_histogram, "record")
 
     with freeze_time() as frozen, caplog.at_level(logging.WARNING):
         async_task()
@@ -132,20 +176,34 @@ def test_retry_should_log_and_record_metrics(async_task, caplog, mocker):
 
         async_task.on_retry(exc=Exception, task_id="1234", args=[], kwargs={}, einfo=None)
 
-    record_mock.assert_called_once_with(
-        5.0,
-        {
-            "celery.task.name": async_task.name,
-            "celery.task.status": "retry",
-            "sqs.queue.name": "test-queue",
-        },
-    )
+    assert duration_record_mock.mock_calls == [
+        mocker.call(
+            5.0,
+            {
+                "celery.task.name": async_task.name,
+                "celery.task.status": "retry",
+                "sqs.queue.name": "test-queue",
+            },
+        )
+    ]
+    assert cputime_record_mock.mock_calls == [
+        mocker.call(
+            RestrictedAny(lambda x: x > 0),
+            {
+                "celery.task.name": async_task.name,
+                "celery.task.status": "retry",
+                "sqs.queue.name": "test-queue",
+            },
+        )
+    ]
+
     assert f"Celery task {async_task.name} (queue: test-queue) started" not in caplog.messages  # log level too low
     assert f"Celery task {async_task.name} (queue: test-queue) failed for retry after 5.0000" in caplog.messages
 
 
 def test_retry_queue_when_applied_synchronously(celery_task, caplog, mocker):
-    record_mock = mocker.patch.object(duration_histogram, "record")
+    duration_record_mock = mocker.patch.object(duration_histogram, "record")
+    cputime_record_mock = mocker.patch.object(celery_task_cpu_time_histogram, "record")
 
     with freeze_time() as frozen, caplog.at_level(logging.WARNING):
         celery_task()
@@ -153,20 +211,34 @@ def test_retry_queue_when_applied_synchronously(celery_task, caplog, mocker):
 
         celery_task.on_retry(exc=Exception, task_id="1234", args=[], kwargs={}, einfo=None)
 
-    record_mock.assert_called_once_with(
-        5.0,
-        {
-            "celery.task.name": celery_task.name,
-            "celery.task.status": "retry",
-            "sqs.queue.name": "none",
-        },
-    )
+    assert duration_record_mock.mock_calls == [
+        mocker.call(
+            5.0,
+            {
+                "celery.task.name": celery_task.name,
+                "celery.task.status": "retry",
+                "sqs.queue.name": "none",
+            },
+        )
+    ]
+    assert cputime_record_mock.mock_calls == [
+        mocker.call(
+            RestrictedAny(lambda x: x > 0),
+            {
+                "celery.task.name": celery_task.name,
+                "celery.task.status": "retry",
+                "sqs.queue.name": "none",
+            },
+        )
+    ]
+
     assert f"Celery task {celery_task.name} (queue: none) started" not in caplog.messages  # log level too low
     assert f"Celery task {celery_task.name} (queue: none) failed for retry after 5.0000" in caplog.messages
 
 
 def test_failure_should_log_and_record_metrics(async_task, caplog, mocker):
-    record_mock = mocker.patch.object(duration_histogram, "record")
+    duration_record_mock = mocker.patch.object(duration_histogram, "record")
+    cputime_record_mock = mocker.patch.object(celery_task_cpu_time_histogram, "record")
 
     with freeze_time() as frozen, caplog.at_level(logging.INFO):
         async_task()
@@ -174,35 +246,60 @@ def test_failure_should_log_and_record_metrics(async_task, caplog, mocker):
 
         async_task.on_failure(exc=Exception, task_id=1234, args=[], kwargs={}, einfo=None)
 
-    record_mock.assert_called_once_with(
-        5.0,
-        {
-            "celery.task.name": async_task.name,
-            "celery.task.status": "failure",
-            "sqs.queue.name": "test-queue",
-        },
-    )
+    assert duration_record_mock.mock_calls == [
+        mocker.call(
+            5.0,
+            {
+                "celery.task.name": async_task.name,
+                "celery.task.status": "failure",
+                "sqs.queue.name": "test-queue",
+            },
+        )
+    ]
+    assert cputime_record_mock.mock_calls == [
+        mocker.call(
+            RestrictedAny(lambda x: x > 0),
+            {
+                "celery.task.name": async_task.name,
+                "celery.task.status": "failure",
+                "sqs.queue.name": "test-queue",
+            },
+        )
+    ]
 
     assert f"Celery task {async_task.name} (queue: test-queue) started" in caplog.messages
     assert f"Celery task {async_task.name} (queue: test-queue) failed after 5.0000" in caplog.messages
 
 
 def test_failure_queue_when_applied_synchronously(celery_task, caplog, mocker):
-    record_mock = mocker.patch.object(duration_histogram, "record")
+    duration_record_mock = mocker.patch.object(duration_histogram, "record")
+    cputime_record_mock = mocker.patch.object(celery_task_cpu_time_histogram, "record")
 
     with freeze_time() as frozen, caplog.at_level(logging.ERROR):
         celery_task()
         frozen.tick(5)
         celery_task.on_failure(exc=Exception, task_id=1234, args=[], kwargs={}, einfo=None)
 
-    record_mock.assert_called_once_with(
-        5.0,
-        {
-            "celery.task.name": celery_task.name,
-            "celery.task.status": "failure",
-            "sqs.queue.name": "none",
-        },
-    )
+    assert duration_record_mock.mock_calls == [
+        mocker.call(
+            5.0,
+            {
+                "celery.task.name": celery_task.name,
+                "celery.task.status": "failure",
+                "sqs.queue.name": "none",
+            },
+        )
+    ]
+    assert cputime_record_mock.mock_calls == [
+        mocker.call(
+            RestrictedAny(lambda x: x > 0),
+            {
+                "celery.task.name": celery_task.name,
+                "celery.task.status": "failure",
+                "sqs.queue.name": "none",
+            },
+        )
+    ]
 
     assert f"Celery task {celery_task.name} (queue: none) started" not in caplog.messages  # log level too low
     assert f"Celery task {celery_task.name} (queue: none) failed after 5.0000" in caplog.messages


### PR DESCRIPTION
https://trello.com/c/dYDuTWoW/746-add-cpu-time-measurements-to-celery-tasks

Annotate this onto the completion log message and generate a metric with it.

Note this does *not* include the cpu time used by child processes such as those launched by subprocess in template-preview.