### PR TITLE
Simplify `add_prefix` call on `SMSPreviewTemplate`

### DIFF
--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -399,7 +399,7 @@ class SMSPreviewTemplate(BaseSMSTemplate):
                             redact_missing_personalisation=self.redact_missing_personalisation,
                         )
                     )
-                    .then(add_prefix, (escape_html(self.prefix) or None) if self.show_prefix else None)
+                    .then(add_prefix, escape_html(self.prefix))
                     .then(sms_encode if self.downgrade_non_sms_characters else str)
                     .then(remove_whitespace_before_punctuation)
                     .then(normalise_whitespace_and_newlines)


### PR DESCRIPTION
`add_prefix` will only change the content if its `prefix` argument is truthy:
https://github.com/alphagov/notifications-utils/blob/c998adaf019ecddcc1fdb47293b0bb3f77059c41/notifications_utils/formatters.py#L71-L74

`escape_html` will return a non-truthy value for non-truthy input: https://github.com/alphagov/notifications-utils/blob/c998adaf019ecddcc1fdb47293b0bb3f77059c41/notifications_utils/formatters.py#L176-L178

`SMSPreviewTemplate.prefix` will be `None` if initialised with `show_prefix=False`: https://github.com/alphagov/notifications-utils/blob/c998adaf019ecddcc1fdb47293b0bb3f77059c41/notifications_utils/template.py#L222-L224

So we don’t need to do all these extra conditonals here.

***

This follows the same call for `BaseSMSTemplate`:
https://github.com/alphagov/notifications-utils/blob/c998adaf019ecddcc1fdb47293b0bb3f77059c41/notifications_utils/template.py#L320

***

This is tested here:
https://github.com/alphagov/notifications-utils/blob/798794019a0793147623b4167fcad25507636661/tests/test_template_types.py#L500-L552