### PR TITLE
`PhoneNumber.validate` should reject numbers to ofcom protected block when `block_ofcom_protected_block = True`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 131.2.0
+
+* Adds `block_ofcom_protected_ranges` as an optional argument to `PhoneNumber.validate`
+
 ## 131.1.0
 
 * Makes `PhoneNumber._is_tv_number` a public method (`PhoneNumber.is_tv_number`)

--- a/notifications_utils/recipient_validation/phone_number.py
+++ b/notifications_utils/recipient_validation/phone_number.py
@@ -103,9 +103,24 @@ class PhoneNumber:
         if str(self.number.country_code) not in COUNTRY_PREFIXES:
             raise InvalidPhoneError(code=InvalidPhoneError.Codes.UNSUPPORTED_COUNTRY_CODE)
 
-    def validate(self, allow_international_number: bool = False, allow_uk_landline: bool = False) -> None:
+    def _raise_if_service_who_blocked_it_tries_sending_to_ofcom_protected_ranges(
+        self, block_ofcom_protected_ranges: bool = False
+    ):
+        if block_ofcom_protected_ranges:
+            if self.is_number_in_S7_protected_range() and not self.is_tv_number(self.number):
+                raise InvalidPhoneError(code=InvalidPhoneError.Codes.INVALID_NUMBER)
+
+    def validate(
+        self,
+        allow_international_number: bool = False,
+        allow_uk_landline: bool = False,
+        block_ofcom_protected_ranges: bool = False,
+    ) -> None:
         self._raise_if_service_cannot_send_to_international_but_tries_to(allow_international=allow_international_number)
         self._raise_if_service_cannot_send_to_uk_landline_but_tries_to(allow_uk_landline=allow_uk_landline)
+        self._raise_if_service_who_blocked_it_tries_sending_to_ofcom_protected_ranges(
+            block_ofcom_protected_ranges=block_ofcom_protected_ranges
+        )
         self._raise_if_unsupported_country()
 
     @staticmethod

--- a/notifications_utils/version.py
+++ b/notifications_utils/version.py
@@ -5,4 +5,4 @@
 # - `make version-minor` for new features
 # - `make version-patch` for bug fixes
 
-__version__ = "131.1.0"  # 628ee66af93953d3bc2c714177922f72
+__version__ = "131.2.0"  # a7e5fa1b7721c038d3e79532612b1624

--- a/tests/recipient_validation/test_phone_number.py
+++ b/tests/recipient_validation/test_phone_number.py
@@ -259,6 +259,21 @@ mock_S7_prefixes = (
 )
 
 
+@pytest.fixture(scope="function")
+def mock_get_S7_protected_prefixes(mocker):
+    return mocker.patch(
+        "notifications_utils.recipient_validation.phone_number.get_S7_protected_prefixes",
+        return_value=(
+            "70346",
+            "703470",
+            "703477",
+            "70348",
+            "703490",
+            "7075",
+        ),
+    )
+
+
 @pytest.mark.parametrize("phone_number", valid_international_phone_numbers)
 def test_detect_international_phone_numbers(phone_number):
     number = PhoneNumber(phone_number)
@@ -468,6 +483,35 @@ class TestPhoneNumberClass:
             number.validate(allow_international_number=True, allow_uk_landline=False)
         assert exc.value.code == InvalidPhoneError.Codes.NOT_A_UK_MOBILE
 
+    @pytest.mark.parametrize(
+        "phone_number, should_raise",
+        (
+            ("07000000000", False),
+            ("07011100876", False),
+            ("07034700000", True),
+            ("07034701000", True),
+            ("07034710000", False),
+            ("07034777777", True),
+            ("07074971099", False),
+            ("07075971077", True),
+            ("07999999999", False),
+            # non-uk number
+            ("+1 202-483-3000", False),
+        ),
+    )
+    @pytest.mark.parametrize("block_ofcom_protected_ranges", [True, False])
+    def test_PhoneNumber_rejects_valid_uk_mobiles_if_in_ofcom_protected_range(
+        self, phone_number, should_raise, block_ofcom_protected_ranges, mock_get_S7_protected_prefixes
+    ):
+        number = PhoneNumber(phone_number)
+        if should_raise and block_ofcom_protected_ranges:
+            with pytest.raises(InvalidPhoneError):
+                number.validate(
+                    allow_international_number=True, block_ofcom_protected_ranges=block_ofcom_protected_ranges
+                )
+        else:
+            number.validate(allow_international_number=True, block_ofcom_protected_ranges=block_ofcom_protected_ranges)
+
     @pytest.mark.parametrize("phone_number, expected_info", international_phone_info_fixtures)
     def test_get_international_phone_info(self, phone_number, expected_info):
         assert PhoneNumber(phone_number).get_international_phone_info() == expected_info
@@ -655,11 +699,7 @@ class TestPhoneNumberClass:
             ("+1 202-483-3000", False),
         ),
     )
-    def test_is_number_in_S7_protected_range(self, candidate_number, expected_result, mocker):
-        mocker.patch(
-            "notifications_utils.recipient_validation.phone_number.get_S7_protected_prefixes",
-            return_value=mock_S7_prefixes,
-        )
+    def test_is_number_in_S7_protected_range(self, candidate_number, expected_result, mock_get_S7_protected_prefixes):
         assert PhoneNumber(candidate_number).is_number_in_S7_protected_range() == expected_result
 
 


### PR DESCRIPTION
Add `block_ofcom_protected_block` as an optional argument to `PhoneNumber.validate`

our current pattern for all service permission specific validation is to put it in the `PhoneNumber.validate` method. We should do the same here for permission-based blocking of notifications to protected blocks, it's consistend vs using the new public methods (`is_number_in_S7_protected_range` and `is_tv_number` directly whenever we try to validate.