### PR TITLE
remove libphonenumber carrier logging methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 130.1.0
+
+* Reverts change in 127.1.0. notifications-api is no longer using these methods.
+
 ## 130.0.0
 
 * Removes `RecipientCSV.placeholders_as_column_keys` (use `RecipientCSV.placeholders` instead, now an instance of `InsensitiveSet`)

--- a/notifications_utils/recipient_validation/phone_number.py
+++ b/notifications_utils/recipient_validation/phone_number.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 from contextlib import suppress
 
 import phonenumbers
-from phonenumbers import carrier
 
 from notifications_utils.formatters import (
     ALL_WHITESPACE,
@@ -297,11 +296,3 @@ class PhoneNumber:
                 else phonenumbers.PhoneNumberFormat.INTERNATIONAL
             ),
         )
-
-    def is_uk_mobile_number(self) -> bool:
-        return (
-            phonenumbers.number_type(self.number) == phonenumbers.PhoneNumberType.MOBILE and self.is_uk_phone_number()
-        )
-
-    def get_carrier_info(self) -> str:
-        return carrier.name_for_number(self.number, "en")

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "130.0.0"  # 44dff7233c76b7e864285f62cd150f16
+__version__ = "130.1.0"  # 7faa27ebe05569a10fc3fe12e88efb6a

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -20,20 +20,6 @@ valid_uk_mobile_phone_numbers = [
     "\u200b\t\t+44 (0)7723 456 789\ufeff \r\n",
 ]
 
-valid_uk_mobile_phone_numbers_without_carrier = [
-    "7329472819",
-    "07246859165",
-    "+44 7152 749 721",
-    "+44 (0)7152 749 722",
-]
-
-valid_uk_mobile_phone_numbers_with_original_carrier = [
-    ("7106826587", "O2"),
-    ("07364792458", "Three"),
-    ("+44 7341468273", "Vodafone"),
-    ("+44 7342 468 273", "Vodafone"),
-]
-
 
 valid_international_phone_numbers = [
     "+7 (8) (495) 123-45-67",  # russia
@@ -426,30 +412,6 @@ class TestPhoneNumberClass:
         with pytest.raises(InvalidPhoneError) as e:
             PhoneNumber(phone_number)
         assert InvalidPhoneError.ERROR_MESSAGES[e.value.code] == error_message
-
-    @pytest.mark.parametrize("phone_number", valid_uk_mobile_phone_numbers_without_carrier + valid_uk_landlines)
-    def test_sending_to_uk_mobiles_without_carrier_validates_and_returns_correct_carrier_info(self, phone_number):
-        number = PhoneNumber(phone_number)
-        number.validate(allow_uk_landline=True)
-        assert number.get_carrier_info() == ""
-
-    @pytest.mark.parametrize("phone_number, carrier", valid_uk_mobile_phone_numbers_with_original_carrier)
-    def test_get_carrier_info_returns_correct_network(self, phone_number, carrier):
-        number = PhoneNumber(phone_number)
-        number.validate()
-        assert number.get_carrier_info() == carrier
-
-    @pytest.mark.parametrize("phone_number", valid_uk_mobile_phone_numbers)
-    def test_is_uk_mobile_number_returns_true_for_valid_uk_mobile_number(self, phone_number):
-        number = PhoneNumber(phone_number)
-        number.validate()
-        assert number.is_uk_mobile_number()
-
-    @pytest.mark.parametrize("phone_number", valid_uk_landlines + valid_international_phone_numbers)
-    def test_is_uk_mobile_number_returns_false_for_valid_number_that_is_not_uk_mobile(self, phone_number):
-        number = PhoneNumber(phone_number)
-        number.validate(allow_international_number=True, allow_uk_landline=True)
-        assert not number.is_uk_mobile_number()
 
     @pytest.mark.parametrize("phone_number", invalid_uk_landlines)
     def test_rejects_invalid_uk_landlines(self, phone_number):


### PR DESCRIPTION
These are no longer used by notifications-api as of https://github.com/alphagov/notifications-api/pull/4957