### PR TITLE
Make more things in `RecipientCSV` instances of `InsensitiveSet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 130.0.0
+
+* Removes `RecipientCSV.placeholders_as_column_keys` (use `RecipientCSV.placeholders` instead, now an instance of `InsensitiveSet`)
+* Removes `RecipientCSV.recipient_column_headers_as_column_keys` (use `RecipientCSV.recipient_column_headers` instead, now an instance of `InsensitiveSet`)
+* Renames `RecipientCSV.column_headers_as_column_keys` to `RecipientCSV.insensitive_column_headers`
+* Removes `RecipientCSV.is_address_column(key)` (use `key in RecipientCSV.address_columns` instead)
+* Removes `recipients.address_columns` (use `RecipientCSV.address_columns` instead)
+
 ## 129.0.0
 
 * Running `make lint` will now flag commented-out code (per https://docs.astral.sh/ruff/rules/commented-out-code/)

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -297,11 +297,7 @@ class RecipientCSV:
 
     @property
     def missing_column_headers(self) -> set[str]:
-        return {
-            key
-            for key in self.placeholders
-            if (key not in self.insensitive_column_headers and not self.is_address_column(key))
-        }
+        return {key for key in self.placeholders - self.insensitive_column_headers if not self.is_address_column(key)}
 
     @cached_property
     def duplicate_recipient_column_headers(self) -> OrderedSet[str]:

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -34,8 +34,6 @@ first_column_headings = {
     "letter": [line.replace("_", " ") for line in address_lines_1_to_6_and_postcode_keys + [address_line_7_key]],
 }
 
-address_columns = InsensitiveSet(first_column_headings["letter"])
-
 
 class RecipientCSV:
     max_rows: int = 100_000
@@ -296,8 +294,8 @@ class RecipientCSV:
         return InsensitiveSet(self.column_headers)
 
     @property
-    def missing_column_headers(self) -> set[str]:
-        return {key for key in self.placeholders - self.insensitive_column_headers if not self.is_address_column(key)}
+    def missing_column_headers(self) -> InsensitiveSet[str]:
+        return self.placeholders - self.insensitive_column_headers - self.address_columns
 
     @cached_property
     def duplicate_recipient_column_headers(self) -> OrderedSet[str]:
@@ -313,8 +311,9 @@ class RecipientCSV:
             if raw_recipient_column_headers.count(InsensitiveDict.make_key(column_header)) > 1
         )
 
-    def is_address_column(self, key) -> bool:
-        return self.template_type == "letter" and key in address_columns
+    @property
+    def address_columns(self) -> InsensitiveSet:
+        return self.recipient_column_headers if self.template_type == "letter" else InsensitiveSet()
 
     @property
     def count_of_required_recipient_columns(self) -> int:
@@ -348,7 +347,7 @@ class RecipientCSV:
         return False
 
     def _get_error_for_field(self, key, value) -> str | None:
-        if self.is_address_column(key):
+        if key in self.address_columns:
             return None
 
         if key in self.recipient_column_headers:

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -47,9 +47,8 @@ class RecipientCSV:
     _template: Template
     template_type: str
     recipient_column_headers_as_column_keys: InsensitiveSet[str]
-    placeholders_as_column_keys: InsensitiveSet[str]
     _guestlist: Sequence[Any]
-    _placeholders: Sequence[Any]
+    _placeholders: InsensitiveSet[Any]
     _rows_as_list: Sequence["None | Row"]
 
     def __init__(
@@ -113,17 +112,13 @@ class RecipientCSV:
         self.placeholders = self._template.placeholders
 
     @property
-    def placeholders(self) -> Sequence[Any]:
+    def placeholders(self) -> InsensitiveSet[Any]:
         return self._placeholders
 
     @placeholders.setter
-    def placeholders(self, value):
-        try:
-            self._placeholders = list(value) + self.recipient_column_headers
-        except TypeError:
-            self._placeholders = self.recipient_column_headers
-        self.placeholders_as_column_keys = InsensitiveSet(self._placeholders)
+    def placeholders(self, value: InsensitiveSet):
         self.recipient_column_headers_as_column_keys = InsensitiveSet(self.recipient_column_headers)
+        self._placeholders = value | self.recipient_column_headers_as_column_keys
 
     @property
     def has_errors(self) -> bool:
@@ -232,7 +227,7 @@ class RecipientCSV:
                 index=index,
                 error_fn=self._get_error_for_field,
                 recipient_column_headers=self.recipient_column_headers,
-                placeholders=self.placeholders_as_column_keys,
+                placeholders=self.placeholders,
                 template=self.template,
                 allow_international_letters=self.allow_international_letters,
                 validate_row=self.should_validate,
@@ -382,7 +377,7 @@ class RecipientCSV:
             except InvalidRecipientError as error:
                 return str(error)
 
-        if key in self.placeholders_as_column_keys and value in [None, ""]:
+        if key in self.placeholders and value in [None, ""]:
             return Cell.missing_field_error
 
         return None

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -46,7 +46,7 @@ class RecipientCSV:
     template_type: str
     recipient_column_headers: InsensitiveSet[str]
     _guestlist: Sequence[Any]
-    _placeholders: InsensitiveSet[Any]
+    placeholders: InsensitiveSet[str]
     _rows_as_list: Sequence["None | Row"]
 
     def __init__(
@@ -107,15 +107,7 @@ class RecipientCSV:
         self._template = value
         self.template_type = self._template.template_type
         self.recipient_column_headers = InsensitiveSet(first_column_headings[self.template_type])
-        self.placeholders = self._template.placeholders
-
-    @property
-    def placeholders(self) -> InsensitiveSet[Any]:
-        return self._placeholders
-
-    @placeholders.setter
-    def placeholders(self, value: InsensitiveSet):
-        self._placeholders = value | self.recipient_column_headers
+        self.placeholders = self._template.placeholders | self.recipient_column_headers
 
     @property
     def has_errors(self) -> bool:

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -46,7 +46,7 @@ class RecipientCSV:
 
     _template: Template
     template_type: str
-    recipient_column_headers_as_column_keys: InsensitiveSet[str]
+    recipient_column_headers: InsensitiveSet[str]
     _guestlist: Sequence[Any]
     _placeholders: InsensitiveSet[Any]
     _rows_as_list: Sequence["None | Row"]
@@ -108,7 +108,7 @@ class RecipientCSV:
             raise TypeError("template must be an instance of notifications_utils.template.Template")
         self._template = value
         self.template_type = self._template.template_type
-        self.recipient_column_headers = first_column_headings[self.template_type]
+        self.recipient_column_headers = InsensitiveSet(first_column_headings[self.template_type])
         self.placeholders = self._template.placeholders
 
     @property
@@ -117,8 +117,7 @@ class RecipientCSV:
 
     @placeholders.setter
     def placeholders(self, value: InsensitiveSet):
-        self.recipient_column_headers_as_column_keys = InsensitiveSet(self.recipient_column_headers)
-        self._placeholders = value | self.recipient_column_headers_as_column_keys
+        self._placeholders = value | self.recipient_column_headers
 
     @property
     def has_errors(self) -> bool:
@@ -208,7 +207,7 @@ class RecipientCSV:
             for column_name, column_value in zip(column_headers, row[:length_of_widest_row], strict=False):
                 column_value = strip_and_remove_obscure_whitespace(column_value)
 
-                if column_name in self.recipient_column_headers_as_column_keys:
+                if column_name in self.recipient_column_headers:
                     output_dict[column_name] = column_value or None
                 else:
                     insert_or_append_to_dict(output_dict, column_name, column_value or None)
@@ -312,7 +311,7 @@ class RecipientCSV:
         raw_recipient_column_headers: list[str] = [
             InsensitiveDict.make_key(column_header)
             for column_header in self._raw_column_headers
-            if column_header in self.recipient_column_headers_as_column_keys
+            if column_header in self.recipient_column_headers
         ]
 
         return OrderedSet(
@@ -338,7 +337,7 @@ class RecipientCSV:
             ]
         else:
             sets_to_check = [
-                self.recipient_column_headers_as_column_keys,
+                self.recipient_column_headers,
             ]
 
         for set_to_check in sets_to_check:
@@ -359,7 +358,7 @@ class RecipientCSV:
         if self.is_address_column(key):
             return None
 
-        if key in self.recipient_column_headers_as_column_keys:
+        if key in self.recipient_column_headers:
             if self.duplicate_recipient_column_headers:
                 return None
 

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -292,7 +292,7 @@ class RecipientCSV:
         return list(OrderedSet(self._raw_column_headers))
 
     @property
-    def column_headers_as_column_keys(self) -> InsensitiveSet[str]:
+    def insensitive_column_headers(self) -> InsensitiveSet[str]:
         return InsensitiveSet(self.column_headers)
 
     @property
@@ -300,10 +300,7 @@ class RecipientCSV:
         return {
             key
             for key in self.placeholders
-            if (
-                InsensitiveDict.make_key(key) not in self.column_headers_as_column_keys
-                and not self.is_address_column(key)
-            )
+            if (key not in self.insensitive_column_headers and not self.is_address_column(key))
         }
 
     @cached_property
@@ -346,7 +343,7 @@ class RecipientCSV:
                     # Work out which columns are shared between the possible
                     # letter address columns and the columns in the user’s
                     # spreadsheet (`&` means set intersection)
-                    set_to_check & self.column_headers_as_column_keys
+                    set_to_check & self.insensitive_column_headers
                 )
                 >= self.count_of_required_recipient_columns
             ):

--- a/notifications_utils/recipients.py
+++ b/notifications_utils/recipients.py
@@ -281,7 +281,7 @@ class RecipientCSV:
     def column_headers(self) -> Sequence[str]:
         return list(OrderedSet(self._raw_column_headers))
 
-    @property
+    @cached_property
     def insensitive_column_headers(self) -> InsensitiveSet[str]:
         return InsensitiveSet(self.column_headers)
 
@@ -303,7 +303,7 @@ class RecipientCSV:
             if raw_recipient_column_headers.count(InsensitiveDict.make_key(column_header)) > 1
         )
 
-    @property
+    @cached_property
     def address_columns(self) -> InsensitiveSet:
         return self.recipient_column_headers if self.template_type == "letter" else InsensitiveSet()
 

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "129.0.0"  # ba4091424968b6608bd817f0ea876395
+__version__ = "130.0.0"  # 44dff7233c76b7e864285f62cd150f16

--- a/tests/test_recipient_csv.py
+++ b/tests/test_recipient_csv.py
@@ -1250,7 +1250,7 @@ def test_multiple_sms_recipient_columns(international_sms):
         allow_international_sms=international_sms,
     )
     assert recipients.column_headers == ["phone number", "phone_number", "foo"]
-    assert recipients.column_headers_as_column_keys == {"phonenumber": "", "foo": ""}.keys()
+    assert recipients.insensitive_column_headers == {"phonenumber": "", "foo": ""}.keys()
     assert recipients.rows[0].get("phone number").data == ("07900 900333")
     assert recipients.rows[0].get("phone_number").data == ("07900 900333")
     assert recipients.rows[0].get("phone number").error is None
@@ -1274,7 +1274,7 @@ def test_multiple_sms_recipient_columns_with_missing_data(column_name):
     if column_name != "phone number":
         expected_column_headers.append(column_name)
     assert recipients.column_headers == expected_column_headers
-    assert recipients.column_headers_as_column_keys == {"phonenumber": "", "names": ""}.keys()
+    assert recipients.insensitive_column_headers == {"phonenumber": "", "names": ""}.keys()
     # A piece of weirdness uncovered: since rows are created before spaces in column names are normalised, when
     # there are duplicate recipient columns and there is data for only one of the columns, if the columns have the same
     # spacing, phone number data will be the correct phone number, while if the spacing style differs between two
@@ -1491,7 +1491,7 @@ def test_column_headers_are_cached(mocker):
     for _ in range(3):
         assert recipients._raw_column_headers == ("phone_number", "PhoneNumber", "name", "name")
         assert recipients.column_headers == ["phone_number", "PhoneNumber", "name"]
-        assert recipients.column_headers_as_column_keys == OrderedSet(["phonenumber", "name"])
+        assert recipients.insensitive_column_headers == OrderedSet(["phonenumber", "name"])
 
     assert mock_csv_reader.call_args_list == [mocker.call(ANY, quoting=0, skipinitialspace=True)]
 


### PR DESCRIPTION
This removes over 20 lines of complexity from some of our fiddliest code.

Detail in individual commits.

***

Breaking changes (I don’t think the apps actually depend on any of these):
* Removes `RecipientCSV.placeholders_as_column_keys` (use `RecipientCSV.placeholders` instead, now an instance of `InsensitiveSet`)
* Removes `RecipientCSV.recipient_column_headers_as_column_keys` (use `RecipientCSV.recipient_column_headers` instead, now an instance of `InsensitiveSet`)
* Renames `RecipientCSV.column_headers_as_column_keys` to `RecipientCSV.insensitive_column_headers`
* Removes `RecipientCSV.is_address_column(key)` (use `key in RecipientCSV.address_columns` instead)
* Removes `recipients.address_columns` (use `RecipientCSV.address_columns` instead)