### PR TITLE
add carrier code check to phonenumber validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 127.1.0
+
+* Adds additional methods to `recipient_validation.phone_number.PhoneNumber`, `is_uk_mobile_number` and `get_carrier_info`
+
 ## 127.0.0
 
 * Removes `SanitiseText.get_non_compatible_characters()` (for text message content use `SanitiseText.get_non_gsm_characters()` instead)

--- a/notifications_utils/recipient_validation/phone_number.py
+++ b/notifications_utils/recipient_validation/phone_number.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 from contextlib import suppress
 
 import phonenumbers
+from phonenumbers import carrier
 
 from notifications_utils.formatters import (
     ALL_WHITESPACE,
@@ -296,3 +297,11 @@ class PhoneNumber:
                 else phonenumbers.PhoneNumberFormat.INTERNATIONAL
             ),
         )
+
+    def is_uk_mobile_number(self):
+        return (
+            phonenumbers.number_type(self.number) == phonenumbers.PhoneNumberType.MOBILE and self.is_uk_phone_number()
+        )
+
+    def get_carrier_info(self):
+        return carrier.name_for_number(self.number, "en")

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "127.0.0"  # 61e99fd00f752af77e1682110110a928
+__version__ = "127.1.0"  # 986f6701730cc40f7810bd66099084c3

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -20,6 +20,20 @@ valid_uk_mobile_phone_numbers = [
     "\u200b\t\t+44 (0)7723 456 789\ufeff \r\n",
 ]
 
+valid_uk_mobile_phone_numbers_without_carrier = [
+    "7329472819",
+    "07246859165",
+    "+44 7152 749 721",
+    "+44 (0)7152 749 722",
+]
+
+valid_uk_mobile_phone_numbers_with_original_carrier = [
+    ("7106826587", "O2"),
+    ("07364792458", "Three"),
+    ("+44 7341468273", "Vodafone"),
+    ("+44 7342 468 273", "Vodafone"),
+]
+
 
 valid_international_phone_numbers = [
     "+7 (8) (495) 123-45-67",  # russia
@@ -412,6 +426,30 @@ class TestPhoneNumberClass:
         with pytest.raises(InvalidPhoneError):
             PhoneNumber(phone_number)
         # assert e.value.code == InvalidPhoneError.Codes.INVALID_NUMBER
+
+    @pytest.mark.parametrize("phone_number", valid_uk_mobile_phone_numbers_without_carrier + valid_uk_landlines)
+    def test_sending_to_uk_mobiles_without_carrier_validates_and_returns_correct_carrier_info(self, phone_number):
+        number = PhoneNumber(phone_number)
+        number.validate(allow_uk_landline=True)
+        assert number.get_carrier_info() == ""
+
+    @pytest.mark.parametrize("phone_number, carrier", valid_uk_mobile_phone_numbers_with_original_carrier)
+    def test_get_carrier_info_returns_correct_network(self, phone_number, carrier):
+        number = PhoneNumber(phone_number)
+        number.validate()
+        assert number.get_carrier_info() == carrier
+
+    @pytest.mark.parametrize("phone_number", valid_uk_mobile_phone_numbers)
+    def test_is_uk_mobile_number_returns_true_for_valid_uk_mobile_number(self, phone_number):
+        number = PhoneNumber(phone_number)
+        number.validate()
+        assert number.is_uk_mobile_number()
+
+    @pytest.mark.parametrize("phone_number", valid_uk_landlines + valid_international_phone_numbers)
+    def test_is_uk_mobile_number_returns_false_for_valid_number_that_is_not_uk_mobile(self, phone_number):
+        number = PhoneNumber(phone_number)
+        number.validate(allow_international_number=True, allow_uk_landline=True)
+        assert not number.is_uk_mobile_number()
 
     @pytest.mark.parametrize("phone_number", invalid_uk_landlines)
     def test_rejects_invalid_uk_landlines(self, phone_number):


### PR DESCRIPTION
These are two new helper methods that wrap some fairly simple calls to libphonenumber to check whether a number is uk mobile, and to return the carrier info for the number. These will initially be used in notifications-api to log when a user tries to send to a UK mobile that doesn't have a carrier. This should help inform future decisions about how we can tighten up our phone number validation.