### PR TITLE
Make `RecipientCSV` properly iterable, remove `RecipientCSV.rows`, `RecipientCSV._rows_as_list`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 131.0.0
+
+* Removes `RecipientCSV.rows`, `RecipientCSV._rows_as_list` (use, for example `for r in RecipientCSV(…)` instead)
+
 ## 130.2.0
 
 * Bundles a reduced list of "protected" phone prefixes from OFCOM's `S7.csv` file and provides a new `PhoneNumber` method, `is_number_in_S7_protected_range()` to efficiently query it.

--- a/notifications_utils/interruptible_io.py
+++ b/notifications_utils/interruptible_io.py
@@ -152,7 +152,7 @@ class InterruptibleIterableMixin[T]:
         )
 
 
-class InterruptibleIterableList(InterruptibleIterableMixin, list):
+class InterruptibleIterableList[T](InterruptibleIterableMixin, list):
     pass
 
 

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -85,6 +85,9 @@ class RecipientCSV:
     def __getitem__(self, requested_index) -> "Row | None":
         return self.rows[requested_index]
 
+    def __iter__(self) -> Iterator["Row | None"]:
+        return iter(self.rows)
+
     @property
     def guestlist(self) -> Sequence[Any]:
         return self._guestlist

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -130,7 +130,7 @@ class RecipientCSV:
             return True
         if not self.guestlist:
             return True
-        return all(allowed_to_send_to(row.recipient, self.guestlist) for row in self if row)
+        return all(allowed_to_send_to(row.recipient, self.guestlist) for row in self._filter_rows())
 
     @cached_property
     def international_sms_count(self) -> int:
@@ -139,9 +139,7 @@ class RecipientCSV:
         return sum(self._international_sms_count_generator())
 
     def _international_sms_count_generator(self) -> Iterator[bool]:
-        for row in self:
-            if not row:
-                continue
+        for row in self._filter_rows():
             with suppress(InvalidPhoneError):
                 yield not get_phone_number_object(row.recipient).is_uk_phone_number()
 
@@ -238,8 +236,8 @@ class RecipientCSV:
             return self.initial_rows_with_errors
         return self.initial_rows
 
-    def _filter_rows(self, attr) -> "Iterator[Row]":
-        return (row for row in self if row and getattr(row, attr))
+    def _filter_rows(self, attr: str | None = None) -> "Iterator[Row]":
+        return (row for row in self if row and (attr is None or getattr(row, attr)))
 
     @property
     def rows_with_errors(self) -> "Iterator[Row]":

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -76,23 +76,16 @@ class RecipientCSV:
         self.remaining_international_sms_messages = remaining_international_sms_messages
         self.should_validate = should_validate
         self.should_validate_phone_number = should_validate_phone_number
+        self._rows_as_list = InterruptibleIterableList(self._get_rows())
+        self._rows_as_list.INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY = self.rows_list_iteration_interruptible_every
 
     def __len__(self):
-        if not hasattr(self, "_rows_as_list"):
-            iter(self)
-        if not hasattr(self, "_len"):
-            self._len = len(self._rows_as_list)
-        return self._len
+        return len(self._rows_as_list)
 
     def __getitem__(self, requested_index) -> "Row | None":
-        if not hasattr(self, "_rows_as_list"):
-            iter(self)
         return self._rows_as_list[requested_index]
 
     def __iter__(self) -> Iterator["Row | None"]:
-        if not hasattr(self, "_rows_as_list"):
-            self._rows_as_list = InterruptibleIterableList(self._get_rows())
-            self._rows_as_list.INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY = self.rows_list_iteration_interruptible_every
         return iter(self._rows_as_list)
 
     @property

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -82,7 +82,7 @@ class RecipientCSV:
             self._len = len(self.rows)
         return self._len
 
-    def __getitem__(self, requested_index) -> "Row":
+    def __getitem__(self, requested_index) -> "Row | None":
         return self.rows[requested_index]
 
     @property
@@ -127,7 +127,7 @@ class RecipientCSV:
             return True
         if not self.guestlist:
             return True
-        return all(allowed_to_send_to(row.recipient, self.guestlist) for row in self.rows)
+        return all(allowed_to_send_to(row.recipient, self.guestlist) for row in self.rows if row)
 
     @cached_property
     def international_sms_count(self) -> int:
@@ -137,6 +137,8 @@ class RecipientCSV:
 
     def _international_sms_count_generator(self) -> Iterator[bool]:
         for row in self.rows:
+            if not row:
+                continue
             with suppress(InvalidPhoneError):
                 yield not get_phone_number_object(row.recipient).is_uk_phone_number()
 
@@ -147,7 +149,7 @@ class RecipientCSV:
         return self.international_sms_count > max(self.remaining_international_sms_messages, 0)
 
     @property
-    def rows(self):
+    def rows(self) -> "Sequence[Row | None]":
         if not hasattr(self, "_rows_as_list"):
             self._rows_as_list = InterruptibleIterableList(self._get_rows())
             self._rows_as_list.INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY = self.rows_list_iteration_interruptible_every

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -78,15 +78,22 @@ class RecipientCSV:
         self.should_validate_phone_number = should_validate_phone_number
 
     def __len__(self):
+        if not hasattr(self, "_rows_as_list"):
+            iter(self)
         if not hasattr(self, "_len"):
-            self._len = len(self.rows)
+            self._len = len(self._rows_as_list)
         return self._len
 
     def __getitem__(self, requested_index) -> "Row | None":
-        return self.rows[requested_index]
+        if not hasattr(self, "_rows_as_list"):
+            iter(self)
+        return self._rows_as_list[requested_index]
 
     def __iter__(self) -> Iterator["Row | None"]:
-        return iter(self.rows)
+        if not hasattr(self, "_rows_as_list"):
+            self._rows_as_list = InterruptibleIterableList(self._get_rows())
+            self._rows_as_list.INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY = self.rows_list_iteration_interruptible_every
+        return iter(self._rows_as_list)
 
     @property
     def guestlist(self) -> Sequence[Any]:
@@ -130,7 +137,7 @@ class RecipientCSV:
             return True
         if not self.guestlist:
             return True
-        return all(allowed_to_send_to(row.recipient, self.guestlist) for row in self.rows if row)
+        return all(allowed_to_send_to(row.recipient, self.guestlist) for row in self if row)
 
     @cached_property
     def international_sms_count(self) -> int:
@@ -139,7 +146,7 @@ class RecipientCSV:
         return sum(self._international_sms_count_generator())
 
     def _international_sms_count_generator(self) -> Iterator[bool]:
-        for row in self.rows:
+        for row in self:
             if not row:
                 continue
             with suppress(InvalidPhoneError):
@@ -150,13 +157,6 @@ class RecipientCSV:
         if self.template_type != "sms":
             return False
         return self.international_sms_count > max(self.remaining_international_sms_messages, 0)
-
-    @property
-    def rows(self) -> "Sequence[Row | None]":
-        if not hasattr(self, "_rows_as_list"):
-            self._rows_as_list = InterruptibleIterableList(self._get_rows())
-            self._rows_as_list.INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY = self.rows_list_iteration_interruptible_every
-        return self._rows_as_list
 
     @property
     def _rows(self) -> Iterator[Sequence[str]]:
@@ -237,7 +237,7 @@ class RecipientCSV:
 
     @property
     def initial_rows(self) -> "Iterator[Row | None]":
-        return islice(self.rows, self.max_initial_rows_shown)
+        return islice(self, self.max_initial_rows_shown)
 
     @property
     def displayed_rows(self) -> "Iterator[Row | None]":
@@ -246,7 +246,7 @@ class RecipientCSV:
         return self.initial_rows
 
     def _filter_rows(self, attr) -> "Iterator[Row]":
-        return (row for row in self.rows if row and getattr(row, attr))
+        return (row for row in self if row and getattr(row, attr))
 
     @property
     def rows_with_errors(self) -> "Iterator[Row]":

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -35,19 +35,18 @@ first_column_headings = {
 }
 
 
-class RecipientCSV:
+class RecipientCSV(InterruptibleIterableList["Row | None"]):
     max_rows: int = 100_000
     get_rows_loop_interruptible_every: int = 128
     # we're less certain a significant amount of work is going to be done on each iteration
     # through the resultant row list
-    rows_list_iteration_interruptible_every: int = 512
+    INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY: int = 512
 
     _template: Template
     template_type: str
     recipient_column_headers: InsensitiveSet[str]
     _guestlist: Sequence[Any]
     placeholders: InsensitiveSet[str]
-    _rows_as_list: Sequence["None | Row"]
 
     def __init__(
         self,
@@ -76,17 +75,7 @@ class RecipientCSV:
         self.remaining_international_sms_messages = remaining_international_sms_messages
         self.should_validate = should_validate
         self.should_validate_phone_number = should_validate_phone_number
-        self._rows_as_list = InterruptibleIterableList(self._get_rows())
-        self._rows_as_list.INTERRUPTIBLE_ITERABLE_INTERRUPTIBLE_EVERY = self.rows_list_iteration_interruptible_every
-
-    def __len__(self):
-        return len(self._rows_as_list)
-
-    def __getitem__(self, requested_index) -> "Row | None":
-        return self._rows_as_list[requested_index]
-
-    def __iter__(self) -> Iterator["Row | None"]:
-        return iter(self._rows_as_list)
+        super().__init__(self._get_rows())
 
     @property
     def guestlist(self) -> Sequence[Any]:

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "130.2.0"  # 0383a27d87124247a4b7343e7ac6200b
+__version__ = "131.0.0"  # b219c655a0ad1e26bd636685d6f6f5a8

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -1559,19 +1559,3 @@ def test_cell_ignore_and_error_checking(mocker):
         call("Phone Number", "789"),
         call("Name", "C"),
     ]
-
-
-def test_rows_as_list_is_defined_on_init():
-    recipients = RecipientCSV(
-        """
-        Phone Number, Name, Foo, Bar
-        123,          A,    foo, bar
-        456,          B,    foo, bar
-        789,          C,    foo, bar
-        """,
-        template=_sample_template("sms"),
-    )
-    with pytest.raises(AttributeError):
-        assert RecipientCSV._rows_as_list
-
-    assert recipients._rows_as_list

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -380,11 +380,13 @@ def test_overly_big_list_stops_processing_rows_beyond_max(mocker):
         "notifications_utils.recipients.insert_or_append_to_dict",
     )
 
-    big_csv = RecipientCSV(
+    class Max10RowsRecipientCSV(RecipientCSV):
+        max_rows = 10
+
+    big_csv = Max10RowsRecipientCSV(
         "phonenumber,name\n" + ("07700900123,example\n" * 123),
         template=_sample_template("sms", content="hello ((name))"),
     )
-    big_csv.max_rows = 10
 
     # Our CSV has lots of rows…
     assert big_csv.too_many_rows

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -203,7 +203,7 @@ def test_recipient_column_headers(template_type, expected):
     ],
 )
 def test_get_rows(file_contents, template_type, expected):
-    rows = list(RecipientCSV(file_contents, template=_sample_template(template_type)).rows)
+    rows = list(RecipientCSV(file_contents, template=_sample_template(template_type)))
     if not expected:
         assert rows == expected
     for index, row in enumerate(expected):
@@ -299,10 +299,10 @@ def test_get_annotated_rows(file_contents, template_type, expected):
         file_contents, template=_sample_template(template_type, "hello ((name))"), max_initial_rows_shown=1
     )
     for index, expected_row in enumerate(expected):
-        annotated_row = list(recipients.rows)[index]
+        annotated_row = list(recipients)[index]
         assert annotated_row.index == expected_row["index"]
         assert annotated_row.message_too_long == expected_row["message_too_long"]
-    assert len(list(recipients.rows)) == 2
+    assert len(list(recipients)) == 2
     assert len(list(recipients.initial_rows)) == 1
     assert not recipients.has_errors
 
@@ -342,7 +342,7 @@ def test_big_list_validates_right_through(template_type, row_count, header, fill
         max_errors_shown=100,
         max_initial_rows_shown=3,
     )
-    assert len(list(big_csv.rows)) == row_count
+    assert len(list(big_csv)) == row_count
     assert _index_rows(big_csv.rows_with_bad_recipients) == {row_count - 1}  # 0 indexed
     assert _index_rows(big_csv.rows_with_errors) == {row_count - 1}
     assert len(list(big_csv.initial_rows_with_errors)) == 1
@@ -940,9 +940,9 @@ def test_errors_when_too_many_rows():
 
     assert recipients.too_many_rows is True
     assert recipients.has_errors is True
-    assert recipients.rows[99]["email_address"].data == "a@b.com"
+    assert recipients[99]["email_address"].data == "a@b.com"
     # We stop processing subsequent rows
-    assert recipients.rows[100] is None
+    assert recipients[100] is None
 
 
 @pytest.mark.parametrize(
@@ -1251,9 +1251,9 @@ def test_multiple_sms_recipient_columns(international_sms):
     )
     assert recipients.column_headers == ["phone number", "phone_number", "foo"]
     assert recipients.insensitive_column_headers == {"phonenumber": "", "foo": ""}.keys()
-    assert recipients.rows[0].get("phone number").data == ("07900 900333")
-    assert recipients.rows[0].get("phone_number").data == ("07900 900333")
-    assert recipients.rows[0].get("phone number").error is None
+    assert recipients[0].get("phone number").data == ("07900 900333")
+    assert recipients[0].get("phone_number").data == ("07900 900333")
+    assert recipients[0].get("phone number").error is None
     assert recipients.duplicate_recipient_column_headers == OrderedSet(["phone number", "phone_number"])
     assert recipients.has_errors
 
@@ -1283,8 +1283,8 @@ def test_multiple_sms_recipient_columns_with_missing_data(column_name):
     phone_number_data = None
     if column_name == "phone number":
         phone_number_data = "07900 900111"
-    assert recipients.rows[0]["phonenumber"].data == phone_number_data
-    assert recipients.rows[0].get("phone number").error is None
+    assert recipients[0]["phonenumber"].data == phone_number_data
+    assert recipients[0].get("phone number").error is None
     expected_duplicated_columns = ["phone number"]
     if column_name != "phone number":
         expected_duplicated_columns.append(column_name)
@@ -1300,8 +1300,8 @@ def test_multiple_email_recipient_columns():
         """,
         template=_sample_template("email"),
     )
-    assert recipients.rows[0].get("email address").data == ("two@three.com")
-    assert recipients.rows[0].get("email address").error is None
+    assert recipients[0].get("email address").data == ("two@three.com")
+    assert recipients[0].get("email address").error is None
     assert recipients.has_errors
     assert recipients.duplicate_recipient_column_headers == OrderedSet(["EMAILADDRESS", "email_address"])
     assert recipients.has_errors
@@ -1315,8 +1315,8 @@ def test_multiple_letter_recipient_columns():
         """,
         template=_sample_template("letter"),
     )
-    assert recipients.rows[0].get("addressline1").data == ("3")
-    assert recipients.rows[0].get("addressline1").error is None
+    assert recipients[0].get("addressline1").data == ("3")
+    assert recipients[0].get("addressline1").error is None
     assert recipients.has_errors
     assert recipients.duplicate_recipient_column_headers == OrderedSet(
         ["address line 1", "Address Line 2", "address line 1", "address_line_2"]
@@ -1366,7 +1366,7 @@ def test_multi_line_placeholders_work():
         template=_sample_template("email", "((data))"),
     )
 
-    assert recipients.rows[0].personalisation["data"] == "a\nb\n\nc"
+    assert recipients[0].personalisation["data"] == "a\nb\n\nc"
 
 
 @pytest.mark.parametrize(
@@ -1560,5 +1560,5 @@ def test_rows_as_list_is_not_defined_on_init():
     with pytest.raises(AttributeError):
         recipients._rows_as_list  # noqa: B018
 
-    assert len(recipients.rows) == 3  # Causes recipients._rows_as_list to be defined
+    assert len(recipients) == 3  # Causes recipients._rows_as_list to be defined
     assert len(recipients._rows_as_list) == 3

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -256,12 +256,10 @@ def test_get_rows_only_iterates_over_file_once(mocker):
         template=_sample_template("email", "hello ((name))"),
     )
 
-    rows = recipients._get_rows()
-    for _ in range(3):
-        next(rows)
+    for _ in range(10):
+        list(recipients)
 
     assert row_mock.call_count == 3
-    assert not hasattr(recipients, "_rows_as_list")
 
 
 @pytest.mark.parametrize(
@@ -930,15 +928,18 @@ def test_sms_to_uk_landlines(file_contents, rows_with_bad_recipients):
 
 
 def test_errors_when_too_many_rows():
-    recipients = RecipientCSV(
+    class Max100RowsRecipientCSV(RecipientCSV):
+        max_rows = 100
+
+    recipients = Max100RowsRecipientCSV(
         "email address\n" + ("a@b.com\n" * 101),
         template=_sample_template("email"),
     )
 
     # Confirm the normal max_row limit
-    assert recipients.max_rows == 100_000
-    # Override to make this test faster
-    recipients.max_rows = 100
+    assert RecipientCSV.max_rows == 100_000
+    # Confirm our instance has a lower limit to make the test faster
+    assert recipients.max_rows == 100
 
     assert recipients.too_many_rows is True
     assert recipients.has_errors is True
@@ -1485,17 +1486,25 @@ def test_errors_on_qr_codes_with_too_much_data():
 
 def test_column_headers_are_cached(mocker):
     mock_csv_reader = mocker.patch(
-        "notifications_utils.recipients.csv.reader", return_value=(("phone_number", "PhoneNumber", "name", "name"),)
+        "notifications_utils.recipients.csv.reader",
+        side_effect=lambda *args, **kwargs: iter((("phone_number", "PhoneNumber", "name", "name"),)),
     )
     template = _sample_template("sms", content="Hello")
     recipients = RecipientCSV("mocked", template=template)
 
-    for _ in range(3):
+    for _ in range(5):
         assert recipients._raw_column_headers == ("phone_number", "PhoneNumber", "name", "name")
         assert recipients.column_headers == ["phone_number", "PhoneNumber", "name"]
         assert recipients.insensitive_column_headers == OrderedSet(["phonenumber", "name"])
 
-    assert mock_csv_reader.call_args_list == [mocker.call(ANY, quoting=0, skipinitialspace=True)]
+    assert mock_csv_reader.call_args_list == [
+        # First pass over the file to work out index_of_first_empty_column
+        mocker.call(ANY, quoting=0, skipinitialspace=True),
+        # Second pass over the file (first row only) to get the column headers
+        mocker.call(ANY, quoting=0, skipinitialspace=True),
+        # Third pass over the file to build the Row objects
+        mocker.call(ANY, quoting=0, skipinitialspace=True),
+    ]
 
 
 def test_duplicate_headers_are_cached(mocker):
@@ -1512,6 +1521,9 @@ def test_duplicate_headers_are_cached(mocker):
         assert recipients.duplicate_recipient_column_headers == OrderedSet(("phone_number", "PhoneNumber"))
 
     assert mock_column_headers.call_args_list == [
+        # 2 calls on RecipientCSV.__init__
+        mocker.call(),
+        mocker.call(),
         # 2 calls per loop, but cached after the first of 3 loops
         mocker.call(),
         mocker.call(),
@@ -1549,7 +1561,7 @@ def test_cell_ignore_and_error_checking(mocker):
     ]
 
 
-def test_rows_as_list_is_not_defined_on_init():
+def test_rows_as_list_is_defined_on_init():
     recipients = RecipientCSV(
         """
         Phone Number, Name, Foo, Bar
@@ -1560,7 +1572,6 @@ def test_rows_as_list_is_not_defined_on_init():
         template=_sample_template("sms"),
     )
     with pytest.raises(AttributeError):
-        recipients._rows_as_list  # noqa: B018
+        assert RecipientCSV._rows_as_list
 
-    assert len(recipients) == 3  # Causes recipients._rows_as_list to be defined
-    assert len(recipients._rows_as_list) == 3
+    assert recipients._rows_as_list


### PR DESCRIPTION
Rather than `RecipientCSV` having multiple interfaces to an internal representation of the list of rows, this pull request turns `RecipientCSV` into the list itself. This further removes complexity from this part of the codebase.

***

Changes made incrementally so best reviewed commit-by-commit.

# Breaking changes

* Removes `RecipientCSV.rows`, `RecipientCSV._rows_as_list` (use, for example, `for r in RecipientCSV(…)` instead)