### PR TITLE
Move and rename ‘non compatible characters’ method in `sanitise_text`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 127.0.0
+
+* Removes `SanitiseText.get_non_compatible_characters()` (for text message content use `SanitiseText.get_non_gsm_characters()` instead)
+
 ## 126.0.1
 
 * Runs `remove_whitespace_before_punctuation` before GSM-7-encoding in subclasses of `BaseSMSTemplate`

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -36,15 +36,6 @@ class SanitiseText:
     def encode(cls, content: str) -> str:
         return "".join(cls.encode_char(char) for char in content)
 
-    @classmethod
-    def get_non_compatible_characters(cls, content: str) -> Set:
-        """
-        Given an input string, return a set of non compatible characters.
-
-        This follows the same rules as `cls.encode`, but returns just the characters that encode would replace with `?`
-        """
-        return {c for c in content if c not in cls.ALLOWED_CHARACTERS and cls.downgrade_character(c) is None}
-
     @staticmethod
     def get_unicode_char_from_codepoint(codepoint: str) -> str:
         """
@@ -139,6 +130,15 @@ class SanitiseSMS(SanitiseText):
     ALLOWED_CHARACTERS: Set[str] = GSM_CHARACTERS | WELSH_DIACRITICS
     # some welsh characters are in GSM and some aren't - we need to distinguish between these for counting fragments
     WELSH_NON_GSM_CHARACTERS: Set[str] = WELSH_DIACRITICS - GSM_CHARACTERS
+
+    @classmethod
+    def get_non_compatible_characters(cls, content: str) -> Set:
+        """
+        Given an input string, return a set of non compatible characters.
+
+        This follows the same rules as `cls.encode`, but returns just the characters that encode would replace with `?`
+        """
+        return {c for c in content if c not in cls.ALLOWED_CHARACTERS and cls.downgrade_character(c) is None}
 
 
 class SanitiseASCII(SanitiseText):

--- a/notifications_utils/sanitise_text.py
+++ b/notifications_utils/sanitise_text.py
@@ -132,9 +132,9 @@ class SanitiseSMS(SanitiseText):
     WELSH_NON_GSM_CHARACTERS: Set[str] = WELSH_DIACRITICS - GSM_CHARACTERS
 
     @classmethod
-    def get_non_compatible_characters(cls, content: str) -> Set:
+    def get_non_gsm_characters(cls, content: str) -> Set:
         """
-        Given an input string, return a set of non compatible characters.
+        Return a set of characters which can’t be encoded to GSM-7, either through replacement or decomposition.
 
         This follows the same rules as `cls.encode`, but returns just the characters that encode would replace with `?`
         """

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "126.0.1"  # 91323657d9b2b62a4584031434bbeb55
+__version__ = "127.0.0"  # 61e99fd00f752af77e1682110110a928

--- a/tests/test_sanitise_text.py
+++ b/tests/test_sanitise_text.py
@@ -97,5 +97,5 @@ def test_encode_string(content, expected):
         ("Obscure\u00a0whitespace\u202fcharacters which \u2028we \u2029normalise o\u180eut", set()),
     ],
 )
-def test_sms_encoding_get_non_compatible_characters(content, expected):
-    assert SanitiseSMS.get_non_compatible_characters(content) == expected
+def test_sms_encoding_get_non_gsm_characters(content, expected):
+    assert SanitiseSMS.get_non_gsm_characters(content) == expected

--- a/tests/test_sanitise_text.py
+++ b/tests/test_sanitise_text.py
@@ -87,16 +87,15 @@ def test_encode_string(content, expected):
 
 
 @pytest.mark.parametrize(
-    "content, cls, expected",
+    "content, expected",
     [
-        ("The quick brown fox jumps over the lazy dog", SanitiseSMS, set()),
-        ("The “quick” brown fox has some downgradable characters\xa0", SanitiseSMS, set()),
-        ("Need more 🐮🔔", SanitiseSMS, {"🐮", "🔔"}),
-        ("Ŵêlsh chârâctêrs ârê cômpâtîblê wîth SanitiseSMS", SanitiseSMS, set()),
-        ("Lots of GSM chars that arent ascii compatible:\n\r€", SanitiseSMS, set()),
-        ("Lots of GSM chars that arent ascii compatible:\n\r€", SanitiseASCII, {"\n", "\r", "€"}),
-        ("Obscure\u00a0whitespace\u202fcharacters which \u2028we \u2029normalise o\u180eut", SanitiseSMS, set()),
+        ("The quick brown fox jumps over the lazy dog", set()),
+        ("The “quick” brown fox has some downgradable characters\xa0", set()),
+        ("Need more 🐮🔔", {"🐮", "🔔"}),
+        ("Ŵêlsh chârâctêrs ârê cômpâtîblê wîth SanitiseSMS", set()),
+        ("Lots of GSM chars that arent ascii compatible:\n\r€", set()),
+        ("Obscure\u00a0whitespace\u202fcharacters which \u2028we \u2029normalise o\u180eut", set()),
     ],
 )
-def test_sms_encoding_get_non_compatible_characters(content, cls, expected):
-    assert cls.get_non_compatible_characters(content) == expected
+def test_sms_encoding_get_non_compatible_characters(content, expected):
+    assert SanitiseSMS.get_non_compatible_characters(content) == expected


### PR DESCRIPTION
We don’t use `SanitiseASCII.get_non_compatible_characters` anywhere so we can remove it.

We then rename `SanitiseSMS.get_non_compatible_characters` to `SanitiseSMS.get_non_gsm_characters` to make it clearer what it’s doing (and going to be doing).