### PR TITLE
make `PhoneNumber._is_tv_number` a public method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 131.1.0
+
+* Makes `PhoneNumber._is_tv_number` a public method (`PhoneNumber.is_tv_number`)
+
 ## 131.0.0
 
 * Removes `RecipientCSV.rows`, `RecipientCSV._rows_as_list` (use, for example `for r in RecipientCSV(…)` instead)

--- a/notifications_utils/recipient_validation/phone_number.py
+++ b/notifications_utils/recipient_validation/phone_number.py
@@ -160,7 +160,7 @@ class PhoneNumber:
             # is_possible just checks the length of a number for that country/region. is_valid checks if it's
             # a valid sequence of numbers. This doesn't cover "is this number registered to an MNO".
             # For example UK numbers cannot start "06" as that hasn't been assigned to a purpose by ofcom
-            if self._is_tv_number(number):
+            if self.is_tv_number(number):
                 return number
             else:
                 raise InvalidPhoneError(code=InvalidPhoneError.Codes.INVALID_NUMBER)
@@ -176,7 +176,7 @@ class PhoneNumber:
         return False
 
     @staticmethod
-    def _is_tv_number(phone_number) -> bool:
+    def is_tv_number(phone_number) -> bool:
         """
         The phonenumbers library does not consider TV numbers (fake numbers OFCOM reserves use in TV, film etc)
         valid. This method checks whether a normalised phone number that has failed the library's validation is
@@ -283,7 +283,7 @@ class PhoneNumber:
         """
         if phonenumbers.region_code_for_number(self.number) == "GB":
             return False
-        elif self._is_tv_number(self.number):
+        elif self.is_tv_number(self.number):
             return False
         else:
             return True
@@ -295,7 +295,7 @@ class PhoneNumber:
         handle them (they're not actually valid numbers). In that case we
         always want to return False as we consider them to be UK numbers.
         """
-        if self._is_tv_number(self.number):
+        if self.is_tv_number(self.number):
             return False
         else:
             return self.is_uk_phone_number() and phonenumbers.region_code_for_number(self.number) != "GB"

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "131.0.0"  # b219c655a0ad1e26bd636685d6f6f5a8
+__version__ = "131.1.0"  # 628ee66af93953d3bc2c714177922f72


### PR DESCRIPTION
we want `notifications-api` to be able to use this method directly to assist with AIT mitigations