### PR TITLE
Update `is_number_in_S7_protected_range` to return False if number is a TV number or smoke test number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 131.1.0
+
+* Update `is_number_in_S7_protected_range` to return False if number is a TV number or smoke test number
+
 ## 131.0.0
 
 * Removes `RecipientCSV.rows`, `RecipientCSV._rows_as_list` (use, for example `for r in RecipientCSV(…)` instead)

--- a/notifications_utils/recipient_validation/phone_number.py
+++ b/notifications_utils/recipient_validation/phone_number.py
@@ -25,6 +25,12 @@ EMERGENCY_THREE_DIGIT_NUMBERS = [
     "112",
 ]
 
+SMOKE_TEST_NUMBERS = [
+    "7700900000",
+    "7700900111",
+    "7700900222",
+]
+
 LANDLINE_CODES = {
     phonenumbers.PhoneNumberType.FIXED_LINE,
     phonenumbers.PhoneNumberType.FIXED_LINE_OR_MOBILE,
@@ -248,7 +254,11 @@ class PhoneNumber:
         """
         Returns whether the number is, according to the OFCOM S7 file, within a range that is "protected".
         """
-        if not self.is_uk_phone_number():
+        if (
+            not self.is_uk_phone_number()
+            or (self.number.national_number) in SMOKE_TEST_NUMBERS
+            or self._is_tv_number(self.number)
+        ):
             return False
 
         prefixes = get_S7_protected_prefixes()

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "131.0.0"  # b219c655a0ad1e26bd636685d6f6f5a8
+__version__ = "131.1.0"  # 14db67192557b254d3ecfee34e588fcc

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -256,6 +256,7 @@ mock_S7_prefixes = (
     "70348",
     "703490",
     "7075",
+    "77009",  # prefix for smoke test number
 )
 
 
@@ -653,6 +654,8 @@ class TestPhoneNumberClass:
             ("07999999999", False),
             # non-uk number
             ("+1 202-483-3000", False),
+            # smoke test numbers
+            ("07700900111", False),
         ),
     )
     def test_is_number_in_S7_protected_range(self, candidate_number, expected_result, mocker):


### PR DESCRIPTION
TV numbers and smoke test numbers are in the protected blocks. We don't actually want to block sending to these as they will break our users integration/smoke tests