### PR TITLE
Remove `formatters.sanitise_sms`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 126.0.0
+
+* Removes `formatters.sms_encode` (use `sanitise_text.SantiseSMS.encode` directly instead)
+
 ## 125.1.1
 
 * Ran `make refreeze-requirements` during dependency day

--- a/notifications_utils/formatters.py
+++ b/notifications_utils/formatters.py
@@ -11,8 +11,6 @@ from urllib.parse import quote
 import smartypants
 from markupsafe import Markup
 
-from notifications_utils.sanitise_text import SanitiseSMS
-
 from . import email_with_smart_quotes_regex
 
 OBSCURE_ZERO_WIDTH_WHITESPACE = (
@@ -152,10 +150,6 @@ def create_sanitised_html_for_url(
 
 def prepend_subject(body: str, subject: str) -> str:
     return f"# {subject}\n\n{body}"
-
-
-def sms_encode(content: str) -> str:
-    return SanitiseSMS.encode(content)
 
 
 """

--- a/notifications_utils/template.py
+++ b/notifications_utils/template.py
@@ -36,7 +36,6 @@ from notifications_utils.formatters import (
     replace_hyphens_with_en_dashes,
     replace_hyphens_with_non_breaking_hyphens,
     restore_svg_dashes,
-    sms_encode,
     strip_leading_whitespace,
     strip_unsupported_characters,
     unlink_govuk_escaped,
@@ -248,7 +247,7 @@ class BaseSMSTemplate(Template):
     def content_count_without_prefix(self) -> int:
         if self.prefix:
             # See docstring of `content_count` for explanation
-            prefix_length = len(sms_encode(self.prefix).encode("utf-16-le")) // 2
+            prefix_length = len(SanitiseSMS.encode(self.prefix).encode("utf-16-le")) // 2
 
             # subtract 2 extra characters to account for the colon and the space,
             # added max zero in case the content is empty the __str__ methods strips the white space.
@@ -328,7 +327,7 @@ class BaseSMSTemplate(Template):
 
 class SMSMessageTemplate(BaseSMSTemplate):
     def __str__(self: BaseSMSTemplate) -> str:
-        return sms_encode(self.unsanitised_content)
+        return SanitiseSMS.encode(self.unsanitised_content)
 
 
 class SMSBodyPreviewTemplate(BaseSMSTemplate):
@@ -349,7 +348,7 @@ class SMSBodyPreviewTemplate(BaseSMSTemplate):
                     redact_missing_personalisation=True,
                 )
             )
-            .then(sms_encode)
+            .then(SanitiseSMS.encode)
             .then(remove_whitespace_before_punctuation)
             .then(normalise_whitespace_and_newlines)
             .then(normalise_multiple_newlines)
@@ -400,7 +399,7 @@ class SMSPreviewTemplate(BaseSMSTemplate):
                         )
                     )
                     .then(add_prefix, escape_html(self.prefix))
-                    .then(sms_encode if self.downgrade_non_sms_characters else str)
+                    .then(SanitiseSMS.encode if self.downgrade_non_sms_characters else str)
                     .then(remove_whitespace_before_punctuation)
                     .then(normalise_whitespace_and_newlines)
                     .then(normalise_multiple_newlines)

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "125.1.1"  # c450e79e21d3207134f44afb3f0b5266
+__version__ = "126.0.0"  # b77a88259e469cc5611ad461c630915f

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -11,7 +11,6 @@ from notifications_utils.formatters import (
     remove_smart_quotes_from_email_addresses,
     remove_whitespace_before_punctuation,
     replace_hyphens_with_en_dashes,
-    sms_encode,
     strip_all_whitespace,
     strip_and_remove_obscure_whitespace,
     strip_unsupported_characters,
@@ -147,12 +146,6 @@ def test_sms_preview_adds_newlines():
     template.prefix = None
     template.sender = None
     assert "<br>" in str(template)
-
-
-def test_sms_encode(mocker):
-    sanitise_mock = mocker.patch("notifications_utils.formatters.SanitiseSMS")
-    assert sms_encode("foo") == sanitise_mock.encode.return_value
-    sanitise_mock.encode.assert_called_once_with("foo")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_template_types.py
+++ b/tests/test_template_types.py
@@ -577,7 +577,7 @@ def test_sms_message_preview_hides_sender_by_default():
     assert SMSPreviewTemplate({"content": "foo", "template_type": "sms"}).show_sender is False
 
 
-@mock.patch("notifications_utils.template.sms_encode", return_value="downgraded")
+@mock.patch("notifications_utils.template.SanitiseSMS.encode", return_value="downgraded")
 @pytest.mark.parametrize(
     "template_class, extra_args, expected_call",
     (
@@ -597,7 +597,7 @@ def test_sms_messages_downgrade_non_sms(
     mock_sms_encode.assert_called_once_with(expected_call)
 
 
-@mock.patch("notifications_utils.template.sms_encode", return_value="downgraded")
+@mock.patch("notifications_utils.template.SanitiseSMS.encode", return_value="downgraded")
 def test_sms_messages_dont_downgrade_non_sms_if_setting_is_false(mock_sms_encode):
     template = str(
         SMSPreviewTemplate(


### PR DESCRIPTION
It’s just as alias for `SanitiseSMS.encode` which adds another layer of indirection, and it’s not used by any of the apps.